### PR TITLE
release: v2.3.3 — restlose Barrierefreiheit + Tastatur-Smoketest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Einzelbefehle:
 - `npm install` (root) — install frontend test/lint dependencies (Vitest, ESLint, Prettier)
 - `cd functions && npm test` — run Jest backend unit tests (435 tests)
 - `npm run test:frontend` — run Vitest frontend unit tests (165 tests)
-- `npm run test:e2e` — run Playwright E2E tests (Smoke + axe-A11y-Gate ohne Ausnahmen; misst mit reducedMotion, sonst Schein-Funde durch Einblend-Animation)
+- `npm run test:e2e` — run Playwright E2E tests (Smoke + axe-A11y-Gate ohne Ausnahmen + Tastatur-Durchlauf; A11y misst mit reducedMotion, sonst Schein-Funde durch Einblend-Animation)
 - `cd functions && npm run lint` — ESLint backend
 - `cd functions && npm run format:check` — Prettier backend
 - `npm run lint:frontend` — ESLint frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [2.3.3] — 2026-07-14
+
+Restlose Barrierefreiheit im geprüften Nutzerfluss: die letzten drei (moderaten) axe-Hinweise behoben und der Tastatur-Durchlauf als dauerhafter Test verankert — der Wächter meldet jetzt **null Funde über alle Schweregrade**. Nur-Hosting-Deploy. 165 Frontend- + 435 Backend-Tests, 5 E2E, Lint und Format grün.
+
+### Geändert
+
+- **Landmarken vervollständigt:** GitHub-Hinweis und Unterstützungs-Box lagen zwischen `</main>` und `<footer>` außerhalb jeder Landmarke — für die Screenreader-Schnellnavigation unsichtbar. Beide sitzen jetzt in einem `<aside>`; optisch unverändert. (`public/index.html`)
+- **Überschriften-Reihenfolge im Ergebnis:** Die Verdict-Überschrift war ein `h3` direkt nach dem `h1` (übersprungene Ebene) — jetzt `h2`, mit explizit fixiertem Abstand pixelgleich zum bisherigen Aussehen. (`public/js/render.js`, `public/styles.css`)
+
+### Hinzugefügt
+
+- **Tastatur-Smoketest als dauerhafter E2E-Test** (`e2e/keyboard.test.js`, CI-Pflicht-Check): kompletter Weg Demo-Foto → Disclaimer → Profil nur mit Tab + Enter, inklusive Prüfung, dass die Fokus-Markierung sichtbar ist. Damit ist der letzte offene Punkt der Verifikationsmatrix geschlossen — statt eines einmaligen manuellen Durchklicks wird die Tastatur-Bedienbarkeit jetzt bei jedem PR bewiesen. (`e2e/keyboard.test.js`, `docs/VERIFICATION.md`)
+
 ## [2.3.2] — 2026-07-14
 
 Barrierefreiheits-Feinschliff nach dem ersten Lauf des neuen axe-Wächters plus Governance-Nachrüstung (Phasen 1–3: Betriebs-Doku, Verifikationsmatrix, A11y-Gate, Sammel-Scripts). Nur-Hosting-Deploy — Functions unberührt. 165 Frontend- + 435 Backend-Tests, 4 E2E (A11y-Gate ohne Ausnahmen), Lint und Format grün.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -27,8 +27,8 @@ bewusst als offen ausgewiesen.
 | Profil | Pflicht | Status |
 |---|---|---|
 | UI | E2E-Test des kritischsten Nutzerflusses | ✅ `e2e/smoke.test.js` (CI-Pflicht-Check) |
-| UI | Automatisierter Accessibility-Check dieses Flows | ✅ `e2e/a11y.test.js` (axe-core im Playwright-E2E, CI-Pflicht-Check): serious/critical-Verstöße brechen die CI — **ohne Ausnahmen seit v2.3.2** (Warmgrau-Textstufe `#6e675e`, `role="img"` an Konfidenz-Punkten, Attribution-Unterstreichung; Messung mit reducedMotion gegen Animations-Artefakte). 4/4 grün, 2026-07-14 |
-| UI | Dokumentierter manueller Tastatur-Smoketest | **offen** — bisher nicht dokumentiert durchgeführt |
+| UI | Automatisierter Accessibility-Check dieses Flows | ✅ `e2e/a11y.test.js` (axe-core im Playwright-E2E, CI-Pflicht-Check): serious/critical-Verstöße brechen die CI — **ohne Ausnahmen seit v2.3.2** (Warmgrau-Textstufe `#6e675e`, `role="img"` an Konfidenz-Punkten, Attribution-Unterstreichung; Messung mit reducedMotion gegen Animations-Artefakte). Seit v2.3.3 meldet axe auf beiden Ansichten **null Funde über alle Schweregrade** (Landmarken + Überschriften-Reihenfolge behoben). 2026-07-14 |
+| UI | Tastatur-Smoketest des kritischsten Flusses | ✅ `e2e/keyboard.test.js` (CI-Pflicht-Check, seit v2.3.3): kompletter Weg Demo-Foto → Disclaimer → Profil nur mit Tab + Enter, inkl. Prüfung sichtbarer Fokus-Markierung. Erstmals grün 2026-07-14 — damit dauerhaft automatisiert statt einmalig manuell |
 | SERVICE_API | Request-/Upload-/Response-Grenzen, Rate Limits | ✅ Upload-/Größen-Limits + Magic-Byte-Check (`upload.js`), IP-Rate-Limit (`middleware.js`), Stundenlimit + Output-Bounds (`config.js`, `handle-*.js`) — durch Unit-Tests abgedeckt |
 | SERVICE_API | Autorisierung fail-closed | ✅ Admin nur mit HMAC-Token + Nonce (`auth.js`, Tests); `processJob` nur via OIDC (Cloud Tasks) |
 | DATA_ML_GENAI | LLM-Ausgaben schema-validiert, kein ungeprüftes Freitext-Parsing für Logik | ✅ JSON-Schema in Prompts + `json-repair.js` + Output-Clamps; LLM-Ausgaben steuern keine Tools/Folgeprozesse |

