### PR TITLE
fix: v2.11.1 — reduzierte Bewegung ließ Profilkarten unsichtbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [2.11.1] — 2026-08-11
+
+Drei Fehler, die in der Browser-Konsole sichtbar waren, plus der echte Fehler
+dahinter. Ausgelöst durch eine Meldung des Betreibers aus dem laufenden Betrieb.
+
+### Behoben
+
+- **Karten-Bibliothek verwies auf eine Datei, die es nicht gibt.**
+  `leaflet.js` endete mit `//# sourceMappingURL=leaflet.js.map`; diese
+  Begleitdatei wurde nie mitausgeliefert. Firebase Hosting antwortet für
+  unbekannte Pfade mit der **Startseite** (HTTP 200, `text/html`, 20396 Bytes)
+  — der Browser wollte JSON parsen und meldete
+  `JSON Parse error: Unrecognized token '<'`. Verweis entfernt.
+- **Formatierung im HTML, die die eigene Sicherheitsrichtlinie verbietet.**
+  `stats.html` setzte die Startbreite der Limit-Anzeige als
+  `style="width: 0%"`. Die CSP erlaubt `style-src 'self'` ohne
+  `'unsafe-inline'`; der Browser verwarf das Attribut und meldete es bei jedem
+  Aufruf. Startbreite nach `styles.css` verschoben. Was JavaScript über die
+  CSSOM setzt, war und bleibt erlaubt.
+- **Reduzierte Bewegung schaltete nur die Dauer ab, nicht die Verzögerung.**
+  Die Profilkarten laufen mit `animation: fadeUp … both` und gestaffelten
+  `animation-delay` bis 0,33 s. `both` hält während der Wartezeit den
+  Startzustand `opacity: 0`. Wer Animationen ausdrücklich abbestellt hatte, sah
+  die Karten also weiterhin nacheinander aufpoppen — nur ohne Bewegung.
+  `animation-delay` und `transition-delay` werden jetzt mit zurückgesetzt.
+
+### Neue Dauerprüfungen
+
+- Jeder Source-Map-Verweis im Hosting-Ordner muss auf eine real vorhandene
+  Datei zeigen — geprüft am **Dateibestand**, nicht über HTTP. Grund: Ein
+  HTTP 200 von diesem Hosting beweist nicht, dass eine Datei existiert.
+- Keine `style`-Attribute in den ausgelieferten HTML-Seiten.
+- Bei reduzierter Bewegung darf keine Profilkarte unsichtbar bleiben (E2E,
+  Prüfung auf die Ursache statt auf das Symptom, dadurch nicht flackernd).
+
+Alle drei mit Rückbauprobe belegt. Frontend 203 Tests, E2E 10.
+
+### Wie der dritte Fehler gefunden wurde
+
+Der A11y-Test meldete im CI 19 ernste Kontrastverstöße im Beast Mode — an
+Elementen, die niemand angefasst hatte. Es sah nach einem flackernden Test aus.
+Tatsächlich maß axe unsichtbaren Text: Die Karten warteten noch auf ihre
+Einblende-Verzögerung. Der Fund war echt, nur nicht dort, wo er zu stehen
+schien.
+
+### Betrieb (nicht im Code sichtbar)
+
+- Die Alarm-Richtlinie schickt jetzt zusätzlich an einen **E-Mail-Kanal**. Der
+  ntfy-Push war nicht als zugestellt nachweisbar; Priorität, Weiterleitung und
+  Kanalzuordnung schieden als Ursache aus. Zustellung der E-Mail mit einem
+  Testalarm **belegt**. Rezept in `docs/ERROR-ALERTING.md`.
+- Die DNS-Zone von `malzi.me` steht erstmals schriftlich im
+  [RUNBOOK](docs/RUNBOOK.md) — samt Prüfbefehlen und einer Vorfallnotiz.
+- `api.malzi.me` ist vollständig abgebaut (DNS und Cloud-Run-Zuordnung).
+
 ## [2.11.0] — 2026-08-11
 
 Sanierung des LANGAUDIT vom 2026-08-10 (Bericht wird nicht veröffentlicht).

