### PR TITLE
fix: Sanierung nach LANGAUDIT 2026-07 — Queue-Robustheit, Diagnose-Vergröberung, CI-Härtung

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
 
+# GITHUB_TOKEN minimal halten. Der Repo-Default steht bereits auf "read" —
+# hier festgeschrieben, damit ein künftiges Umstellen des Defaults die CI
+# nicht still mit Schreibrechten ausstattet.
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -81,6 +87,9 @@ jobs:
       - run: npm run test:e2e
 
   lighthouse:
+    # Misst die LIVE-Domain, nicht den PR-Stand — als Post-Deploy-Monitor nur
+    # auf push sinnvoll; auf PRs wäre ein grünes Ergebnis irreführend.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 .env
+# .env.local ist die verbreitete Konvention für lokale Secrets — darf nie ins
+# öffentliche Repo (Vorlage: functions/.env.local.example).
+.env.local
 .DS_Store
 .firebase/
 .grok/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+Sanierung nach LANGAUDIT vom 2026-07-17 (Release-Gate-Audit auf v2.3.4, Multi-Agent, read-only): drei Robustheits-Lücken im Queue-Pfad geschlossen, Diagnose-Daten weiter vergröbert, latente Secret-Falle entschärft, CI gehärtet. Keine Verhaltensänderung im Normalpfad.
+
+### Behoben
+
+- **Reaper/Worker-Race:** Reaper und Worker löschten das zwischengespeicherte Bild auch dann, wenn ihr `abandonJob`-Übergang das Race verloren hatte (Job inzwischen von einem Worker geclaimt) — der laufende Job fand sein Bild nicht mehr und endete als `blocked.apiError`. Aufräumen (Bild + Stunden-Slot) passiert jetzt nur noch nach **erfolgreichem** Statusübergang (`handle-reap.js`, `handle-process-job.js`; je ein neuer Race-Test).
+- **Stunden-Slot-Leck im Enqueue-Fehlerpfad:** Scheiterte `storeImage`/`createJob` NACH dem Ziehen des Stunden-Slots, blieb der Slot bis zu 60 min belegt und ein ggf. schon abgelegtes Bild bis zur 1-Tag-Lifecycle-Regel liegen. Jetzt wird analog zum bestehenden `enqueueJob`-Fehlerpfad aufgeräumt (Slot zurück + Bild weg, neuer Fehlercode `store_failed`; zwei neue Tests).
+- **Queue-Fetches ohne Timeout:** `enqueue`- und Poll-Fetch konnten bei nie settelnden Verbindungen (Mobilfunk-Blackhole) den Wartefluss einfrieren — der Sync-Pfad hatte längst einen Timeout. Jetzt `fetchWithTimeout` (Enqueue 90 s, Poll 30 s; Client gibt nie vor dem Server auf, Timeouts laufen in die bestehende 5-Fehler-Toleranz).
+
+### Geändert
+
+- **Diagnose-Daten weiter vergröbert (Privacy):** Die Fehler-/Telemetrie-Logger senden statt des vollen User-Agent-Strings nur noch die grobe Form „Browser Hauptversion / OS" (`coarseUserAgent()`), statt der exakten Bildschirmauflösung nur noch eine Größenklasse (small/medium/large). Serverseitig `userAgent`-Längenlimit 250 → 80 als zweites Netz. Damit deckt der Code die Zusage „vollständig anonym, Geräteklasse" aus der Datenschutzerklärung wieder wortgenau.
+- **Job-Abholung fail-closed:** Der tote Abwärtskompatibilitäts-Zweig „Alt-Jobs ohne Abhol-Ticket bleiben offen" ist entfernt — jeder Job trägt seit v2.0 ein Ticket (`createJob` setzt es unkonditional); fehlt es wider Erwarten, wird nie ausgeliefert.
+
+### Sicherheit / CI
+
+- **`functions/.env.local` enttrackt** (war seit v2.0.0-rc3 im öffentlichen Repo, enthielt nie Secrets — nur Emulator-Flags) + `.gitignore` deckt jetzt `.env.local`; getrackte Vorlage neu als `functions/.env.local.example`.
+- **ci.yml:** `permissions: contents: read` festgeschrieben (Repo-Default war bereits read); Lighthouse-Job läuft nur noch auf `push` — er misst die Live-Domain, auf PRs war ein grünes Ergebnis irreführend.
+
+### Betrieb (außerhalb des Repos, 2026-07-17)
+
+- **Fehler-Alarm-Policy erweitert** (LANGAUDIT OPS-001): Filter deckt jetzt auch `enqueue`, `processjob`, `jobstatus`, `reapjobs` ab — der Live-Analysepfad war seit der Queue-Umstellung (v2.0) ohne ntfy-Alarm. `errors`/`telemetry` bewusst ausgespart (Client-Fehlerberichte loggen als ERROR → wären Alarm-Spam). Backfill-Release v2.2.1 nachgetragen; gitleaks-Voll-Historien-Scan lokal: 0 Funde.
+
 ## [2.3.4] — 2026-07-16
 
 Auffindbarkeit für Suchmaschinen und KI-Systeme: malziME wird maschinenlesbar mit malziland und Christoph Krieger verknüpft — an der sichtbaren Seite ändert sich nichts. Bewusst KEIN Link auf malziland.at (Seite im Relaunch; Entscheidung des Inhabers, 2026-07-16). Nur-Hosting-Deploy, keine Funktionsänderung.

