### PR TITLE
release: v2.3.6 — Stundenlimit konsistent auf 500

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ functions/src/       Firebase Cloud Functions 2nd Gen (Node 24, europe-west1)
   handle-analyze.js  Synchroner Legacy-Pfad (Fallback): Validation -> Mistral Describe -> SUBJECT-Parsing -> Mistral Profile / Easter-Egg -> Response. Live laeuft die Analyse ueber die Queue (handle-process-job.js).
   handle-stats.js    Stats-Handler (GET-only)
   handle-admin.js    Admin-Endpunkte (Boost, Reset, Maintenance) — 3-Schritt-Flow mit HMAC + Nonce
-  config.js          Konstanten + Mistral-Modell-IDs + Limits + HOURLY_LIMIT (1500)
+  config.js          Konstanten + Mistral-Modell-IDs + Limits + HOURLY_LIMIT (500)
   counter.js         Firestore-Zaehler: Stundenlimit, Totals, Stats, Boost, Reset, Maintenance-Mode
   notify.js          ntfy Push-Benachrichtigungen bei Limit-Erreichung
   animal.js          SUBJECT-Klassifikation aus Mistral-Beschreibungstext + Easter-Egg-Profile (Hund/Katze/Vogel/...)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [2.3.6] — 2026-07-17
+
+Korrektur eines Werts, den der Live-Smoke von v2.3.5 aufgedeckt hat: Das global durchgesetzte Stundenlimit ist **500/h** (rollendes 60-Minuten-Fenster) — der seit jeher gewünschte und live gefahrene Betriebswert. Der Wert wird aus Firestore `stats/current.limit` gelesen; die Code-Konstante `HOURLY_LIMIT` diente nur als Fallback und als Reset-Wert und stand irrtümlich auf 1500. v2.3.5 hatte im Zuge des Doku-Sweeps mehrere Stellen fälschlich auf 1500 angehoben — inklusive der öffentlichen Nutzungsbedingungen. Kein Verhaltenswechsel im Live-Betrieb (dort galt durchgehend 500).
+
+### Behoben
+
+- **Stundenlimit überall konsistent auf 500.** Code-Konstante `HOURLY_LIMIT` 1500 → **500** (`functions/src/config.js`) — damit ein Admin-„Reset" das Firestore-Limit nicht mehr ungewollt auf 1500 hochsetzt (der Reset schreibt die Konstante). Firestore `stats/current.limit` war bereits 500 (unverändert).
+- **Doku-Rückkorrektur:** README, AGENTS, ARCHITECTURE, RUNBOOK, SECURITY-MODEL, SELF-HOSTING, VERIFICATION und die öffentlichen Nutzungsbedingungen von fälschlich 1500 zurück auf 500. In ARCHITECTURE zusätzlich die Einlass-Politik geschärft: 500/h liegt knapp unter dem Verarbeitungs-Durchsatz (~550/h), sodass sich unter dem Limit gar kein Rückstau bilden kann (ARCH-001 damit faktisch entschärft).
+
+### Betrieb (außerhalb des Repos, 2026-07-17)
+
+- **ntfy-Alarm-Topic rotiert:** Der Benachrichtigungs-Kanal lag auf einem kurzen, erratbaren Namen (nur Geheimhaltung schützt ein ntfy-Topic). Neuer langer Zufalls-Kanal als Secret-Version gesetzt, Functions ziehen ihn seit dem v2.3.6-Deploy; Zustellung auf das Gerät des Inhabers verifiziert.
+
 ## [2.3.5] — 2026-07-17
 
 Sanierung nach LANGAUDIT vom 2026-07-17 (Release-Gate-Audit auf v2.3.4, Multi-Agent, read-only): drei Robustheits-Lücken im Queue-Pfad geschlossen, Diagnose-Daten weiter vergröbert, latente Secret-Falle entschärft, CI gehärtet. Keine Verhaltensänderung im Normalpfad.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Im Queue-Betrieb (Feature-Flag `useQueue`) nutzt das Frontend statt `/analyze` z
 - **Timing-Check**: Requests innerhalb von 2s nach Seitenaufruf werden verzoegert
 - **Prompt-Injection-Schutz**: User-Daten in XML-Tags isoliert + escapeXml() auf dynamische Inhalte
 - **HMAC-Admin-Tokens**: Kurzlebige signierte Tokens (30 Min) + Nonces (5 Min) fuer Admin-Aktionen
