### PR TITLE
feat: Auffindbarkeit für Suchmaschinen + KI — Urheber-Verknüpfung, llms.txt, Sitemap-Refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [2.3.4] — 2026-07-16
 
 Auffindbarkeit für Suchmaschinen und KI-Systeme: malziME wird maschinenlesbar mit malziland und Christoph Krieger verknüpft — an der sichtbaren Seite ändert sich nichts. Bewusst KEIN Link auf malziland.at (Seite im Relaunch; Entscheidung des Inhabers, 2026-07-16). Nur-Hosting-Deploy, keine Funktionsänderung.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+Auffindbarkeit für Suchmaschinen und KI-Systeme: malziME wird maschinenlesbar mit malziland und Christoph Krieger verknüpft — an der sichtbaren Seite ändert sich nichts. Bewusst KEIN Link auf malziland.at (Seite im Relaunch; Entscheidung des Inhabers, 2026-07-16). Nur-Hosting-Deploy, keine Funktionsänderung.
+
+### Hinzugefügt
+
+- **`llms.txt`:** maschinenlesbare Kurzbeschreibung für KI-Crawler — was malziME ist, wer dahinter steht (malziland - learning | training | consulting e.U., Inhaber Christoph Krieger), Datenschutz-Kernpunkte, Seitenübersicht, Zitierhinweis mit Fiktiv-Klarstellung. (`public/llms.txt`)
+- **Strukturierte Betreiber-Daten im Impressum:** schema.org-Organization mit Anschrift, UID, Gründer Christoph Krieger (inkl. LinkedIn-Verweis) und GitHub-Profil. (`public/impressum.html`)
+- **Urheber in den strukturierten Daten der Startseite:** Christoph Krieger als `creator` und als Gründer der Betreiber-Organisation, Verweis aufs GitHub-Repository (`sameAs`); Autor-Meta-Tag nennt jetzt Person + Firma. (`public/index.html`)
+- **Alternativtexte fürs Teilen-Vorschaubild** (`og:image:alt`, `twitter:image:alt`). (`public/index.html`)
+
+### Geändert
+
+- **Impressum-Seitentitel korrigiert:** „malziland e.U." ist keine existierende Firmierung — jetzt „Impressum — malziME by malziland". (`public/impressum.html`)
+- **Sitemap-Änderungsdaten aktualisiert** (standen seit Februar unverändert). (`public/sitemap.xml`)
+- **README nennt den Inhaber:** Attribution am Seitenende um Christoph Krieger (LinkedIn) und den Live-Link malzi.me ergänzt. (`README.md`)
+
 ## [2.3.3] — 2026-07-14
 
 Restlose Barrierefreiheit im geprüften Nutzerfluss: die letzten drei (moderaten) axe-Hinweise behoben und der Tastatur-Durchlauf als dauerhafter Test verankert — der Wächter meldet jetzt **null Funde über alle Schweregrade**. Nur-Hosting-Deploy. 165 Frontend- + 435 Backend-Tests, 5 E2E, Lint und Format grün.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Auffindbarkeit für Suchmaschinen und KI-Systeme: malziME wird maschinenlesbar m
 
 ### Geändert
 
-- **Impressum-Seitentitel korrigiert:** „malziland e.U." ist keine existierende Firmierung — jetzt „Impressum — malziME by malziland". (`public/impressum.html`)
+- **Impressum-Seitentitel korrigiert:** nannte bisher eine nicht existierende Kurz-Firmierung — jetzt „Impressum — malziME by malziland". Die Firma heißt überall vollständig „malziland - learning | training | consulting e.U." (Schreibweise laut Impressum). (`public/impressum.html`)
 - **Sitemap-Änderungsdaten aktualisiert** (standen seit Februar unverändert). (`public/sitemap.xml`)
 - **README nennt den Inhaber:** Attribution am Seitenende um Christoph Krieger (LinkedIn) und den Live-Link malzi.me ergänzt. (`README.md`)
 