--- a/docs/QUEUE-EMULATOR.md
+++ b/docs/QUEUE-EMULATOR.md
@@ -30,7 +30,8 @@ Das startet Functions-, Firestore-, Hosting- und Pub/Sub-Emulator. Warten bis
 
 ## Was im Lokal-Modus anders ist
 
-`functions/.env.local` setzt `QUEUE_LOCAL=1` und `MISTRAL_MOCK=1`. Damit:
+`functions/.env.local` setzt `QUEUE_LOCAL=1` und `MISTRAL_MOCK=1` (Datei ist
+un-getrackt — einmalig anlegen per `cp functions/.env.local.example functions/.env.local`). Damit:
 
 - **Mistral** ist eine Attrappe — vorgefertigte `[MOCK-PROFIL]`-Profile,
   konfigurierbare Verzögerung (`MISTRAL_MOCK_DELAY_MS`). Keine Kosten.

--- a/functions/.env.local.example
+++ b/functions/.env.local.example
@@ -1,3 +1,7 @@
+# Vorlage: nach functions/.env.local kopieren (die echte Datei ist bewusst
+# un-getrackt — .env.local ist die uebliche Konvention fuer lokale Secrets
+# und darf nie im oeffentlichen Repo liegen).
+#
 # Emulator-only Konfiguration (Phase 3 — lokaler Durchklick + Mock-Lasttest).
 # Der Firebase-Emulator laedt diese Datei automatisch; `firebase deploy`
 # ignoriert .env.local — die Produktion ist davon also nie betroffen.

--- a/functions/src/__tests__/handle-enqueue.test.js
+++ b/functions/src/__tests__/handle-enqueue.test.js
@@ -211,3 +211,29 @@ describe("handleEnqueue — Cloud-Tasks-Ausfall", () => {
     expect(storage.deleteImage).toHaveBeenCalledWith("queue-uploads/test.jpg");
   });
 });
