### PR TITLE
release: v2.3.2 — Barrierefreiheits-Feinschliff + Governance-Doku

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Einzelbefehle:
 - `npm install` (root) — install frontend test/lint dependencies (Vitest, ESLint, Prettier)
 - `cd functions && npm test` — run Jest backend unit tests (435 tests)
 - `npm run test:frontend` — run Vitest frontend unit tests (165 tests)
-- `npm run test:e2e` — run Playwright E2E tests (Smoke + axe-A11y-Gate; neue ernste A11y-Verstöße brechen CI, Bestands-Ausnahmen siehe e2e/a11y.test.js)
+- `npm run test:e2e` — run Playwright E2E tests (Smoke + axe-A11y-Gate ohne Ausnahmen; misst mit reducedMotion, sonst Schein-Funde durch Einblend-Animation)
 - `cd functions && npm run lint` — ESLint backend
 - `cd functions && npm run format:check` — Prettier backend
 - `npm run lint:frontend` — ESLint frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,24 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [2.3.2] — 2026-07-14
 
-Governance-Nachrüstung Phase 1: Betriebs- und Sicherheitswissen wandert aus dem Kopf/Assistenten-Gedächtnis ins Repo. Reine Dokumentation plus drei Konfigurations-Kleindateien — kein Code, kein Deploy, das Live-Verhalten ist unberührt.
+Barrierefreiheits-Feinschliff nach dem ersten Lauf des neuen axe-Wächters plus Governance-Nachrüstung (Phasen 1–3: Betriebs-Doku, Verifikationsmatrix, A11y-Gate, Sammel-Scripts). Nur-Hosting-Deploy — Functions unberührt. 165 Frontend- + 435 Backend-Tests, 4 E2E (A11y-Gate ohne Ausnahmen), Lint und Format grün.
+
+### Geändert
+
+- **Barrierefreiheit: Nebentexte auf „Warmgrau-Textstufe" `#6e675e`** (Field Decision im malziland Design System, 2026-07-14). Das Marken-Warmgrau `#82796e` verfehlte als Textfarbe die WCAG-Norm 4,5:1 auf allen hellen Flächen knapp (4,0:1 auf Papier / 4,3:1 auf Weiß / 3,6:1 im Hinweis-Kasten des Foto-Dialogs) — 22 Stellen, gefunden vom neuen A11y-Gate. Die Textstufe behält den identischen Farbton (33°/8 %) und ist nur so dunkel wie nötig (jetzt 5,2 / 5,6 / 4,7). Linien, Rahmen, Flächen und der Gruppenakzent behalten den Vollton; gilt auch für die Druck-Stile. Analog zu den bestehenden Dark-Theme-Textstufen (`#4698b9`/`#c17d67`) — die CI-Lücke betraf alle malziland-Dokumente, nicht nur malziME. (`public/styles.css`)
+- **Barrierefreiheit, zwei Kleinigkeiten:** Die Konfidenz-Punkte neben den Profil-Kategorien tragen jetzt `role="img"` — damit ist das vorhandene `aria-label` für Screenreader technisch gültig (vorher wurde es ignoriert). Der OpenStreetMap-Quellenhinweis unter der GPS-Karte ist als Link unterstrichen (war nur an der Farbe erkennbar). (`public/js/render.js`, `public/styles.css`)
+- **A11y-Gate voll scharf:** Der Wächter misst jetzt mit reduzierter Bewegung — vorher erwischte axe Elemente mitten in der Einblend-Animation, was ~60 Schein-Funde mit Kontrast ~1:1 erzeugte. Die Bestands-Ausnahmeliste aus dem ersten Wurf ist komplett entfernt: Jeder ernste Verstoß (serious/critical) bricht ab sofort die CI. (`e2e/a11y.test.js`)
+- **Doku-Drift korrigiert:** AGENTS.md nannte das Stundenlimit noch mit 500 (Code: 1500) und ließ `release.yml` unerwähnt; `docs/ARCHITECTURE.md` nannte das Limit ebenfalls mit 500 und die Liveness-Karenz mit 3 min (Code: 8 min seit v2.2.3/UX-001). (`AGENTS.md`, `docs/ARCHITECTURE.md`)
 
 ### Hinzugefügt
 
 - **Betriebs- und Governance-Doku:** `docs/RUNBOOK.md` (Deploy-Ablauf, alle fünf Rollback-Hebel vom Wartungsmodus bis zum Hosting-Rollback, Störungs-Rezepte inkl. Scanner-Rauschen und `error.readFailed`, Log-Aufbewahrung), `docs/FLAGS.md` (Feature-Flag-Register mit Entfernungs-Kriterien und der 3-Schritt-Warnung für `useSingleLargeCall`), `docs/SECURITY-MODEL.md` (Schutzgüter, Rollen, Vertrauensgrenzen, Missbrauchsfälle mit Gegenmaßnahmen, Aufbewahrungs-Tabelle, Privacy-Notiz) und `docs/adr/0001-grundentscheidungen.md` (nachträglich dokumentierte Grundentscheidungen inkl. bewusster Abweichungen: keine Pre-commit-Hooks, Deutsch statt Englisch, leichtgewichtige Tags). README verlinkt das Runbook.
 - **Toolchain-Kleindateien:** `.nvmrc` (Node 24, gleicht Editor/Terminal an `functions/engines` und CI an), `.editorconfig`, `.gitattributes` (LF-Zeilenenden, Binärdatei-Markierung).
