### PR TITLE
feat: v2.12.0 — Datenbank läuft in Europa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,75 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [2.12.0] — 2026-08-11
+
+**Die Datenbank läuft ab jetzt in Europa.** Damit stimmt die Zusage der
+Datenschutzerklärung erstmals auch für die Datenbank — und das Projekt hat
+keinen Speicherort mehr ausserhalb der EU.
+
+### Was sich ändert
+
+Der Schalter aus 2.11.2 ist umgelegt: `FIRESTORE_DATABASE_ID = "malzime-eu"`.
+Alle Lese- und Schreibvorgänge gehen in die Datenbank in `europe-west1` — dort,
+wo auch die Programme und die Fotos liegen. Für Besucher ändert sich nichts;
+die Anwendung verhält sich identisch.
+
+Damit endet der Zustand, dass ein Job-Dokument — und darin bis zu zwei Stunden
+lang das fertige Profil eines oft minderjährigen Menschen — in den USA lag.
+Das war der letzte offene Punkt aus dem Audit vom 2026-08-10 und zugleich der
+schwerste: Die Zusage „Daten in Europa" stand drei Audits lang im Dokument,
+ohne dass sie an der Infrastruktur geprüft worden wäre.
+
+### Die alte Datenbank bleibt zunächst stehen
+
+Bewusst nicht gelöscht. Solange sie existiert, ist der Rückweg zwei Minuten
+weit weg: `scripts/firestore-umzug-sync.mjs --zurueck`, Schalter zurück,
+ausrollen. Löschen erst nach ein paar ruhigen Tagen im Betrieb.
+
+### Nachweis
+
+Nicht behauptet, sondern gemessen — Ablauf in
+[RUNBOOK](docs/RUNBOOK.md), Abschnitt „Firestore-Umzug".
+
+Backend 618 Tests grün.
+
 ## [2.11.2] — 2026-08-11
 
-Vorbereitung des Firestore-Umzugs nach Europa. **Ändert das Verhalten nicht** —
-der Schalter steht weiterhin auf der alten Datenbank.
+Vorbereitung des Umzugs **der Datenbank** nach Europa. **Ändert das Verhalten
+nicht** — der Schalter steht weiterhin auf der alten Datenbank.
 
-### Warum
+### Worum es geht — und worum ausdrücklich nicht
+
+Betroffen ist **ausschliesslich die Firestore-Datenbank**, nicht die Speicherorte
+insgesamt. Zur Klarstellung, weil das leicht verwechselt wird:
+
+| | Standort | betroffen? |
+|---|---|---|
+| **Fotos** (`malzime-queue-uploads`) | `europe-west1` | nein — lagen immer in Europa |
+| Quellstände der Functions | `europe-west1` | nein |
+| **Firestore-Datenbank** | `nam5` (USA) | **ja — darum geht es hier** |
+
+Die hochgeladenen Bilder haben Europa also zu keinem Zeitpunkt verlassen. Das
+wurde an der Infrastruktur nachgemessen, nicht aus dem Quelltext geschlossen.
+
+### Warum die Datenbank
 
 Die Datenschutzerklärung verspricht Europa; die Datenbank liegt in `nam5` (USA),
 und ein Job-Dokument enthält bis zu zwei Stunden lang das fertige Profil eines
 oft minderjährigen Menschen. Der Standort einer Firestore-Datenbank ist
 **unveränderlich** — es gibt keinen Umzugsknopf. Der Wechsel läuft deshalb über
 eine zweite Datenbank.
+
+### Was in der neuen Datenbank liegt — und was nicht
+
+**Es sind noch keine Nutzerdaten dorthin gelangt.** Kopiert wurden
+ausschliesslich drei technische Dokumente: die Schalterstellungen der
+Anwendung, der Zählerstand des Stundenlimits und die Gesamtzähler. Kein Foto,
+kein Profil, keine Auftragsdaten, nichts Personenbezogenes.
+
+Der Schalter steht unverändert auf der alten Datenbank — der laufende Betrieb
+schreibt weiterhin dorthin. Die neue Datenbank ist vorbereitet, aber noch nicht
+in Benutzung.
 
 ### Vorbereitet
 
@@ -40,6 +97,22 @@ rot, als eingebaute Erinnerung, die Dokumentation mitzuziehen.
 
 Backend 618 Tests (611 + 7 neue). Ablauf, Nachweis und Rückweg:
 [RUNBOOK](docs/RUNBOOK.md), Abschnitt „Firestore-Umzug".
+
+### Letzter US-Speicher entfernt (Infrastruktur, kein Code)
+
+`malzime_cloudbuild` lag als einziger Speicher in den USA. Inhalt geprüft, bevor
+etwas passierte: **7 Dateien, 5 Kilobyte, neueste vom 6. Juni** — die
+Bauanleitung des ntfy-Servers (Dockerfile, `entrypoint.sh`, `server.yml`).
+**Keine Nutzerdaten, keine Zugangsdaten** (die Passwörter kommen zur Laufzeit
+aus Umgebungsvariablen, der Dockerfile hält das ausdrücklich fest), kein
+ntfy-Kanalname.
+
+Der Speicher war seit zwei Monaten unbeteiligt: Die Deploys dieses Tages haben
+in den EU-Speicher `gcf-v2-sources-…-europe-west1` geschrieben, nicht dorthin.
+Die Bauanleitung existierte nirgends sonst und wurde vor dem Löschen ausserhalb
+des Repos gesichert.
+
+**Damit liegt kein einziger Speicher des Projekts mehr ausserhalb Europas.**
 
 ## [2.11.1] — 2026-08-11
 

