### PR TITLE
fix: von der eigenen Sicherheitsrichtlinie verbotene Formatierung im HTML

### DIFF
--- a/public/__tests__/csp-inline-styles.test.js
+++ b/public/__tests__/csp-inline-styles.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/* Keine style-Attribute im HTML (Konsolenfund 2026-08-10).
+
+   ANLASS: `stats.html` enthielt `style="width: 0%"` an der Balkenanzeige des
+   Stundenlimits. Die eigene Content-Security-Policy erlaubt nur `style-src
+   'self'` — ohne `'unsafe-inline'`. Der Browser hat das Attribut daher
+   verworfen und bei jedem Aufruf zwei Fehler in die Konsole geschrieben:
+
+     Refused to apply a stylesheet because its hash, its nonce, or
+     'unsafe-inline' does not appear in the style-src directive …
+
+   Nachgewiesen mit WebKit (dem Motor von Safari) über die echte Seite.
+
+   WICHTIG zur Abgrenzung: Verboten ist das **Attribut im HTML**. Was
+   JavaScript über die CSSOM setzt (`el.style.width = …` in stats.js), ist von
+   der Richtlinie ausdrücklich erlaubt und bleibt unangetastet. Die Startbreite
+   gehört deshalb in die Stilvorlage, nicht ins Markup.
+
+   Diese Prüfung hält das für alle ausgelieferten HTML-Seiten fest. */
+
+const PUBLIC_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const STYLE_ATTRIBUT = /<[^>]+\sstyle\s*=\s*["'][^"']*["']/gi;
+
+const seiten = readdirSync(PUBLIC_DIR).filter((n) => n.endsWith(".html"));
+
+describe("Content-Security-Policy: keine style-Attribute im HTML", () => {
+  it("es wurden überhaupt HTML-Seiten gefunden (Positivkontrolle der Suche)", () => {
+    expect(seiten.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it.each(seiten)("%s kommt ohne style-Attribut aus", (name) => {
+    const inhalt = readFileSync(join(PUBLIC_DIR, name), "utf8");
+    const treffer = [...inhalt.matchAll(STYLE_ATTRIBUT)].map((m) => m[0].slice(0, 90));
+    expect(treffer).toEqual([]);
+  });
+
+  /* Gegenprobe: Der Erkenner findet ein style-Attribut auch wirklich. Ohne das
+     könnte die Suche stillschweigend an allem vorbeigehen und trotzdem grün
+     sein — der häufigste Weg, wie eine Dauerprüfung wertlos wird. */
+  it("ein eingebautes style-Attribut würde erkannt (Gegenprobe)", () => {
+    const beispiel = '<div class="x" id="limitBar" style="width: 0%"></div>';
+    expect([...beispiel.matchAll(STYLE_ATTRIBUT)]).toHaveLength(1);
+  });
+});

--- a/public/stats.html
+++ b/public/stats.html
@@ -86,7 +86,7 @@
           <span class="stats-limit__badge stats-limit__badge--ok" id="limitBadge">&ndash;</span>
         </div>
         <div class="stats-limit__bar-wrap">
-          <div class="stats-limit__bar-fill stats-limit__bar-fill--low" id="limitBar" style="width: 0%"></div>
+          <div class="stats-limit__bar-fill stats-limit__bar-fill--low" id="limitBar"></div>
         </div>
         <div class="stats-limit__labels">
           <span id="limitLabels">&ndash; / &ndash;</span>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1796,6 +1796,11 @@ html[data-has-result] {
 
 .stats-limit__bar-fill {
   height: 100%;
+  /* Startbreite gehört hierher, nicht als style="width: 0%" ins HTML: Die
+     Content-Security-Policy erlaubt kein style-Attribut, der Browser hätte es
+     verworfen und in der Konsole gemeldet. stats.js setzt die Breite danach
+     über die CSSOM — das ist von der Richtlinie erlaubt. */
+  width: 0;
   border-radius: 3px;
   transition: width 0.6s var(--ease);
 }


### PR DESCRIPTION
## Der Fund

Gefunden beim Nachstellen der Seite in **WebKit** (dem Motor von Safari) gegen
die Live-Seite. Auf `stats.html` meldet die Konsole bei jedem Aufruf:

```
Refused to apply a stylesheet because its hash, its nonce, or 'unsafe-inline'
does not appear in the style-src directive of the Content Security Policy.
  → https://malzi.me/stats.html:88
```

## Ursache

Die Startbreite der Limit-Anzeige stand als Attribut im Markup:

```html
<div class="stats-limit__bar-fill …" id="limitBar" style="width: 0%"></div>
```

Die eigene CSP erlaubt `style-src 'self'` **ohne** `'unsafe-inline'`. Der
Browser verwirft das Attribut also — die Anzeige startete mit undefinierter
Breite statt bei null.

## Änderung

- Startbreite nach `styles.css` verschoben (`width: 0`)
- Attribut aus `stats.html` entfernt
- Dauerprüfung `public/__tests__/csp-inline-styles.test.js` über **alle**
  ausgelieferten HTML-Seiten, mit Positivkontrolle der Suche und Gegenprobe
  des Erkenners

**Abgrenzung:** Verboten ist das Attribut im Markup. Was JavaScript über die
CSSOM setzt (`el.style.width = …` in `stats.js`), erlaubt die Richtlinie
ausdrücklich — das bleibt unangetastet, und die Prüfung fängt es nicht.

**Rückbauprobe:** Attribut wieder eingebaut → Test rot, nennt `stats.html`.
Zurückgebaut → grün. Frontend 203 Tests grün, Lint und Format sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)