-- **Stundenlimit**: Rollendes 60-Minuten-Fenster (1500 Analysen/Stunde, anonyme Timestamps in Firestore)
+- **Stundenlimit**: Rollendes 60-Minuten-Fenster (500 Analysen/Stunde, anonyme Timestamps in Firestore)
 - **Keine dauerhafte Datenspeicherung**: Bilder nur kurz zur Verarbeitung gehalten, Job-Daten spaetestens nach 2 h geloescht, kein Logging von Bilddaten
 
 ## Tests

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,7 +40,7 @@ Seit v1.6.0 läuft die komplette KI-Analyse über Mistral AI (Paris, EU). Google
 │     ├─ Maintenance-Mode-Check (Firestore, 30s Cache)              │
 │     ├─ Rate-Limit (IP-basiert, 500/10min, In-Memory pro Instanz)  │
 │     ├─ Honeypot + MIME + Magic-Byte-Validierung                   │
-│     └─ Hourly-Limit-Check (Firestore, 1500/Std. rollendes Fenster) │
+│     └─ Hourly-Limit-Check (Firestore, 500/Std. rollendes Fenster)  │
 │                                                                    │
 │  2. Mistral Large 3 — Beschreibung                                 │
 │     ├─ mistral.js → POST api.mistral.ai/v1/chat/completions        │
@@ -118,7 +118,7 @@ Der Client hält keine lange Verbindung mehr, sondern pollt. Jeder `job-status`-
 
 ### Einlass-Politik
 
-Der Enqueue prüft bewusst **keine Queue-Tiefe** — der Einlass ist allein durch das Stundenlimit begrenzt (1500/h), das über dem Durchsatz liegt (~550 Analysen/h bei Concurrency 10 × ~65 s/Job). Begründung: Nutzer sehen Position + ETA sofort nach dem Upload und können selbst entscheiden, ob sie warten; Abbrecher werden nach der 8-Minuten-Karenz gereapt und geben ihren Stunden-Slot zurück (Selbstregulation); realer Workshop-Verkehr liegt weit unter dem Durchsatz. Der Client deckelt das Polling bei 30 min. Bewusste Entscheidung, bestätigt im LANGAUDIT 2026-07 (ARCH-001).
+Der Enqueue prüft bewusst **keine Queue-Tiefe** — der Einlass ist allein durch das Stundenlimit begrenzt (500/h). Das liegt sogar knapp **unter** dem Verarbeitungs-Durchsatz (~550 Analysen/h bei Concurrency 10 × ~65 s/Job), sodass sich unter dem Limit gar kein nennenswerter Rückstau aufbauen kann — das Stundenlimit deckelt den Einlass, bevor die Queue-Tiefe je zum Problem wird. Zusätzlich: Nutzer sehen Position + ETA sofort nach dem Upload und können selbst entscheiden, ob sie warten; Abbrecher werden nach der 8-Minuten-Karenz gereapt und geben ihren Stunden-Slot zurück (Selbstregulation). Der Client deckelt das Polling bei 30 min. Bewusste Entscheidung, bestätigt im LANGAUDIT 2026-07 (ARCH-001).
 
 ### Lokaler Betrieb
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -11,7 +11,7 @@ das Alerting-Setup [ERROR-ALERTING.md](ERROR-ALERTING.md), die Feature-Flags
 - **Aktiver Pfad:** Upload → Cloud-Tasks-Queue → Single-Large-Call
   (`featureFlags/current`: `useQueue = true`, `useSingleLargeCall = true`),
   Cloud-Tasks-Concurrency **10**.