-- **Barrierefreiheits-Gate im E2E** (Phase 3): neuer Playwright-Test `e2e/a11y.test.js` prüft Startseite + fertige Profil-Ansicht mit axe-core (`@axe-core/playwright`, dev-only). Jeder **neue** ernste Verstoß (serious/critical) bricht ab jetzt die CI. Drei Bestands-Funde des aktuellen Designs sind dokumentiert ausgenommen und warten auf Sanierungs-Entscheidung (Kontrast Warmgrau-auf-Warmweiß u. a. bei Fließtext/Footer/Datenwert-Bereich; `aria-label` auf den Konfidenz-Badges; Leaflet-Attributions-Link) — Details in `docs/VERIFICATION.md` und im Test-Kommentar. (`e2e/a11y.test.js`, `package.json`)
+- **Barrierefreiheits-Gate im E2E** (Phase 3): neuer Playwright-Test `e2e/a11y.test.js` prüft Startseite + fertige Profil-Ansicht mit axe-core (`@axe-core/playwright`, dev-only). Jeder **neue** ernste Verstoß (serious/critical) bricht ab jetzt die CI. Die drei beim ersten Lauf gefundenen Bestands-Punkte des Designs wurden noch im selben Release behoben (siehe „Barrierefreiheit" unter Geändert). (`e2e/a11y.test.js`, `package.json`)
 - **Sammel-Befehle im Root** (Phase 3): `npm run setup` / `npm test` / `npm run lint` / `npm run format:check` decken jetzt Frontend + Backend in einem Aufruf ab (reine Aliasse auf die bestehenden Einzel-Scripts). (`package.json`, `AGENTS.md`)
 - **Verifikationsmatrix `docs/VERIFICATION.md`** (Phase 2): Welche Anforderung ist wodurch belegt — Tests, Secret-Scan, Dependency-Audit, Lighthouse, Profilpflichten (inkl. zweier ehrlich als offen ausgewiesener Punkte: automatisierter A11y-Check, dokumentierter Tastatur-Smoketest) und externe Kontrollen. Dazu die **erste dokumentierte Rollback-Probe**: Tag `v2.3.1` in temporärem worktree ausgecheckt, `npm ci` + beide Test-Suiten grün (435 + 165) — der Rücksprung auf den letzten Release-Stand ist damit nachgewiesen, nicht nur beschrieben. (`docs/VERIFICATION.md`, `docs/RUNBOOK.md`)
-
-### Geändert
-
-- **Doku-Drift korrigiert:** AGENTS.md nannte das Stundenlimit noch mit 500 (Code: 1500) und ließ `release.yml` unerwähnt; `docs/ARCHITECTURE.md` nannte das Limit ebenfalls mit 500 und die Liveness-Karenz mit 3 min (Code: 8 min seit v2.2.3/UX-001). (`AGENTS.md`, `docs/ARCHITECTURE.md`)
 
 ## [2.3.1] — 2026-07-13
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -27,7 +27,7 @@ bewusst als offen ausgewiesen.
 | Profil | Pflicht | Status |
 |---|---|---|
 | UI | E2E-Test des kritischsten Nutzerflusses | ✅ `e2e/smoke.test.js` (CI-Pflicht-Check) |
-| UI | Automatisierter Accessibility-Check dieses Flows | ✅ `e2e/a11y.test.js` (axe-core im Playwright-E2E, CI-Pflicht-Check; Gate: neue serious/critical-Verstöße brechen die CI) — **mit 3 dokumentierten Bestands-Ausnahmen** (`color-contrast`, `aria-prohibited-attr`, `link-in-text-block`, Aufnahme 2026-07-14): deren Behebung ändert Farbwerte des Design-Systems, Sanierungs-Entscheidung des Inhabers **offen** |
+| UI | Automatisierter Accessibility-Check dieses Flows | ✅ `e2e/a11y.test.js` (axe-core im Playwright-E2E, CI-Pflicht-Check): serious/critical-Verstöße brechen die CI — **ohne Ausnahmen seit v2.3.2** (Warmgrau-Textstufe `#6e675e`, `role="img"` an Konfidenz-Punkten, Attribution-Unterstreichung; Messung mit reducedMotion gegen Animations-Artefakte). 4/4 grün, 2026-07-14 |
 | UI | Dokumentierter manueller Tastatur-Smoketest | **offen** — bisher nicht dokumentiert durchgeführt |
 | SERVICE_API | Request-/Upload-/Response-Grenzen, Rate Limits | ✅ Upload-/Größen-Limits + Magic-Byte-Check (`upload.js`), IP-Rate-Limit (`middleware.js`), Stundenlimit + Output-Bounds (`config.js`, `handle-*.js`) — durch Unit-Tests abgedeckt |
 | SERVICE_API | Autorisierung fail-closed | ✅ Admin nur mit HMAC-Token + Nonce (`auth.js`, Tests); `processJob` nur via OIDC (Cloud Tasks) |

--- a/e2e/a11y.test.js
+++ b/e2e/a11y.test.js
@@ -3,19 +3,14 @@ import AxeBuilder from "@axe-core/playwright";
 
 /* Automatisierter Accessibility-Check (axe-core) des kritischsten Nutzerflusses:
    Startseite und fertige Profil-Ansicht. Gate: Verstöße mit Impact "serious"
-   oder "critical" brechen den Test; leichtere Funde werden nur geloggt, damit
-   sie sichtbar bleiben, ohne jeden PR zu blockieren. */
+   oder "critical" brechen den Test — OHNE Ausnahmen (Altlasten in v2.3.2
+   behoben); leichtere Funde werden nur geloggt, damit sie sichtbar bleiben,
+   ohne jeden PR zu blockieren.
 
-/* Bestandsschutz: Diese Regeln schlagen im Design-Stand v2.3.x an (Aufnahme
-   2026-07-14) und sind als OFFENE Sanierungs-Punkte in docs/VERIFICATION.md
-   dokumentiert — Behebung ändert das Erscheinungsbild (Farbwerte des
-   malziland Design Systems) und braucht die Freigabe des Inhabers. Sie werden
-   geloggt, brechen aber den Test nicht. Jede NEUE ernste Regel bricht die CI.
-   - color-contrast: Warmgrau-Text auf Warmweiß unter 4,5:1 (Startseite,
-     Footer, Datenwert-Bereich)
-   - aria-prohibited-attr: aria-label auf span ohne Rolle (.high/.med)
-   - link-in-text-block: Leaflet-Attributions-Link nur per Farbe erkennbar */
-const BEKANNTE_ALTLASTEN = ["color-contrast", "aria-prohibited-attr", "link-in-text-block"];
+   Gemessen wird mit reduzierter Bewegung: Ohne das erwischt axe Elemente
+   mitten in der Einblend-Animation (halbtransparenter Text → Schein-Funde
+   mit Kontrast ~1:1). Die Seite respektiert prefers-reduced-motion ohnehin
+   vollständig — gemessen wird also ein realer Endzustand. */
 
 const MOCK_RESPONSE = {
   profiles: {
@@ -52,9 +47,7 @@ async function checkA11y(page, kontext) {
       alle.map((v) => `${v.id} (${v.impact}) × ${v.nodes.length}`).join(", ")
     );
   }
-  const ernst = alle.filter(
-    (v) => (v.impact === "serious" || v.impact === "critical") && !BEKANNTE_ALTLASTEN.includes(v.id)
-  );
+  const ernst = alle.filter((v) => v.impact === "serious" || v.impact === "critical");
   expect(
     ernst.map((v) => ({ regel: v.id, impact: v.impact, elemente: v.nodes.map((n) => n.target.join(" ")) })),
     `Ernste A11y-Verstöße auf ${kontext}`
@@ -72,6 +65,7 @@ test("A11y: Startseite ohne ernste Verstöße", async ({ page }) => {
     })
   );
 
+  await page.emulateMedia({ reducedMotion: "reduce" });
   await page.goto("/");
   await expect(page.locator("h1")).toBeVisible();
 
@@ -109,6 +103,7 @@ test("A11y: Profil-Ansicht ohne ernste Verstöße", async ({ page }) => {
     route.fulfill({ status: 200, contentType: "application/json", body: "[]" })
   );
 
+  await page.emulateMedia({ reducedMotion: "reduce" });
   await page.goto("/");
   await page.click('[data-demo="selfie"]');
   await expect(page.locator("#disclaimerModal")).toHaveClass(/active/, { timeout: 20000 });

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026071302" />
+    <link rel="stylesheet" href="./styles.css?v=2026071401" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026071302" />
+    <link rel="stylesheet" href="./styles.css?v=2026071401" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -67,7 +67,7 @@
     <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
     <link rel="preconnect" href="https://nominatim.openstreetmap.org" crossorigin />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026071302" />
+    <link rel="stylesheet" href="./styles.css?v=2026071401" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -264,6 +264,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026071302"></script>
+    <script type="module" src="./app.js?v=2026071401"></script>
   </body>
 </html>

--- a/public/js/render.js
+++ b/public/js/render.js
@@ -168,7 +168,7 @@ function renderCategories(profile) {
           <div class="cat-card" data-key="${escapeHtml(key)}" data-grp="${grp.id}">
             <div class="cat-head">
               <span class="cat-label">${escapeHtml(cat.label)}</span>
-              <span class="cat-conf cat-conf--dots ${cls}" aria-label="Konfidenz">${dotsHtml}</span>
+              <span class="cat-conf cat-conf--dots ${cls}" role="img" aria-label="Konfidenz">${dotsHtml}</span>
             </div>
             <p class="cat-value">${highlightKeyTerms(escapeHtml(cat.value))}</p>
           </div>

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026071302" />
+    <link rel="stylesheet" href="./styles.css?v=2026071401" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026071302" />
+    <link rel="stylesheet" href="./styles.css?v=2026071401" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/styles.css
+++ b/public/styles.css
@@ -92,7 +92,10 @@
   --border: rgba(130, 121, 110, 0.4);
   --border-soft: rgba(130, 121, 110, 0.15);
   --text: #404749;
-  --muted: #82796e;
+  /* Warmgrau-TEXTSTUFE (Field Decision 2026-07-14): identischer Ton wie
+     --ml-warmgray (33°/8 %), abgedunkelt auf WCAG 4,5:1 gegen Papier, Weiß
+     und Tint-Flächen. Linien/Rahmen/Flächen bleiben beim Vollton #82796e. */
+  --muted: #6e675e;
   --heading: #156480;
   --teal-text: #156480;
   --rust-text: #9c4e36;
@@ -1023,6 +1026,12 @@ h1 {
   letter-spacing: var(--ls-label);
   color: var(--rust-text);
   margin-bottom: 12px;
+}
+
+/* Quellenhinweis-Links der Karte: als Link erkennbar, nicht nur per Farbe
+   (WCAG link-in-text-block; eigene Regel statt Eingriff in lib/leaflet) */
+.leaflet-control-attribution a {
+  text-decoration: underline;
 }
 
 .gps-address {
@@ -2489,7 +2498,7 @@ ol.legal-list > li::before {
     --border: rgba(130, 121, 110, 0.4);
     --border-soft: rgba(130, 121, 110, 0.15);
     --text: #404749;
-    --muted: #82796e;
+    --muted: #6e675e; /* Warmgrau-Textstufe, siehe :root */
     --heading: #156480;
     --teal-text: #156480;
     --rust-text: #9c4e36;
@@ -2667,7 +2676,7 @@ ol.legal-list > li::before {
     display: block;
     text-align: center;
     font-size: 8pt;
-    color: #82796e;
+    color: #6e675e; /* Warmgrau-Textstufe, siehe :root */
     padding: 10px 0 6px;
     border-top: 1px solid rgba(130, 121, 110, 0.4);
     margin: 8px 0;


### PR DESCRIPTION
## Was

Umsetzung des freigegebenen Vorschlags ([Artifact](https://claude.ai/code/artifact/3ca7f096-fe92-4abd-aca8-3e90f9489618)):

- **Warmgrau-Textstufe `#6e675e`** für Nebentexte (Field Decision, identischer Farbton wie `#82796e`, nur dunkler): 22 Kontrast-Fundstellen von knapp durchgefallen auf 5,2/5,6/4,7:1. Linien/Rahmen/Flächen/Gruppenakzent behalten den Vollton; Druck-Stile ebenfalls umgestellt.
- **`role="img"`** an den Konfidenz-Punkten (macht das aria-label gültig), **Unterstreichung** für den OSM-Attributions-Link.
- **A11y-Gate voll scharf:** Messung mit reducedMotion (eliminiert ~60 Schein-Funde durch die Einblend-Animation), Bestands-Ausnahmeliste komplett entfernt.
- CHANGELOG auf **v2.3.2** gestempelt (Hosting-Deploy nach Merge, Deploy = Release), Cache-Buster gezielt für styles.css/app.js.

## Beweis (lokal ausgeführt)

- E2E **4/4 grün mit vollem Gate ohne Ausnahmen** — nur noch 3 moderate Hinweise (unterhalb der Schwelle, geloggt)
- Frontend 165/165 grün, Lint + Format sauber (render.js/styles.css geändert)
- Kontraste rechnerisch verifiziert (WCAG-Formel): 5,2:1 Papier / 5,6:1 Weiß / 4,7:1 Hinweis-Kasten

Nach dem Merge: `firebase deploy --only hosting` + Live-Smoke; Field-Decision-Eintrag im Design-Projekt folgt separat (freigegeben).

🤖 Generated with [Claude Code](https://claude.com/claude-code)