--- a/e2e/keyboard.test.js
+++ b/e2e/keyboard.test.js
@@ -1,0 +1,110 @@
+import { test, expect } from "@playwright/test";
+
+/* Tastatur-Smoketest des kritischsten Nutzerflusses (Profilpflicht UI,
+   docs/VERIFICATION.md): Der komplette Weg Demo-Foto → Disclaimer → Profil
+   muss ohne Maus funktionieren — nur mit Tab und Enter — und der Fokus muss
+   dabei sichtbar sein. */
+
+const MOCK_RESPONSE = {
+  profiles: {
+    normal: {
+      categories: {
+        alter_geschlecht: { label: "Alter & Geschlecht", value: "25-30 Jahre, männlich", confidence: 0.8 },
+      },
+      ad_targeting: ["Outdoor-Werbung"],
+      manipulation_triggers: ["FOMO"],
+      profileText: "Ein junger Erwachsener mit aktivem Lebensstil.",
+    },
+    boost: {
+      categories: {
+        alter_geschlecht: { label: "Alter & Geschlecht", value: "25-30 Jahre, männlich", confidence: 0.9 },
+      },
+      ad_targeting: ["Premium-Werbung"],
+      manipulation_triggers: ["Statusangst"],
+      profileText: "Beast-Mode-Profil.",
+    },
+  },
+  privacyRisks: [],
+  exif: { make: "Apple", model: "iPhone 15 Pro" },
+  meta: { requestId: "keyboard-test-123", mode: "multimodal" },
+};
+
+/* Tab drücken, bis das Ziel-Element den Fokus hat (mit Obergrenze) */
+async function tabToElement(page, selector, maxTabs = 40) {
+  for (let i = 0; i < maxTabs; i++) {
+    await page.keyboard.press("Tab");
+    const focused = await page.evaluate(
+      (sel) => document.activeElement?.matches(sel) === true,
+      selector
+    );
+    if (focused) return true;
+  }
+  return false;
+}
+
+/* Sichtbarer Fokus: Outline oder Box-Shadow am fokussierten Element */
+async function focusIsVisible(page) {
+  return page.evaluate(() => {
+    const el = document.activeElement;
+    if (!el || el === document.body) return false;
+    const s = getComputedStyle(el);
+    const hasOutline = s.outlineStyle !== "none" && parseFloat(s.outlineWidth) > 0;
+    const hasShadow = s.boxShadow !== "none";
+    return hasOutline || hasShadow;
+  });
+}
+
+test("Tastatur: Demo-Foto → Disclaimer → Profil, nur mit Tab + Enter", async ({ page }) => {
+  await page.route("**/api/stats", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        current: { count: 10, limit: 500, limitActive: false, retryAfterSeconds: 0 },
+        totals: { today: 10, week: 50, month: 200, total: 1000 },
+        useQueue: true,
+      }),
+    })
+  );
+  await page.route("**/api/enqueue", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ jobId: "kbd-job-1", resultToken: "kbd-token-1" }),
+    })
+  );
+  await page.route("**/api/job-status**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "done", result: MOCK_RESPONSE }),
+    })
+  );
+  await page.route("**/nominatim.openstreetmap.org/**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" })
+  );
+
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+  await expect(page.locator("h1")).toBeVisible();
+
+  /* 1. Per Tab zum Demo-Button — und der Fokus muss sichtbar sein */
+  expect(await tabToElement(page, '[data-demo="selfie"]'), "Demo-Button per Tab erreichbar").toBe(true);
+  expect(await focusIsVisible(page), "Fokus auf dem Demo-Button sichtbar").toBe(true);
+
+  /* 2. Enter startet die Analyse */
+  await page.keyboard.press("Enter");
+  await expect(page.locator("#disclaimerModal")).toHaveClass(/active/, { timeout: 20000 });
+
+  /* 3. Per Tab zum Bestätigen-Button im Disclaimer, Enter bestätigt */
+  const alreadyOnConfirm = await page.evaluate(() => document.activeElement?.id === "disclaimerConfirm");
+  if (!alreadyOnConfirm) {
+    expect(await tabToElement(page, "#disclaimerConfirm"), "Bestätigen-Button per Tab erreichbar").toBe(true);
+  }
+  expect(await focusIsVisible(page), "Fokus auf dem Bestätigen-Button sichtbar").toBe(true);
+  await page.keyboard.press("Enter");
+
+  /* 4. Profil wird angezeigt */
+  await expect(page.locator("#simulation")).not.toBeEmpty({ timeout: 5000 });
+  await expect(page.locator(".cat-card").first()).toBeVisible();
+});

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026071401" />
+    <link rel="stylesheet" href="./styles.css?v=2026071402" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026071401" />
+    <link rel="stylesheet" href="./styles.css?v=2026071402" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -67,7 +67,7 @@
     <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
     <link rel="preconnect" href="https://nominatim.openstreetmap.org" crossorigin />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026071401" />