-- **Limits:** Stundenlimit 1500 Analysen (rollendes Fenster), IP-Rate-Limit
+- **Limits:** Stundenlimit 500 Analysen (rollendes Fenster), IP-Rate-Limit
   500 Requests / 10 min pro Instanz.
 - **Lastprofil:** Workshops sind Stoßlast (Mo–Fr vormittags); genau dafür ist die
   Queue da. Mistral-Latenz schwankt mit Tageszeit/Wochentag — Messungen immer im
@@ -116,7 +116,7 @@ und **Account-Dashboard** prüfen (Limits unterscheiden sich drastisch je
 Modellversion — immer das Dashboard, nicht Code-Kommentare). Notfalls Wartungsmodus
 (Hebel 1).
 
-### Stundenlimit erreicht (1500/h rollend)
+### Stundenlimit erreicht (500/h rollend)
 
 Gewollte Kostenbremse; der ntfy-Push kommt automatisch. Braucht ein Workshop mehr:
 Admin-Boost (+100 je Aufruf) über `/api/admin/boost`, Zähler-Reset über

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -49,7 +49,7 @@ CI vs. Laufzeit (CI ohne Cloud-Rechte).
 
 | Missbrauchsfall | Gegenmaßnahmen |
 |---|---|
-| Bot-Massen-Uploads / Kostenexplosion | IP-Rate-Limit (500/10 min), Honeypot + Timing-Check, Stundenlimit 1500 (rollend), Cloud-Tasks-Concurrency-Deckel, Budget-Alarm (extern) |
+| Bot-Massen-Uploads / Kostenexplosion | IP-Rate-Limit (500/10 min), Honeypot + Timing-Check, Stundenlimit 500 (rollend), Cloud-Tasks-Concurrency-Deckel, Budget-Alarm (extern) |
 | Prompt-Injection über Bildinhalte/sichtbaren Text | User-Daten in XML-Tags isoliert + `escapeXml()`, JSON-Schema, defensiver JSON-Repair, Output-Bounds; LLM-Ausgaben steuern keine Tools oder Folgeprozesse |
 | Upload fremder/heikler Fotos | Datenschutz-Hinweis direkt am Upload-Bereich (neu 2026-07) + Nach-Analyse-Warnung vor ungewollt preisgegebenen Bilddetails (PRIV-002), Kinderschutz-Härtung in den Prompts (DE + EN immer parallel pflegen), keine Persistenz über 2 h hinaus |
 | Ergebnis-Abgriff durch Dritte | Abhol-Ticket (PRIV-003): Job-Status und Ergebnis nur mit Ticket; Ticket lebt im Tab (`sessionStorage`) und stirbt mit ihm |

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -181,10 +181,10 @@ Wenn du keine ntfy-Benachrichtigungen willst, setze die Secrets auf einen Platzh
 
 ### 5h. Stundenlimit anpassen (optional)
 
-Das Standard-Stundenlimit liegt bei 1500 Analysen/Stunde. Du kannst es in `functions/src/config.js` aendern:
+Das Standard-Stundenlimit liegt bei 500 Analysen/Stunde. Du kannst es in `functions/src/config.js` aendern:
 
 ```js
-HOURLY_LIMIT: 1500,  // Maximale Analysen pro Stunde
+HOURLY_LIMIT: 500,  // Maximale Analysen pro Stunde
 ```
 
 ### 5i. Spenden-Button (optional)

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -34,7 +34,7 @@ bewusst als offen ausgewiesen.
 | SERVICE_API | Autorisierung fail-closed | ✅ Admin nur mit HMAC-Token + Nonce (`auth.js`, Tests); `processJob` nur via OIDC (Cloud Tasks) |
 | DATA_ML_GENAI | LLM-Ausgaben schema-validiert, kein ungeprüftes Freitext-Parsing für Logik | ✅ JSON-Schema in Prompts + `json-repair.js` + Output-Clamps; LLM-Ausgaben steuern keine Tools/Folgeprozesse |
 | DATA_ML_GENAI | Untrusted-Input-Annahme (Prompt Injection) | ✅ XML-Isolation + `escapeXml()` (SEC-003), Bounds (SEC-004) |