--- a/e2e/a11y.test.js
+++ b/e2e/a11y.test.js
@@ -124,6 +124,23 @@ test("A11y: Profil-Ansicht ohne ernste Verstöße", async ({ page }) => {
   await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
   await expect(page.locator(".cat-card").first()).toBeVisible();
 
+  /* Bei reduzierter Bewegung darf KEINE Karte unsichtbar sein.
+     Die Karten laufen mit `animation: fadeUp … both` und gestaffelten
+     `animation-delay` bis 0,33 s; `both` haelt waehrend der Wartezeit den
+     Startzustand `opacity: 0`. Der reduced-motion-Block setzte lange nur die
+     Dauer zurueck, nicht die Verzoegerung — die Karten poppten also auch fuer
+     Menschen nacheinander auf, die Animationen ausdruecklich abbestellt haben.
+
+     Fuer axe sah das aus wie unsichtbarer Text: Kontrast 1:1, 19 ernste
+     Verstoesse (CI 2026-08-10). Der Fund war echt, nur nicht dort, wo er zu
+     stehen schien — deshalb hier eine Pruefung auf die URSACHE statt auf das
+     Symptom. Sie haengt nicht am Zeitpunkt der Messung und kann daher nicht
+     flackern. */
+  const unsichtbar = await page.$$eval(".cat-card", (karten) =>
+    karten.map((k, i) => ({ i, opacity: Number(getComputedStyle(k).opacity) })).filter((k) => k.opacity < 1)
+  );
+  expect(unsichtbar, "Karten, die bei reduzierter Bewegung unsichtbar bleiben").toEqual([]);
+
   await checkA11y(page, "Profil-Ansicht im Beast Mode");
 
   /* Und der geklebte Umschalter im gescrollten Zustand — er liegt dann ueber

--- a/public/styles.css
+++ b/public/styles.css
@@ -2534,6 +2534,18 @@ ol.legal-list > li::before {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    /* Verzögerungen müssen mit zurückgesetzt werden, nicht nur die Dauer.
+       Die Profilkarten laufen mit `animation: fadeUp … both` und gestaffelten
+       `animation-delay` bis 0,33 s. `both` hält während der Wartezeit den
+       Startzustand — und der ist `opacity: 0`. Ohne diese beiden Zeilen sieht
+       also gerade die Person, die Animationen abbestellt hat, die Karten
+       weiterhin nacheinander aufpoppen; nur eben ohne Bewegung.
+
+       Nebenwirkung im Test: axe misst dann unsichtbaren Text und meldet
+       Kontrast 1:1 als ernsten Verstoß (19 Elemente, Beast Mode, CI 2026-08-10).
+       Der Fund war echt — nur nicht dort, wo er zu stehen schien. */
+    animation-delay: 0s !important;
+    transition-delay: 0s !important;
   }
 }
 


### PR DESCRIPTION
## Wie das gefunden wurde

Der A11y-Lauf meldete im CI **19 ernste Kontrastverstöße** im Beast Mode — an
Elementen, die in diesem PR niemand angefasst hatte (es war eine reine
Doku-Änderung). Das sah nach einem flackernden Test aus.

War es nicht. axe maß **unsichtbaren Text**.

## Die Ursache

```css
.cat-card { animation: fadeUp 0.35s var(--ease) both; }
.cat-card:nth-child(1) { animation-delay: 0.03s; }   /* … bis 0.33s */
```

`@keyframes fadeUp` startet bei `opacity: 0`, und der Füllmodus `both` hält
diesen Startzustand **während der Verzögerung**. Der
`prefers-reduced-motion`-Block setzte bisher nur die *Dauer* zurück:

```css
animation-duration: 0.01ms !important;   /* war da */
animation-delay:    0s     !important;   /* fehlte */
```

**Das ist ein echter Fehler, kein Testartefakt:** Wer Animationen ausdrücklich
abbestellt hat, sah die Karten weiterhin nacheinander aufpoppen — nur ohne
Bewegung. Genau das Gegenteil dessen, was die Einstellung bezweckt.

## Änderung

- `animation-delay` und `transition-delay` im reduced-motion-Block mit
  zurückgesetzt
- Neue E2E-Prüfung an der **Ursache** statt am Symptom: Bei reduzierter
  Bewegung darf keine Karte `opacity < 1` haben. Hängt nicht am Zeitpunkt der
  Messung und kann daher nicht flackern.
- CHANGELOG-Eintrag `2.11.1`, der zusätzlich die beiden heute bereits
  veröffentlichten Konsolen-Fixes und die Betriebsänderungen nachträgt — die
  waren beim Deploy ohne Versionseintrag geblieben.

## Belege

**Rückbauprobe:** Fix entfernt → Prüfung rot mit `"opacity": 0`. Wieder
eingebaut → grün. Drei Läufe hintereinander stabil.

Voller E2E-Lauf 10 grün, Frontend 203 grün, Lint und Format sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)