--- a/functions/src/__tests__/db-zentral.test.js
+++ b/functions/src/__tests__/db-zentral.test.js
@@ -110,7 +110,7 @@ describe("Stellung des Schalters", () => {
      gemockt, und `jest.doMock` bleibt für die restliche Datei wirksam — ein
      `require("../config")` hier bekäme den Mock und prüfte ins Leere. Der
      Quelltext ist ausserdem genau das, was ein Mensch beim Umschalten ändert. */
-  test("steht derzeit auf der Standard-Datenbank", () => {
+  test("steht auf der Datenbank in Europa", () => {
     const quelle = readFileSync(join(SRC, "config.js"), "utf8");
     const treffer = quelle.match(/^const FIRESTORE_DATABASE_ID = "([^"]*)";$/m);
     /* Kein zweites expect-Argument: Jest kennt die Meldungs-Variante nicht
@@ -120,8 +120,9 @@ describe("Stellung des Schalters", () => {
     expect(treffer === null ? "Zeile `const FIRESTORE_DATABASE_ID = …` fehlt in config.js" : "gefunden").toBe(
       "gefunden"
     );
-    /* Nach dem Umzug wird diese Erwartung bewusst auf "malzime-eu" gezogen — der dann
-       fehlschlagende Test ist die Erinnerung, RUNBOOK und CHANGELOG mitzuziehen. */
-    expect(treffer[1]).toBe("");
+    /* Umgelegt am 2026-08-11 (v2.12.0). Wer zurueckschaltet, muss diese Zeile
+       ebenfalls zuruecknehmen — der dann fehlschlagende Test ist die
+       eingebaute Erinnerung, RUNBOOK und CHANGELOG mitzuziehen. */
+    expect(treffer[1]).toBe("malzime-eu");
   });
 });

--- a/functions/src/config.js
+++ b/functions/src/config.js
@@ -207,7 +207,7 @@ function localQueueConcurrency() {
    `getFirestore()`-Aufruf würde diesen Schalter umgehen und still in die
    falsche Datenbank schreiben. Genau das verhindert eine eigene Prüfung
    (`__tests__/db-zentral.test.js`). */
-const FIRESTORE_DATABASE_ID = "";
+const FIRESTORE_DATABASE_ID = "malzime-eu";
 
 /* Laufzeit-Validierung — fehlerhafte Config crasht sofort statt leise falsch zu laufen */
 if (HOURLY_LIMIT < 1) throw new Error("Config: HOURLY_LIMIT must be >= 1");


### PR DESCRIPTION
Der Schalter aus #72 ist umgelegt. Alle Lese- und Schreibvorgänge gehen ab
jetzt in `malzime-eu` (`europe-west1`) — dort, wo auch die Functions und die
Fotos liegen.

Damit endet der Zustand, dass ein Job-Dokument — und darin bis zu zwei Stunden
lang das fertige Profil eines oft minderjährigen Menschen — in den USA lag.
Letzter offener Punkt des Audits vom 2026-08-10 und zugleich der schwerste:
Die Zusage „Daten in Europa" stand drei Audits lang im Dokument, ohne je an der
**Infrastruktur** geprüft worden zu sein.

## Änderung

- `config.js`: `FIRESTORE_DATABASE_ID` `""` → `"malzime-eu"` — eine Zeile
- `db-zentral.test.js`: erwartete Schalterstellung nachgezogen. Der Test war
  durch das Umlegen **absichtlich rot** geworden; genau dafür ist er gebaut.

## Präzisierung an 2.11.2 (auf Hinweis des Betreibers)

Es geht **ausschliesslich um die Datenbank**, nicht um die Speicherorte
insgesamt:

| | Standort | betroffen? |
|---|---|---|
| Fotos | `europe-west1` | nein — lagen immer in Europa |
| Firestore-Datenbank | `nam5` (USA) | ja |

Und: In die neue Datenbank sind bislang **keine Nutzerdaten** gelangt — kopiert
wurden nur drei technische Dokumente (Schalterstellungen, Zählerstand des
Stundenlimits, Gesamtzähler).

## Letzter US-Speicher entfernt

`malzime_cloudbuild` ist gelöscht. Inhalt vorher geprüft: 7 Dateien, 5 KB,
neueste vom 6. Juni — die Bauanleitung des ntfy-Servers. Keine Nutzerdaten,
keine Zugangsdaten, kein Kanalname. Vor dem Löschen ausserhalb des Repos
gesichert, weil sie sonst nirgends existierte.

**Kein Speicher des Projekts liegt mehr ausserhalb Europas.**

## Rückweg

Die alte Datenbank bleibt bewusst stehen. Rückweg zwei Minuten:
`scripts/firestore-umzug-sync.mjs --zurueck`, Schalter zurück, ausrollen.

Backend **618** Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)