### PR TITLE
release: v2.3.5 — Sanierung nach LANGAUDIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [2.3.5] — 2026-07-17
 
 Sanierung nach LANGAUDIT vom 2026-07-17 (Release-Gate-Audit auf v2.3.4, Multi-Agent, read-only): drei Robustheits-Lücken im Queue-Pfad geschlossen, Diagnose-Daten weiter vergröbert, latente Secret-Falle entschärft, CI gehärtet. Keine Verhaltensänderung im Normalpfad.
 
@@ -17,7 +17,7 @@ Sanierung nach LANGAUDIT vom 2026-07-17 (Release-Gate-Audit auf v2.3.4, Multi-Ag
 ### Geändert
 
 - **Diagnose-Daten weiter vergröbert (Privacy):** Die Fehler-/Telemetrie-Logger senden statt des vollen User-Agent-Strings nur noch die grobe Form „Browser Hauptversion / OS" (`coarseUserAgent()`), statt der exakten Bildschirmauflösung nur noch eine Größenklasse (small/medium/large). Serverseitig `userAgent`-Längenlimit 250 → 80 als zweites Netz. Damit deckt der Code die Zusage „vollständig anonym, Geräteklasse" aus der Datenschutzerklärung wieder wortgenau.
-- **Job-Abholung fail-closed:** Der tote Abwärtskompatibilitäts-Zweig „Alt-Jobs ohne Abhol-Ticket bleiben offen" ist entfernt — jeder Job trägt seit v2.0 ein Ticket (`createJob` setzt es unkonditional); fehlt es wider Erwarten, wird nie ausgeliefert.
+- **Job-Abholung fail-closed:** Der tote Abwärtskompatibilitäts-Zweig „Alt-Jobs ohne Abhol-Ticket bleiben offen" ist entfernt — jeder Job trägt seit v2.2.3 (PRIV-003) ein Ticket (`createJob` setzt es unkonditional); fehlt es wider Erwarten, wird nie ausgeliefert.
 
 ### Sicherheit / CI
 

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026071601" />
+    <link rel="stylesheet" href="./styles.css?v=2026071701" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -44,7 +44,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026071601" />
+    <link rel="stylesheet" href="./styles.css?v=2026071701" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -85,7 +85,7 @@
     <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
     <link rel="preconnect" href="https://nominatim.openstreetmap.org" crossorigin />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026071601" />
+    <link rel="stylesheet" href="./styles.css?v=2026071701" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -209,15 +209,15 @@
         <p class="demo-label" data-i18n="demo.label">Kein Foto zur Hand? Probier ein Beispielbild:</p>
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
-            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026060701" alt="" loading="lazy" />
+            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026071701" alt="" loading="lazy" />
             <span class="demo-caption" data-i18n="demo.selfie">Selfie am Stephansplatz</span>
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
-            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026060701" alt="" loading="lazy" />
+            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026071701" alt="" loading="lazy" />
             <span class="demo-caption" data-i18n="demo.cafe">Im Caf&eacute; in Salzburg</span>
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
-            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026060701" alt="" loading="lazy" />
+            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026071701" alt="" loading="lazy" />
             <span class="demo-caption" data-i18n="demo.hiker">Wanderung bei Hallstatt</span>
           </button>
         </div>
@@ -287,6 +287,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026071601"></script>
+    <script type="module" src="./app.js?v=2026071701"></script>
   </body>
 </html>

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026071601" />
+    <link rel="stylesheet" href="./styles.css?v=2026071701" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026071601" />
+    <link rel="stylesheet" href="./styles.css?v=2026071701" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026022106"></script>
+    <script type="module" src="./js/stats.js?v=2026071701"></script>
   </body>
 </html>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -36,7 +36,13 @@ fi
 TODAY=$(date +"%Y%m%d")
 CURRENT=$(grep -o 'styles\.css?v=[0-9]*' public/index.html | head -1 | grep -o '[0-9]*$' || true)
 if [ "${#CURRENT}" -eq 10 ] && [ "${CURRENT:0:8}" = "$TODAY" ]; then
-  VERSION=$(printf "%s%02d" "$TODAY" "$((10#${CURRENT:8:2} + 1))")
+  NEXT=$((10#${CURRENT:8:2} + 1))
+  if [ "$NEXT" -gt 99 ]; then
+    echo "FEHLER: 99 Hosting-Deploys heute erreicht — die 2-stellige Buster-Nummer läuft über." >&2
+    echo "Das ist praktisch nie ein echter Fall; falls doch, Konvention manuell erweitern." >&2
+    exit 1
+  fi
+  VERSION=$(printf "%s%02d" "$TODAY" "$NEXT")
 else
   VERSION="${TODAY}01"
 fi


### PR DESCRIPTION
Stempelt PRs #50/#51 auf v2.3.5 + die zwei P3-Randnotizen des Abschluss-KURZAUDITs (DOC-101 CHANGELOG-Wortlaut, OPS-101 deploy.sh-Guard) + Cache-Buster 2026071701.

Deploy erfolgt direkt nach Merge (Inhaber-Freigabe 2026-07-17, keine Workshop-Zeit — Sommerferien).

🤖 Generated with [Claude Code](https://claude.com/claude-code)