-| DATA_ML_GENAI | Kosten-Grenzen | ✅ Stundenlimit 1500 (Code-Gate) + GCP-Budget-Alarm (extern, siehe unten) |
+| DATA_ML_GENAI | Kosten-Grenzen | ✅ Stundenlimit 500 (Code-Gate) + GCP-Budget-Alarm (extern, siehe unten) |
 
 ## Externe Kontrollen (nicht aus dem Repo verifizierbar)
 

--- a/functions/src/config.js
+++ b/functions/src/config.js
@@ -62,11 +62,17 @@ const MISTRAL_PROFILE_MAX_TOKENS = 16000;
 const MISTRAL_TIMEOUT_MS = 90000;
 
 /* ── Globales Stundenlimit ──
-   v1.10.6: Von 500 auf 1500 hochgesetzt. Mit Auto-Retries auf Client-Seite
-   plus moeglichen Demo-Klicks kann ein 25er-Workshop locker 200-300
-   Analysen im Stundenfenster verbrennen. 1500 laesst grosszuegig Puffer
-   fuer mehrere Workshops kurz hintereinander. */
-const HOURLY_LIMIT = 1500;
+   500 Analysen pro rollendem 60-Minuten-Fenster — der gewuenschte Betriebswert
+   (kostenstabil beim aktuellen Budget). Mit Auto-Retries auf Client-Seite plus
+   Demo-Klicks verbraucht ein 25er-Workshop rund 200-300 Analysen/Stunde, 500
+   laesst dafuer Puffer.
+
+   WICHTIG: Der LIVE durchgesetzte Wert steht in Firestore `stats/current.limit`
+   und wird dort gelesen (counter.js). Diese Konstante ist (a) der Fallback bei
+   fehlendem Feld und (b) der Wert, auf den `resetHourly` das Dokument setzt.
+   Beide muessen zum Live-Wert passen — sonst kippt ein Admin-Reset das Limit
+   ungewollt. Bei Aenderung IMMER auch `stats/current.limit` mitziehen. */
+const HOURLY_LIMIT = 500;
 const HOURLY_WINDOW_MINUTES = 60;
 
 /* BUG-003: Globales Budget pro Request — verhindert dass die Summe aller

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026071701" />
+    <link rel="stylesheet" href="./styles.css?v=2026071702" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -44,7 +44,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026071701" />
+    <link rel="stylesheet" href="./styles.css?v=2026071702" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -85,7 +85,7 @@
     <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
     <link rel="preconnect" href="https://nominatim.openstreetmap.org" crossorigin />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026071701" />
+    <link rel="stylesheet" href="./styles.css?v=2026071702" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -209,15 +209,15 @@
         <p class="demo-label" data-i18n="demo.label">Kein Foto zur Hand? Probier ein Beispielbild:</p>
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
-            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026071701" alt="" loading="lazy" />
+            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026071702" alt="" loading="lazy" />
             <span class="demo-caption" data-i18n="demo.selfie">Selfie am Stephansplatz</span>
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
-            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026071701" alt="" loading="lazy" />
+            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026071702" alt="" loading="lazy" />
             <span class="demo-caption" data-i18n="demo.cafe">Im Caf&eacute; in Salzburg</span>
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
-            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026071701" alt="" loading="lazy" />
+            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026071702" alt="" loading="lazy" />
             <span class="demo-caption" data-i18n="demo.hiker">Wanderung bei Hallstatt</span>
           </button>
         </div>
@@ -287,6 +287,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026071701"></script>
+    <script type="module" src="./app.js?v=2026071702"></script>
   </body>
 </html>

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026071701" />
+    <link rel="stylesheet" href="./styles.css?v=2026071702" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -84,7 +84,7 @@
           <li><strong>Missbrauch der Ergebnisse:</strong> Profile d&uuml;rfen nicht als Tatsachenbehauptungen &uuml;ber reale Personen verbreitet werden. Du darfst die Ergebnisse nicht verwenden, um andere Personen zu beleidigen, zu diskriminieren, zu mobben oder blo&szlig;zustellen.</li>
           <li><strong>Fotos Dritter ohne Einwilligung:</strong> Lade keine Fotos von Personen hoch, die dem nicht zugestimmt haben &ndash; es sei denn, es handelt sich um Stock-Fotos oder die Nutzung erfolgt im Rahmen eines betreuten Workshops mit entsprechender Einwilligung.</li>
           <li><strong>Illegale Inhalte:</strong> Das Hochladen von illegalen, gewaltverherrlichenden, pornografischen oder kindesmissbr&auml;uchlichen Inhalten ist verboten. Mistral AI pr&uuml;ft alle Anfragen maschinell auf solche Inhalte.</li>
-          <li><strong>Automatisierte Zugriffe:</strong> Bots, Scraper oder automatisierte Massenanfragen sind nicht erlaubt. malziME ist durch Rate Limiting gesch&uuml;tzt (maximal 500 Anfragen pro 10&nbsp;Minuten pro IP-Adresse, maximal 1500 Analysen pro Stunde insgesamt).</li>
+          <li><strong>Automatisierte Zugriffe:</strong> Bots, Scraper oder automatisierte Massenanfragen sind nicht erlaubt. malziME ist durch Rate Limiting gesch&uuml;tzt (maximal 500 Anfragen pro 10&nbsp;Minuten pro IP-Adresse, maximal 500 Analysen pro Stunde insgesamt).</li>
           <li><strong>Umgehung von Schutzma&szlig;nahmen:</strong> Versuche, den Missbrauchsschutz, Rate Limits oder andere technische Schutzma&szlig;nahmen zu umgehen, sind untersagt.</li>
           <li><strong>Kommerzielle Nutzung:</strong> Die Nutzung von malziME oder dessen Ergebnissen f&uuml;r kommerzielle Zwecke (z.&thinsp;B. kostenpflichtige Profiling-Dienste, Werbeprofile) ist ohne vorherige schriftliche Zustimmung nicht gestattet.</li>
         </ul>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026071701" />
+    <link rel="stylesheet" href="./styles.css?v=2026071702" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026071701"></script>
+    <script type="module" src="./js/stats.js?v=2026071702"></script>
   </body>
 </html>


### PR DESCRIPTION
Rückkorrektur des v2.3.5-Doku-Drifts, aufgedeckt durch den Live-Smoke.

**Kern:** Das durchgesetzte Stundenlimit ist 500/h (Firestore `stats/current.limit`, gewünschter Live-Wert seit Feb 2026). Die Code-Konstante `HOURLY_LIMIT` (Fallback + Reset-Wert) stand fälschlich auf 1500; v2.3.5 hatte mehrere Doku-Stellen auf 1500 angehoben — inkl. öffentlicher Nutzungsbedingungen.

- config.js 1500 → 500 (verhindert ungewolltes Hochspringen bei Admin-Reset)
- Doku überall zurück auf 500 (8 Dateien)
- ARCHITECTURE: Einlass-Politik geschärft (500/h < ~550/h → kein Rückstau)
- Firestore-Doc unverändert (war bereits 500)

Backend 439/439 · Frontend 165/165 · Lint/Format grün. Deploy direkt nach Merge (Inhaber-Freigabe 2026-07-17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)