+    <link rel="stylesheet" href="./styles.css?v=2026071402" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -206,6 +206,9 @@
 
     </main>
 
+    <!-- Landmark (WCAG region): Projekt-Links gehören in eine Landmarke,
+         sonst sind sie für Screenreader-Navigation unsichtbar -->
+    <aside class="page-extras">
     <div class="opensource-box">
       <a href="https://github.com/malziland/malzime" target="_blank" rel="noopener" class="opensource-link" tabindex="0">
         <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -218,6 +221,7 @@
       <p class="support-text" data-i18n="support.text">Und du h&auml;ltst es am Laufen.</p>
       <a href="https://buymeacoffee.com/malzime" target="_blank" rel="noopener" class="support-btn" tabindex="0" data-i18n="support.button">Jetzt Projekt unterst&uuml;tzen</a>
     </div>
+    </aside>
 
     <footer class="site-footer">
       <div class="footer-inner">
@@ -264,6 +268,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026071401"></script>
+    <script type="module" src="./app.js?v=2026071402"></script>
   </body>
 </html>

--- a/public/js/render.js
+++ b/public/js/render.js
@@ -356,7 +356,7 @@ function renderSimulation(text) {
     <div class="verdict">
       <div class="verdict-head">
         <svg class="verdict-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v4m0 4h.01M3.6 19.8h16.8a1.2 1.2 0 001.04-1.8L13.04 4.2a1.2 1.2 0 00-2.08 0L2.56 18a1.2 1.2 0 001.04 1.8z"/></svg>
-        <h3>${t("verdict.title")}</h3>
+        <h2>${t("verdict.title")}</h2>
       </div>
       <p class="verdict-text">${escapeHtml(text)}</p>
     </div>

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026071401" />
+    <link rel="stylesheet" href="./styles.css?v=2026071402" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026071401" />
+    <link rel="stylesheet" href="./styles.css?v=2026071402" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1150,12 +1150,13 @@ h1 {
   flex-shrink: 0;
 }
 
-.verdict-head h3 {
+.verdict-head h2 {
   font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: var(--ls-label);
   color: var(--rust-text);
+  margin: 1em 0; /* war h3 (Browser-Default 1em); h2 nur wegen Überschriften-Reihenfolge (WCAG) */
 }
 
 .verdict-text {
@@ -2625,7 +2626,7 @@ ol.legal-list > li::before {
   }
 
   /* ── Verdict ── */
-  .verdict-head h3 {
+  .verdict-head h2 {
     color: #9c4e36;
   }
   .verdict-icon {


### PR DESCRIPTION
## Was

Schließt die letzten offenen Punkte aus der Barrierefreiheits-Prüfung:

- **Landmarken:** GitHub-Hinweis + Unterstützungs-Box (zwischen `</main>` und `<footer>`) in ein `<aside>` — vorher für Screenreader-Navigation unsichtbar. Optisch unverändert.
- **Überschriften-Reihenfolge:** Verdict-Überschrift `h3`→`h2` (war Ebenen-Sprung nach `h1`), Abstand explizit fixiert → pixelgleich.
- **Tastatur-Smoketest als dauerhafter E2E-Test:** kompletter Flow Demo-Foto → Disclaimer → Profil nur mit Tab + Enter inkl. Fokus-Sichtbarkeits-Prüfung. Schließt den letzten offenen Punkt der Verifikationsmatrix.
- CHANGELOG auf **v2.3.3** gestempelt (Hosting-Deploy nach Merge), Cache-Buster 2026071402.

## Beweis (lokal ausgeführt)

- E2E **5/5 grün** — axe meldet **null Funde über alle Schweregrade** (vorher 3× moderate)
- Frontend 165/165, Lint + Format sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)