--- a/README.md
+++ b/README.md
@@ -295,4 +295,4 @@ malziland - learning | training | consulting e.U. Details: [TRADEMARKS.md](TRADE
 
 ---
 
-Erstellt von [malziland - learning | training | consulting e.U.](https://malziland.at)
+Erstellt von [malziland - learning | training | consulting e.U.](https://malziland.at) &mdash; Inhaber: [Christoph Krieger](https://www.linkedin.com/in/christophkrieger/) &middot; Live unter [malzi.me](https://malzi.me)

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026071402" />
+    <link rel="stylesheet" href="./styles.css?v=2026071601" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#f9f7f4" />
-    <title>Impressum &mdash; malziME | malziland e.U.</title>
+    <title>Impressum &mdash; malziME by malziland</title>
     <meta name="description" content="Impressum von malziME, einem Lern-Tool f&uuml;r Medienkompetenz und Datenschutz-Sensibilisierung. Betreiber: malziland - learning | training | consulting e.U., &Ouml;sterreich." />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://malzi.me/impressum" />
@@ -14,12 +14,37 @@
     <meta property="og:description" content="Impressum und Kontaktdaten von malziME by malziland." />
     <meta property="og:url" content="https://malzi.me/impressum" />
 
+    <!-- Structured Data: Betreiber-Organisation (verknuepft malziME mit malziland + Christoph Krieger) -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "malziland - learning | training | consulting e.U.",
+      "url": "https://malziland.at",
+      "email": "info@malzi.me",
+      "vatID": "ATU76410108",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "Tassilostraße 22",
+        "postalCode": "4501",
+        "addressLocality": "Neuhofen an der Krems",
+        "addressCountry": "AT"
+      },
+      "founder": {
+        "@type": "Person",
+        "name": "Christoph Krieger",
+        "sameAs": ["https://www.linkedin.com/in/christophkrieger/"]
+      },
+      "sameAs": ["https://github.com/malziland"]
+    }
+    </script>
+
     <link rel="icon" href="./favicon.ico" sizes="48x48" />
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026071402" />
+    <link rel="stylesheet" href="./styles.css?v=2026071601" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <title>malziME &mdash; Was KI aus deinem Foto liest | Workshop-Tool f&uuml;r Medienkompetenz</title>
     <meta name="description" content="Lade ein Foto hoch und sieh, was Algorithmen aus einem einzigen Bild &uuml;ber dich herauslesen: Alter, Einkommen, Interessen, Werbeprofil. Kostenloses Lern-Tool f&uuml;r Workshops zu Datenschutz und Medienkompetenz." />
     <meta name="keywords" content="Medienkompetenz, Datenschutz, KI-Analyse, Safer Internet, Workshop, Schule, Jugendliche, Algorithmus, Bias, Profiling, Datenbroker, DSGVO" />
-    <meta name="author" content="malziland - learning | training | consulting e.U." />
+    <meta name="author" content="Christoph Krieger, malziland - learning | training | consulting e.U." />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://malzi.me/" />
 
@@ -22,12 +22,14 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:alt" content="malziME &mdash; Was KI aus deinem Foto liest. Workshop-Tool f&uuml;r Medienkompetenz von malziland." />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="malziME &mdash; Was KI aus deinem Foto liest" />
     <meta name="twitter:description" content="Lade ein Foto hoch und sieh, was Algorithmen &uuml;ber dich behaupten. Lern-Tool f&uuml;r Workshops zu Datenschutz und Medienkompetenz." />
     <meta name="twitter:image" content="https://malzi.me/og-image.png" />
+    <meta name="twitter:image:alt" content="malziME &mdash; Was KI aus deinem Foto liest. Workshop-Tool f&uuml;r Medienkompetenz von malziland." />
 
     <!-- Structured Data -->
     <script type="application/ld+json">
@@ -39,6 +41,7 @@
       "description": "KI-basiertes Lern-Tool f\u00fcr Medienkompetenz und Datenschutz-Sensibilisierung. Zeigt, was Algorithmen aus einem einzigen Foto \u00fcber eine Person behaupten k\u00f6nnten.",
       "applicationCategory": "EducationalApplication",
       "operatingSystem": "Web",
+      "sameAs": ["https://github.com/malziland/malzime"],
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -47,7 +50,22 @@
       "author": {
         "@type": "Organization",
         "name": "malziland - learning | training | consulting e.U.",
-        "url": "https://malziland.at"
+        "url": "https://malziland.at",
+        "founder": {
+          "@type": "Person",
+          "name": "Christoph Krieger",
+          "url": "https://malziland.at",
+          "sameAs": ["https://www.linkedin.com/in/christophkrieger/"]
+        }
+      },
+      "creator": {
+        "@type": "Person",
+        "name": "Christoph Krieger",
+        "worksFor": {
+          "@type": "Organization",
+          "name": "malziland - learning | training | consulting e.U.",
+          "url": "https://malziland.at"
+        }
       },
       "audience": {
         "@type": "EducationalAudience",
@@ -67,7 +85,7 @@
     <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
     <link rel="preconnect" href="https://nominatim.openstreetmap.org" crossorigin />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026071402" />
+    <link rel="stylesheet" href="./styles.css?v=2026071601" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -268,6 +286,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026071402"></script>
+    <script type="module" src="./app.js?v=2026071601"></script>
   </body>
 </html>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,27 @@
+# malziME
+
+> malziME (https://malzi.me) ist ein kostenloses Lern-Tool für Medienkompetenz und Datenschutz-Sensibilisierung. Nutzer laden ein Foto hoch und sehen, was KI-Algorithmen aus einem einzigen Bild über sie behaupten könnten: Alter, Einkommen, Interessen, Werbeprofil. Alle generierten Profile sind fiktiv — sie zeigen, was Algorithmen behaupten KÖNNTEN, nichts davon ist wahr oder bewiesen.
+
+Betreiber: malziland - learning | training | consulting e.U., Inhaber Christoph Krieger, Neuhofen an der Krems, Österreich.
+
+Zielgruppe: Workshops mit Kindern, Jugendlichen und Erwachsenen zu Datenschutz, Algorithmen-Bias und Profiling (Safer Internet, Schule, Erwachsenenbildung).
+
+Datenschutz: Hochgeladene Fotos werden nur für die Dauer der Analyse verarbeitet und danach aktiv gelöscht. GPS-Daten (EXIF) verlassen nie den Browser. Keine Cookies, kein Tracking, keine Konten.
+
+Sprachen: Deutsch (Standard) und Englisch (umschaltbar auf der Seite).
+
+## Seiten
+
+- [Startseite / Analyse-Tool](https://malzi.me/): Foto hochladen, KI-Profil ansehen (seriöser Modus und „Beast Mode" mit maximaler Überspitzung)
+- [Auslastung](https://malzi.me/stats): aktuelle Nutzungsstatistik
+- [Impressum](https://malzi.me/impressum): Betreiber- und Kontaktdaten
+- [Datenschutzerklärung](https://malzi.me/datenschutz): was mit Fotos und Daten passiert
+- [Nutzungsbedingungen](https://malzi.me/nutzungsbedingungen)
+
+## Quellcode
+
+- [GitHub-Repository](https://github.com/malziland/malzime): Open Source (MIT-Lizenz, Marken ausgenommen)
+
+## Zitierhinweis
+
+Bitte als „malziME — Workshop-Tool für Medienkompetenz von malziland (Christoph Krieger)" referenzieren und auf https://malzi.me verlinken. Wichtig bei jeder Wiedergabe: Die KI-Profile sind bewusst fiktiv und dienen der Aufklärung über algorithmisches Profiling.

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026071402" />
+    <link rel="stylesheet" href="./styles.css?v=2026071601" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://malzi.me/</loc>
-    <lastmod>2026-02-21</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://malzi.me/stats</loc>
-    <lastmod>2026-02-21</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://malzi.me/datenschutz</loc>
-    <lastmod>2026-02-21</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://malzi.me/impressum</loc>
-    <lastmod>2026-02-16</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://malzi.me/nutzungsbedingungen</loc>
-    <lastmod>2026-02-24</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026071402" />
+    <link rel="stylesheet" href="./styles.css?v=2026071601" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>


### PR DESCRIPTION
## Was

malziME wird für Suchmaschinen und KI-Systeme maschinenlesbar mit **malziland - learning | training | consulting e.U.** und **Christoph Krieger** verknüpft. An der sichtbaren Seite ändert sich nichts. **Bewusst KEIN Link auf malziland.at** (Seite im Relaunch — Entscheidung des Inhabers, 2026-07-16).

## Änderungen

- **`public/llms.txt` (neu):** Selbstbeschreibung für KI-Crawler — was malziME ist, wer es betreibt, Datenschutz-Kernpunkte, Seitenübersicht, Zitierhinweis mit Fiktiv-Klarstellung.
- **Impressum:** schema.org-Organization (Anschrift, UID, Gründer Christoph Krieger inkl. LinkedIn, GitHub-Profil); Seitentitel korrigiert — nannte bisher eine nicht existierende Kurz-Firmierung, jetzt „Impressum — malziME by malziland". Der Firmenname steht überall vollständig in der Schreibweise laut Impressum.
- **Startseite:** Christoph Krieger als `creator`/`founder` im JSON-LD, GitHub-Repo als `sameAs`, Autor-Meta nennt Person + Firma, `og:image:alt`/`twitter:image:alt` ergänzt.
- **Sitemap:** `lastmod` aktualisiert (stand seit Februar). **README:** Inhaber-Attribution + Live-Link. Cache-Buster → `2026071601`.

## Verifikation

- Backend 435 + Frontend 165 Tests grün, Lint + Format grün
- E2E 5/5 grün (inkl. axe-A11y-Gate und Tastatur-Smoketest)
- JSON-LD beider Seiten mit `JSON.parse` validiert
- Live geprüft: robots.txt/sitemap.xml werden korrekt mit richtigem Content-Type ausgeliefert (kein Catch-All-Problem); llms.txt greift nach Deploy, weil statische Dateien Vorrang vor dem `**`-Rewrite haben — Live-Smoke nach Deploy eingeplant

🤖 Generated with [Claude Code](https://claude.com/claude-code)