+
+/* ── Storage-/Firestore-Ausfall nach gezogenem Stunden-Slot ──────── */
+
+describe("handleEnqueue — Ausfall zwischen Slot und Task", () => {
+  test("schlägt storeImage fehl → 503, Slot zurückgegeben, kein deleteImage nötig", async () => {
+    storage.storeImage.mockRejectedValue(new Error("gcs down"));
+    const res = makeRes();
+    await handleEnqueue(jsonReq(), res, SECRETS);
+    expect(res.statusCode).toBe(503);
+    expect(res.body.code).toBe("store_failed");
+    expect(counter.releaseHourlySlot).toHaveBeenCalledTimes(1);
+    expect(storage.deleteImage).not.toHaveBeenCalled();
+    expect(tasks.enqueueJob).not.toHaveBeenCalled();
+  });
+
+  test("schlägt createJob fehl → 503, Slot zurückgegeben UND Bild-Waise gelöscht", async () => {
+    jobs.createJob.mockRejectedValue(new Error("firestore blip"));
+    const res = makeRes();
+    await handleEnqueue(jsonReq(), res, SECRETS);
+    expect(res.statusCode).toBe(503);
+    expect(res.body.code).toBe("store_failed");
+    expect(counter.releaseHourlySlot).toHaveBeenCalledTimes(1);
+    expect(storage.deleteImage).toHaveBeenCalledWith("queue-uploads/test.jpg");
+    expect(tasks.enqueueJob).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/__tests__/handle-job-status.test.js
+++ b/functions/src/__tests__/handle-job-status.test.js
@@ -90,11 +90,11 @@ describe("handleJobStatus — Status-Antworten", () => {
     expect(res.body.etaSeconds).toBeGreaterThan(0);
   });
 
-  test("done → Status done samt Ergebnis", async () => {
+  test("done → Status done samt Ergebnis (mit Abhol-Ticket)", async () => {
     const result = { profiles: { normal: {}, boost: {} }, meta: { mode: "multimodal" } };
-    jobs.getJob.mockResolvedValue({ id: "job-1", status: "done", result });
+    jobs.getJob.mockResolvedValue({ id: "job-1", status: "done", result, resultToken: "ticket-abc" });
     const res = makeRes();
-    await handleJobStatus(getReq("job-1"), res);
+    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, res);
     expect(res.body.status).toBe("done");
     expect(res.body.result).toEqual(result);
   });
@@ -147,12 +147,13 @@ describe("handleJobStatus — Auslieferungs-Messung", () => {
       id: "job-1",
       status: "done",
       result: {},
+      resultToken: "ticket-abc",
       traceId: "trace1",
       createdAt: 1000,
       finishedAt: 5000,
     });
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
-    await handleJobStatus(getReq("job-1"), makeRes());
+    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, makeRes());
     expect(jobs.markDelivered).toHaveBeenCalledWith("job-1");
     const delivered = logSpy.mock.calls
       .map((c) => {
@@ -171,8 +172,14 @@ describe("handleJobStatus — Auslieferungs-Messung", () => {
   });
 
   test("bereits ausgelieferter Job → kein erneutes markDelivered", async () => {
-    jobs.getJob.mockResolvedValue({ id: "job-1", status: "done", result: {}, deliveredAt: 9999 });
-    await handleJobStatus(getReq("job-1"), makeRes());
+    jobs.getJob.mockResolvedValue({
+      id: "job-1",
+      status: "done",
+      result: {},
+      resultToken: "ticket-abc",
+      deliveredAt: 9999,
+    });
+    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, makeRes());
     expect(jobs.markDelivered).not.toHaveBeenCalled();
   });
 });
@@ -216,10 +223,14 @@ describe("handleJobStatus — PRIV-003 Abhol-Ticket", () => {
     expect(res.body.tokenRequired).toBe(true);
   });
 
-  test("Alt-Job ohne resultToken → Ergebnis bleibt abwärtskompatibel abrufbar", async () => {
+  test("Job ohne resultToken (darf nicht vorkommen) → wird NIE ausgeliefert", async () => {
+    /* createJob setzt das Ticket unkonditional; der frühere Abwärts-
+       kompatibilitäts-Zweig (Alt-Jobs offen ausliefern) ist entfernt —
+       fail-closed statt leise offen. */
     jobs.getJob.mockResolvedValue(doneJob({ resultToken: null }));
     const res = makeRes();
     await handleJobStatus(getReq("job-1"), res);
-    expect(res.body.result).toEqual({ profileText: "geheim" });
+    expect(res.body.result).toBeNull();
+    expect(res.body.tokenRequired).toBe(true);
   });
 });

--- a/functions/src/__tests__/handle-process-job.test.js
+++ b/functions/src/__tests__/handle-process-job.test.js
@@ -17,6 +17,7 @@ jest.mock("../queue-storage", () => ({
 }));
 jest.mock("../counter", () => ({
   incrementTotals: jest.fn(() => Promise.resolve()),
+  releaseHourlySlot: jest.fn(() => Promise.resolve()),
 }));
 jest.mock("../cloud-tasks", () => ({
   redispatchJobLocal: jest.fn(),
@@ -64,7 +65,7 @@ beforeEach(() => {
   jobs.claimJob.mockResolvedValue(true);
   jobs.completeJob.mockResolvedValue();
   jobs.isAbandoned.mockReturnValue(false);
-  jobs.abandonJob.mockResolvedValue();
+  jobs.abandonJob.mockResolvedValue(true);
   jobs.countProcessingJobs.mockResolvedValue(0);
   storage.loadImage.mockResolvedValue({ buffer: Buffer.from("img"), mimeType: "image/jpeg" });
   storage.deleteImage.mockResolvedValue();
@@ -121,6 +122,18 @@ describe("handleProcessJob — Abweisungen", () => {
     expect(jobs.claimJob).not.toHaveBeenCalled();
     expect(jobs.completeJob).not.toHaveBeenCalled();
     expect(storage.deleteImage).toHaveBeenCalledWith("queue-uploads/x.jpg");
+    expect(counter.releaseHourlySlot).toHaveBeenCalledTimes(1);
+  });
+
+  test("abandonJob verliert das Race → Bild bleibt (gehört dem Gewinner), kein Slot zurück", async () => {
+    jobs.isAbandoned.mockReturnValue(true);
+    jobs.abandonJob.mockResolvedValue(false);
+    const res = makeRes();
+    await handleProcessJob(postReq("job-1"), res);
+    expect(res.body.reason).toBe("abandoned");
+    expect(storage.deleteImage).not.toHaveBeenCalled();
+    expect(counter.releaseHourlySlot).not.toHaveBeenCalled();
+    expect(jobs.claimJob).not.toHaveBeenCalled();
   });
 
   test("Lokal-Modus, Drossel voll → Job vertagt, kein Claim, Re-Dispatch geplant", async () => {

--- a/functions/src/__tests__/handle-reap.test.js
+++ b/functions/src/__tests__/handle-reap.test.js
@@ -11,20 +11,25 @@ jest.mock("../jobs", () => ({
 jest.mock("../queue-storage", () => ({
   deleteImage: jest.fn(),
 }));
+jest.mock("../counter", () => ({
+  releaseHourlySlot: jest.fn(),
+}));
 
 const { reapJobs } = require("../handle-reap");
 const jobs = require("../jobs");
 const storage = require("../queue-storage");
+const counter = require("../counter");
 
 beforeEach(() => {
   jest.clearAllMocks();
   jobs.findAbandonedJobs.mockResolvedValue([]);
   jobs.findStaleProcessingJobs.mockResolvedValue([]);
   jobs.findExpiredJobs.mockResolvedValue([]);
-  jobs.abandonJob.mockResolvedValue();
-  jobs.failJob.mockResolvedValue();
+  jobs.abandonJob.mockResolvedValue(true);
+  jobs.failJob.mockResolvedValue(true);
   jobs.deleteJob.mockResolvedValue();
   storage.deleteImage.mockResolvedValue();
+  counter.releaseHourlySlot.mockResolvedValue();
 });
 
 describe("reapJobs", () => {
@@ -46,6 +51,17 @@ describe("reapJobs", () => {
     expect(jobs.abandonJob).toHaveBeenCalledWith("a1");
     expect(jobs.abandonJob).toHaveBeenCalledWith("a2");
     expect(storage.deleteImage).toHaveBeenCalledWith("queue-uploads/a1.jpg");
+    /* BIZ-001: pro erfolgreich verlassenem Job kommt der Stunden-Slot zurück. */
+    expect(counter.releaseHourlySlot).toHaveBeenCalledTimes(2);
+  });
+
+  test("abandonJob verliert das Race (Job inzwischen geclaimt) → Bild bleibt, kein Slot zurück", async () => {
+    jobs.findAbandonedJobs.mockResolvedValue([{ id: "a1", imagePath: "queue-uploads/a1.jpg" }]);
+    jobs.abandonJob.mockResolvedValue(false);
+    const result = await reapJobs();
+    expect(result.abandoned).toBe(0);
+    expect(storage.deleteImage).not.toHaveBeenCalled();
+    expect(counter.releaseHourlySlot).not.toHaveBeenCalled();
   });
 
   test("in processing hängende Jobs → failed (processing_timeout), Bild gelöscht", async () => {
@@ -77,7 +93,7 @@ describe("reapJobs", () => {
       { id: "a1", imagePath: "x" },
       { id: "a2", imagePath: "y" },
     ]);
-    jobs.abandonJob.mockResolvedValueOnce().mockRejectedValueOnce(new Error("firestore blip"));
+    jobs.abandonJob.mockResolvedValueOnce(true).mockRejectedValueOnce(new Error("firestore blip"));
     const result = await reapJobs();
     expect(result.abandoned).toBe(1);
   });

--- a/functions/src/handle-enqueue.js
+++ b/functions/src/handle-enqueue.js
@@ -170,11 +170,24 @@ async function handleEnqueue(req, res, secrets) {
     }
 
     /* ── Bild ablegen → Job anlegen → in Cloud Tasks einreihen ── */
-    const imagePath = await storeImage(file.buffer, file.mimeType);
     /* PRIV-003: Abhol-Ticket fürs Ergebnis — nur dieser Browser bekommt es von
        job-status zurück (zweites Schloss zusätzlich zur unerratbaren jobId). */
     const resultToken = crypto.randomUUID();
-    const jobId = await createJob({ lang, traceId, imagePath, exif, resultToken });
+    let imagePath;
+    let jobId;
+    try {
+      imagePath = await storeImage(file.buffer, file.mimeType);
+      jobId = await createJob({ lang, traceId, imagePath, exif, resultToken });
+    } catch (err) {
+      /* Der Stunden-Slot ist hier schon gezogen, aber es entsteht nie eine
+         Analyse — Slot zurückgeben und ein evtl. schon abgelegtes Bild nicht
+         bis zur Lifecycle-Regel liegen lassen. */
+      console.log(JSON.stringify({ requestId, traceId, warning: "store-or-create-failed", error: err.message }));
+      releaseHourlySlot().catch(() => {});
+      if (imagePath) await deleteImage(imagePath);
+      res.status(503).json({ error: "Queue unavailable", code: "store_failed" });
+      return;
+    }
 
     try {
       await enqueueJob(jobId);

--- a/functions/src/handle-errors.js
+++ b/functions/src/handle-errors.js
@@ -19,7 +19,9 @@ const STRING_FIELDS = {
   errorMessage: 500,
   phase: 50,
   url: 200,
-  userAgent: 250,
+  /* Client sendet nur noch den vergröberten UA ("Chrome 126 / Android");
+     das knappe Limit ist das zweite Netz gegen volle UA-Strings alter Clients. */
+  userAgent: 80,
   requestId: 50,
   traceId: 50,
   wakeLock: 40,

--- a/functions/src/handle-job-status.js
+++ b/functions/src/handle-job-status.js
@@ -76,9 +76,10 @@ async function handleJobStatus(req, res) {
 
   if (job.status === "done") {
     /* PRIV-003: das fertige Profil nur an den Browser herausgeben, der das
-       Abhol-Ticket besitzt. Alt-Jobs ohne resultToken (vor diesem Stand
-       angelegt) bleiben abwärtskompatibel offen. */
-    if (job.resultToken && !safeCompare(token, job.resultToken)) {
+       Abhol-Ticket besitzt. Jeder Job trägt ein Ticket (createJob setzt es
+       unkonditional) — fehlt es wider Erwarten, wird nie ausgeliefert statt
+       offen zu bleiben. */
+    if (!job.resultToken || !safeCompare(token, job.resultToken)) {
       res.status(200).json({ status: "done", result: null, tokenRequired: true });
       return;
     }

--- a/functions/src/handle-process-job.js
+++ b/functions/src/handle-process-job.js
@@ -312,9 +312,17 @@ async function handleProcessJob(req, res) {
      löschen, fertig. Backstop für die Lücke, bis der Reaper den Job erwischt. */
   if (isAbandoned(job)) {
     const didAbandon = await abandonJob(jobId);
+    if (!didAbandon) {
+      /* Übergang verloren: Entweder hat der Reaper parallel abgeräumt (Bild
+         dort gelöscht) oder ein zweiter Dispatch hat den Job geclaimt und
+         braucht das Bild noch — in beiden Fällen gehört das Aufräumen ihm. */
+      console.log(JSON.stringify({ step: "process-job", jobId, status: "abandon-raced" }));
+      res.status(200).json({ ok: false, reason: "abandoned" });
+      return;
+    }
     /* BIZ-001: nur freigeben, wenn DIESER Aufruf den Job wirklich verlassen hat
        (sonst Doppel-Freigabe, falls der Reaper parallel war). */
-    if (didAbandon) releaseHourlySlot().catch(() => {});
+    releaseHourlySlot().catch(() => {});
     await deleteImage(job.imagePath);
     console.log(JSON.stringify({ step: "process-job", jobId, status: "abandoned" }));
     res.status(200).json({ ok: false, reason: "abandoned" });

--- a/functions/src/handle-reap.js
+++ b/functions/src/handle-reap.js
@@ -49,8 +49,11 @@ async function reapJobs() {
   for (const job of abandoned) {
     try {
       const ok = await abandonJob(job.id);
+      /* Schlug der Übergang fehl, hat ein Worker den Job zwischen Query und
+         Abbruch geclaimt — er läuft noch und braucht das Bild: nichts anfassen. */
+      if (!ok) continue;
       /* BIZ-001: Stunden-Slot zurückgeben — verlassener Job machte nie eine Analyse. */
-      if (ok) await releaseHourlySlot();
+      await releaseHourlySlot();
       await deleteImage(job.imagePath);
       reapedAbandoned += 1;
     } catch (err) {

--- a/functions/src/handle-telemetry.js
+++ b/functions/src/handle-telemetry.js
@@ -14,7 +14,8 @@ const { checkRateLimit, getClientIp } = require("./middleware");
 const STRING_FIELDS = {
   eventType: 50,
   url: 200,
-  userAgent: 250,
+  /* Client sendet nur noch den vergröberten UA — knappes Limit als zweites Netz. */
+  userAgent: 80,
   traceId: 50,
 };
 const NUMBER_FIELDS = ["durationMs"];

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -450,10 +450,24 @@ const JOB_DISCLAIMER_ACK_KEY = "malzime.queueDisclaimerAcked";
    er aufgibt — ein Netz-Wackler darf den wartenden User nicht rauswerfen,
    das Ergebnis liegt serverseitig sicher. */
 const MAX_POLL_FAILURES = 5;
-/* Gesamt-Obergrenze fürs Pollen. Selbst eine tiefe Warteschlange ist deutlich
-   darunter; greift nur, falls ein Job dauerhaft hängt (z.B. Cloud-Tasks-
-   Ausfall) — dann nicht endlos pollen, sondern sauber abbrechen. */
+/* Gesamt-Obergrenze fürs Pollen. Bei randvollem Stundenbudget kann die ehrliche
+   Wartezeit darüber liegen (Extremfall: ~950 wartende Jobs ≈ 100 min ETA) —
+   dieser Deckel ist der bewusste Schlussstrich, damit kein Tab stundenlang
+   pollt. Der aufgegebene Job wird nach der Herzschlag-Karenz gereapt und gibt
+   seinen Stunden-Slot zurück. */
 const MAX_POLL_DURATION_MS = 30 * 60 * 1000;
+/* Timeouts für die Queue-Fetches: Der Client darf nie vor dem Server aufgeben
+   (enqueue-Function 60 s, job-status 10 s), aber ein Fetch, der nie settelt
+   (Netz-Blackhole auf Mobilgeräten), darf den Wartefluss nicht einfrieren —
+   der Sync-Pfad hat denselben Schutz (FETCH_TIMEOUT_MS). */
+const ENQUEUE_TIMEOUT_MS = 90000;
+const POLL_TIMEOUT_MS = 30000;
+
+function fetchWithTimeout(url, options, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  return fetch(url, { ...options, signal: controller.signal }).finally(() => clearTimeout(timer));
+}
 
 function storeJobId(jobId, resultToken) {
   try {
@@ -567,7 +581,11 @@ async function pollJob(jobId, myId, resultToken, pollImmediately = false) {
     let data;
     try {
       const tokenParam = resultToken ? `&token=${encodeURIComponent(resultToken)}` : "";
-      const resp = await fetch(`${JOB_STATUS_URL}?jobId=${encodeURIComponent(jobId)}${tokenParam}`);
+      const resp = await fetchWithTimeout(
+        `${JOB_STATUS_URL}?jobId=${encodeURIComponent(jobId)}${tokenParam}`,
+        {},
+        POLL_TIMEOUT_MS
+      );
       if (!resp.ok) {
         /* 404 = Job existiert nicht (mehr) — kein transienter Fehler. */
         if (resp.status === 404) return { error: t("error.queueFailed") };
@@ -758,18 +776,22 @@ async function analyzeImageQueued() {
 
     /* ── Job einreihen ── */
     const enqueueStart = Date.now();
-    const enqueueResp = await fetch(ENQUEUE_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        imageBase64: state.lastPrepared.imageBase64,
-        exif: state.lastPrepared.exif,
-        mimeType: "image/jpeg",
-        filename: "upload.jpg",
-        lang: getLanguage(),
-        traceId,
-      }),
-    });
+    const enqueueResp = await fetchWithTimeout(
+      ENQUEUE_URL,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          imageBase64: state.lastPrepared.imageBase64,
+          exif: state.lastPrepared.exif,
+          mimeType: "image/jpeg",
+          filename: "upload.jpg",
+          lang: getLanguage(),
+          traceId,
+        }),
+      },
+      ENQUEUE_TIMEOUT_MS
+    );
     timings.enqueueMs = Date.now() - enqueueStart;
     if (state.requestId !== myId) return;
 

--- a/public/js/client-context.js
+++ b/public/js/client-context.js
@@ -15,6 +15,35 @@ export function generateTraceId() {
   return rand.slice(0, 16);
 }
 
+/* Vergröbert den User-Agent auf Browser-Familie + Hauptversion + OS-Familie
+   (z. B. "Safari 17 / iOS"). Der volle UA-String ist ein stabiler Fingerprint-
+   Vektor und geht deshalb nie über die Diagnose-Endpunkte hinaus — die grobe
+   Form reicht für jede bisherige Fehlersuche (Browser-/OS-Klasse). */
+export function coarseUserAgent() {
+  try {
+    const ua = (typeof navigator !== "undefined" && navigator.userAgent) || "";
+    let os = "other";
+    if (/iPhone|iPad|iPod/i.test(ua)) os = "iOS";
+    else if (/Android/i.test(ua)) os = "Android";
+    else if (/Windows/i.test(ua)) os = "Windows";
+    else if (/Mac OS X|Macintosh/.test(ua)) os = "macOS";
+    else if (/Linux/i.test(ua)) os = "Linux";
+    let browser = "other";
+    let major = "";
+    let m;
+    if ((m = ua.match(/Edg\/(\d+)/))) [browser, major] = ["Edge", m[1]];
+    else if ((m = ua.match(/OPR\/(\d+)/))) [browser, major] = ["Opera", m[1]];
+    else if ((m = ua.match(/SamsungBrowser\/(\d+)/))) [browser, major] = ["SamsungBrowser", m[1]];
+    else if ((m = ua.match(/Firefox\/(\d+)/))) [browser, major] = ["Firefox", m[1]];
+    else if ((m = ua.match(/Chrome\/(\d+)/))) [browser, major] = ["Chrome", m[1]];
+    else if ((m = ua.match(/Version\/(\d+).*Safari/))) [browser, major] = ["Safari", m[1]];
+    else if (/Safari/.test(ua)) browser = "Safari";
+    return `${browser}${major ? " " + major : ""} / ${os}`;
+  } catch (_) {
+    return "unknown";
+  }
+}
+
 export function collectClientContext() {
   const ctx = {};
   try {
@@ -32,7 +61,10 @@ export function collectClientContext() {
     }
     if (typeof screen !== "undefined") {
       if (typeof screen.width === "number" && typeof screen.height === "number") {
-        ctx.screen = `${screen.width}x${screen.height}`;
+        /* Größenklasse statt exakter Auflösung: die exakten Pixel sind ein
+           stabiles Fingerprint-Merkmal, für die Diagnose zählt nur die Klasse. */
+        const maxDim = Math.max(screen.width, screen.height);
+        ctx.screen = maxDim < 1000 ? "small" : maxDim < 1800 ? "medium" : "large";
       }
     }
     if (typeof window !== "undefined" && typeof window.devicePixelRatio === "number") {

--- a/public/js/error-logger.js
+++ b/public/js/error-logger.js
@@ -8,7 +8,7 @@
  * nie davon abhaengt.
  */
 
-import { collectClientContext } from "./client-context.js";
+import { collectClientContext, coarseUserAgent } from "./client-context.js";
 
 const ERROR_ENDPOINT = "/api/errors";
 
@@ -23,7 +23,7 @@ export function logClientError(error, context = {}) {
       durationMs: typeof context.durationMs === "number" && isFinite(context.durationMs) ? context.durationMs : 0,
       online: typeof navigator !== "undefined" ? navigator.onLine : true,
       hidden: typeof document !== "undefined" ? document.hidden : false,
-      userAgent: (navigator && navigator.userAgent) || "",
+      userAgent: coarseUserAgent(),
       url: (typeof location !== "undefined" && location.pathname) || "",
       requestId: typeof context.requestId === "string" ? context.requestId : null,
       traceId: typeof context.traceId === "string" ? context.traceId : null,

--- a/public/js/telemetry-logger.js
+++ b/public/js/telemetry-logger.js
@@ -8,7 +8,7 @@
  * ERROR), damit Cloud Logging die Klassen sauber trennt.
  */
 
-import { collectClientContext } from "./client-context.js";
+import { collectClientContext, coarseUserAgent } from "./client-context.js";
 
 const TELEMETRY_ENDPOINT = "/api/telemetry";
 
@@ -21,7 +21,7 @@ export function logTelemetry(eventType, context = {}) {
       durationMs: typeof context.durationMs === "number" && isFinite(context.durationMs) ? context.durationMs : 0,
       online: typeof navigator !== "undefined" ? navigator.onLine : true,
       hidden: typeof document !== "undefined" ? document.hidden : false,
-      userAgent: (navigator && navigator.userAgent) || "",
+      userAgent: coarseUserAgent(),
       url: (typeof location !== "undefined" && location.pathname) || "",
       traceId: typeof context.traceId === "string" ? context.traceId : null,
       timings: context.timings && typeof context.timings === "object" ? context.timings : null,


### PR DESCRIPTION
## Was

PR A der Audit-Sanierung (LANGAUDIT 2026-07-17 auf v2.3.4, Modus: AUDIT-REMEDIATION). Schließt die Code-Findings BUG-001/002/003, PRIV-001 (Code-Teil), SEC-001 sowie zwei Härtungsnotizen. **Keine Verhaltensänderung im Normalpfad** — alle Fixes greifen nur in Fehler-/Race-Fenstern bzw. vergröbern Diagnose-Daten.

## Findings → Fixes

| Finding | Fix |
|---|---|
| BUG-001 Reaper/Worker-Race | Bild-Löschung + Slot-Rückgabe nur nach erfolgreichem `abandonJob`-Übergang (2 Stellen, +2 Race-Tests) |
| BUG-002 Slot-Leck | `storeImage`/`createJob`-Fehler räumen jetzt auf (Slot zurück + Bild weg, `store_failed`; +2 Tests) |
| BUG-003 Fetch ohne Timeout | `fetchWithTimeout` für enqueue (90 s) + Poll (30 s); Client gibt nie vor dem Server auf |
| PRIV-001 UA/Fingerprint | `coarseUserAgent()` (Familie + Major / OS), Screen als Größenklasse; Server-Limit 250→80 |
| SEC-001 .env.local | enttrackt + .gitignore; Vorlage `.env.local.example` |
| Hygiene | toter Alt-Job-Zweig ohne Ticket entfernt (fail-closed); ci.yml `permissions: contents: read`; Lighthouse nur auf push |

## Beweis-Befehle

- Backend: `npm test --prefix functions` → **439/439** (4 neue Tests)
- Frontend: `npm run test:frontend` → **165/165**
- Lint/Format: grün
- Emulator-Lasttest (`emulators:exec` + `queue-emulator-loadtest.js 100`): **100 done / 0 failed / 0 abandoned / 0 verloren** — Claim-/Race-Logik empirisch bestätigt

## Deploy

Wird NICHT automatisch deployt — Live-Deploy erfolgt gebündelt mit PR B nach expliziter Freigabe des Inhabers (CHANGELOG-Stempelung auf v2.3.5 im Deploy-Schritt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)