### PR TITLE
fix: v2.12.1 — Beast Mode überlebt ein Neuladen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [2.12.1] — 2026-08-11
+
+Der Beast Mode überlebt jetzt ein Neuladen.
+
+### Behoben
+
+Wer im Beast Mode die Seite neu lud, landete wieder im seriösen Modus — das
+Ergebnis wurde zwar wiederhergestellt, aber im falschen Modus, und die
+Umschaltung musste von Hand wiederholt werden.
+
+Das war ursprünglich Absicht („Beast startet immer ausgeschaltet"). Der
+Betreiber hat die Regel präzisiert, und die Präzisierung trifft den Kern:
+
+> „Beast startet immer ausgeschaltet — das stimmt, aber ein Reload ist kein
+> Start."
+
+Die Wahl liegt jetzt im `sessionStorage`: Sie überlebt Neuladen und
+Tab-Wechsel, endet aber mit dem Tab. **Der didaktische Einstieg bleibt damit
+erhalten** — im Workshop startet jede neue Person und jedes weitergereichte
+Gerät wieder im seriösen Modus und stellt den Kontrast selbst her.
+
+Datenschutz unverändert: dieselbe Ablage, die schon die Job-Nummer nutzt,
+nichts Personenbezogenes, endet mit dem Tab. Kein `localStorage` — das wird
+eigens geprüft, weil ein Wechsel dorthin die didaktische Zusage still
+aushebeln würde.
+
+### Prüfungen
+
+- Unit: sechs Fälle, darunter die Unterscheidung „nie gewählt" gegen „bewusst
+  seriös gewählt" und ein defekter Speicher (privater Safari-Modus)
+- E2E: umschalten → neu laden → weiterhin Beast; und ein **neuer Tab** startet
+  wieder seriös
+- Rückbauprobe: Fix entfernt → E2E rot mit `Received: "light"`; wieder
+  eingebaut → grün
+
+Frontend 209 Tests, E2E 12.
+
 ## [2.12.0] — 2026-08-11
 
 **Die Datenbank läuft ab jetzt in Europa.** Damit stimmt die Zusage der

--- a/e2e/modus-merken.test.js
+++ b/e2e/modus-merken.test.js
@@ -1,0 +1,75 @@
+import { test, expect } from "@playwright/test";
+
+/* Beast Mode überlebt ein Neuladen — aber nicht einen neuen Tab.
+
+   ANLASS (Betreiber-Meldung 2026-08-11): Im Beast Mode neu laden landete
+   wieder im seriösen Modus. Die Regel lautete „Beast startet immer
+   ausgeschaltet"; der Betreiber hat sie präzisiert:
+
+     „Beast startet immer ausgeschaltet — das stimmt, aber ein Reload ist
+      kein Start."
+
+   Genau diese Unterscheidung prüfen die beiden Tests hier: Der eine hält das
+   gewünschte neue Verhalten fest, der andere die didaktische Zusage, die dabei
+   NICHT verloren gehen darf. Ohne den zweiten wäre ein Wechsel auf
+   localStorage eine stille Verschlechterung, die niemandem auffällt. */
+
+async function seiteMitMocks(page) {
+  await page.route("**/api/stats", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        current: { count: 0, limit: 500, limitActive: false, retryAfterSeconds: 0 },
+        totals: { today: 0, week: 0, month: 0, year: 0, allTime: 0 },
+        useQueue: true,
+      }),
+    })
+  );
+  await page.goto("/");
+  await expect(page.locator("h1")).toBeVisible();
+}
+
+/* Die Checkbox ist visuell durch den Schalter ersetzt und daher nicht direkt
+   klickbar — wie in den anderen E2E-Tests über das Element selbst. */
+async function beastEinschalten(page) {
+  await page.evaluate(() => document.getElementById("biasSwitch").click());
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+}
+
+test("Beast Mode überlebt ein Neuladen", async ({ page }) => {
+  await seiteMitMocks(page);
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+
+  await beastEinschalten(page);
+
+  await page.reload();
+  await expect(page.locator("h1")).toBeVisible();
+
+  /* Beides prüfen: das Aussehen UND den Schalter. Nur das Theme zu prüfen
+     würde einen Zustand durchgehen lassen, in dem die Seite dunkel aussieht,
+     der Schalter aber auf „seriös" steht — dann wäre der nächste Klick ein
+     Sprung ins Dunkle statt zurück ins Helle. */
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  await expect(page.locator("#biasSwitch")).toBeChecked();
+});
+
+test("ein neuer Tab startet wieder seriös (didaktische Zusage)", async ({ browser }) => {
+  const kontext = await browser.newContext();
+
+  const ersteSeite = await kontext.newPage();
+  await seiteMitMocks(ersteSeite);
+  await beastEinschalten(ersteSeite);
+  await ersteSeite.close();
+
+  /* Neuer Tab = neue sessionStorage-Sitzung. Im Workshop ist das die nächste
+     Person am weitergereichten Gerät: Sie soll den Kontrast selbst herstellen
+     und nicht bereits im Beast Mode landen. */
+  const zweiteSeite = await kontext.newPage();
+  await seiteMitMocks(zweiteSeite);
+
+  await expect(zweiteSeite.locator("html")).toHaveAttribute("data-theme", "light");
+  await expect(zweiteSeite.locator("#biasSwitch")).not.toBeChecked();
+
+  await kontext.close();
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -100,6 +100,11 @@ export default [
         afterAll: "readonly",
         vi: "readonly",
         sessionStorage: "readonly",
+        /* Für den Test des Modus-Speichers: `localStorage` als Gegenprobe
+           (die Wahl darf dort NICHT landen), `Storage` zum Nachstellen eines
+           defekten Speichers wie im privaten Safari-Modus. */
+        localStorage: "readonly",
+        Storage: "readonly",
       },
     },
     rules: {

--- a/public/__tests__/modus-speicher.test.js
+++ b/public/__tests__/modus-speicher.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { merkeModus, gemerkterModus, vergissModus } from "../js/modus-speicher.js";
+
+/* Merken der Modus-Wahl über ein Neuladen hinweg (Betreiber-Meldung 2026-08-11).
+
+   ANLASS: Im Beast Mode neu laden landete wieder im seriösen Modus. Die alte
+   Regel lautete „Beast startet immer ausgeschaltet". Der Betreiber hat sie
+   präzisiert — und die Präzisierung ist der ganze Kern dieser Datei:
+
+     „Beast startet immer ausgeschaltet — das stimmt, aber ein Reload ist
+      kein Start."
+
+   Deshalb sessionStorage und nicht localStorage: Neuladen und Tab-Wechsel
+   behalten die Wahl, das Schliessen des Tabs verwirft sie. Im Workshop startet
+   damit jede neue Person wieder seriös. */
+
+describe("Modus-Speicher", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("ohne gemerkte Wahl kommt null zurück — nicht false", () => {
+    /* Der Unterschied ist tragend: `false` hiesse „bewusst seriös gewählt" und
+       würde eine vom Browser wiederhergestellte Checkbox überschreiben. */
+    expect(gemerkterModus()).toBeNull();
+  });
+
+  it("gemerkter Beast Mode kommt als true zurück", () => {
+    merkeModus(true);
+    expect(gemerkterModus()).toBe(true);
+  });
+
+  it("gemerkter seriöser Modus kommt als false zurück", () => {
+    merkeModus(false);
+    expect(gemerkterModus()).toBe(false);
+  });
+
+  it('vergissModus setzt auf "nie gewählt" zurück', () => {
+    merkeModus(true);
+    vergissModus();
+    expect(gemerkterModus()).toBeNull();
+  });
+
+  it("die Wahl liegt in sessionStorage, NICHT in localStorage", () => {
+    /* Das ist die eigentliche Zusage: Sie endet mit dem Tab. Läge sie in
+       localStorage, würde ein weitergereichtes Gerät im Beast Mode starten —
+       genau der didaktische Einstieg ginge verloren. */
+    merkeModus(true);
+    expect(sessionStorage.length).toBeGreaterThan(0);
+    expect(localStorage.length).toBe(0);
+  });
+
+  it("ein defekter Speicher legt nichts lahm (privater Modus)", () => {
+    /* Safari im privaten Modus kann bei setItem werfen. Die Umschaltung selbst
+       darf daran nicht scheitern — sie funktioniert dann eben ohne Gedächtnis. */
+    const setzen = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    const lesen = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+
+    expect(() => merkeModus(true)).not.toThrow();
+    expect(gemerkterModus()).toBeNull();
+
+    setzen.mockRestore();
+    lesen.mockRestore();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+});

--- a/public/app.js
+++ b/public/app.js
@@ -12,6 +12,7 @@ import {
 } from "./js/ui.js";
 import { initDemo } from "./js/demo.js";
 import { initStickyToggle, renderKeepingScrollAnchor } from "./js/sticky-toggle.js";
+import { merkeModus, gemerkterModus } from "./js/modus-speicher.js";
 
 /* ── i18n initialisieren (vor allem anderen) ── */
 await initI18n();
@@ -148,8 +149,13 @@ document.addEventListener("drop", (e) => e.preventDefault());
 
 /* Modus-Theme-Kopplung (malziland Design System): Seriöse Analyse = heller
    Papier-Look, Beast Mode = dunkles Theme. Das Theme hängt am Modus — es
-   gibt bewusst keinen separaten Hell/Dunkel-Schalter und keine Speicherung
-   (Beast startet immer ausgeschaltet). */
+   gibt bewusst keinen separaten Hell/Dunkel-Schalter.
+
+   Zur Speicherung: Beast startet weiterhin immer ausgeschaltet — aber ein
+   Reload ist kein Start. Die Wahl liegt deshalb im sessionStorage: Sie
+   überlebt Neuladen und Tab-Wechsel, endet aber mit dem Tab. Im Workshop
+   startet damit jede neue Person und jedes weitergereichte Gerät wieder
+   seriös und erlebt den Kontrast selbst (siehe js/modus-speicher.js). */
 function applyModeTheme() {
   const boost = elements.biasSwitch.checked;
   document.documentElement.setAttribute("data-mode", boost ? "boost" : "normal");
@@ -158,6 +164,12 @@ function applyModeTheme() {
   const themeMeta = document.querySelector('meta[name="theme-color"]');
   if (themeMeta) themeMeta.setAttribute("content", boost ? "#171d1f" : "#f9f7f4");
 }
+/* Gemerkte Wahl wiederherstellen, BEVOR das Theme angewendet wird — sonst
+   blitzt kurz der falsche Look auf. `null` heisst „nie gewählt": dann bleibt
+   der Zustand, den der Browser selbst wiederhergestellt hat, unangetastet. */
+const gemerkt = gemerkterModus();
+if (gemerkt !== null) elements.biasSwitch.checked = gemerkt;
+
 /* Beim Start anwenden — Browser können den Checkbox-Zustand nach einem
    Reload wiederherstellen, dann muss das Theme mitziehen. */
 applyModeTheme();
@@ -166,6 +178,7 @@ applyModeTheme();
 initStickyToggle();
 
 elements.biasSwitch.addEventListener("change", () => {
+  merkeModus(elements.biasSwitch.checked);
   applyModeTheme();
   if (state.lastData) {
     renderKeepingScrollAnchor(() => renderCurrentMode(state.lastData));

--- a/public/js/modus-speicher.js
+++ b/public/js/modus-speicher.js
@@ -1,0 +1,68 @@
+/* ── Merken der Modus-Wahl (seriös / Beast) über ein Neuladen hinweg ──
+ *
+ * ANLASS (Betreiber-Meldung 2026-08-11): Wer im Beast Mode die Seite neu lädt,
+ * landete wieder im seriösen Modus. Im laufenden Durchgang ist das ärgerlich —
+ * das Ergebnis wird nach dem Neuladen ja wiederhergestellt, aber im falschen
+ * Modus, und die Umschaltung muss von Hand wiederholt werden.
+ *
+ * Vorher war das ausdrücklich so gewollt („Beast startet immer ausgeschaltet").
+ * Der Betreiber hat die Regel präzisiert, und die Präzisierung trifft es genau:
+ *
+ *   „Beast startet immer ausgeschaltet — das stimmt, aber ein Reload ist
+ *    kein Start."
+ *
+ * Der didaktische Sinn bleibt also erhalten, die Umsetzung ändert sich:
+ *
+ *   sessionStorage, NICHT localStorage.
+ *
+ * Damit überlebt die Wahl ein Neuladen und einen Tab-Wechsel, aber NICHT das
+ * Schliessen des Tabs. Wer die Seite frisch aufruft — im Workshop also jede
+ * neue Person, jedes weitergereichte Gerät — startet wieder im seriösen Modus
+ * und erlebt den Kontrast selbst. Genau der Punkt, um den es didaktisch geht.
+ *
+ * Dieselbe Ablage nutzt schon die Job-Nummer (api.js); Datenschutz-Bewertung
+ * daher unverändert: nichts Personenbezogenes, endet mit dem Tab.
+ */
+
+const SCHLUESSEL = "malzime.beastMode";
+
+/**
+ * Merkt die Modus-Wahl. Fehler werden geschluckt: Im privaten Modus kann
+ * sessionStorage werfen, und daran darf die Umschaltung nicht scheitern —
+ * sie funktioniert dann eben nur ohne Gedächtnis.
+ */
+export function merkeModus(beastAktiv) {
+  try {
+    sessionStorage.setItem(SCHLUESSEL, beastAktiv ? "1" : "0");
+  } catch (_err) {
+    /* kein Gedächtnis verfügbar — kein Grund, irgendetwas abzubrechen */
+  }
+}
+
+/**
+ * Liefert die gemerkte Wahl, oder `null`, wenn nichts gemerkt ist.
+ *
+ * Bewusst `null` statt `false`: Der Aufrufer muss „nie gewählt" von „bewusst
+ * seriös gewählt" unterscheiden können. Sonst würde ein leerer Speicher wie
+ * eine aktive Entscheidung aussehen und könnte eine vom Browser
+ * wiederhergestellte Checkbox überschreiben.
+ */
+export function gemerkterModus() {
+  try {
+    const wert = sessionStorage.getItem(SCHLUESSEL);
+    if (wert === "1") return true;
+    if (wert === "0") return false;
+    return null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+/** Vergisst die Wahl (für Tests und einen möglichen Zurücksetzen-Knopf). */
+export function vergissModus() {
+  try {
+    sessionStorage.removeItem(SCHLUESSEL);
+  } catch (_err) {
+    /* nichts zu tun */
+  }
+}


### PR DESCRIPTION
## Der Fund

Betreiber-Meldung: Im Beast Mode neu laden → wieder im seriösen Modus.

Das war **ursprünglich Absicht**, so stand es im Code: „Beast startet immer
ausgeschaltet". Die Präzisierung des Betreibers trifft den Kern:

> „Beast startet immer ausgeschaltet — das stimmt, aber ein Reload ist kein
> Start."

## Änderung

Die Wahl liegt jetzt im `sessionStorage` — überlebt Neuladen und Tab-Wechsel,
endet mit dem Tab. **Der didaktische Einstieg bleibt erhalten:** Im Workshop
startet jede neue Person und jedes weitergereichte Gerät wieder seriös und
stellt den Kontrast selbst her.

- `public/js/modus-speicher.js` — merken / lesen / vergessen
- `app.js` stellt die Wahl **vor** dem Anwenden des Themes wieder her, sonst
  blitzt kurz der falsche Look auf
- `gemerkterModus()` liefert bewusst `null` statt `false`, wenn nie gewählt
  wurde — sonst sähe ein leerer Speicher wie eine Entscheidung aus und würde
  eine vom Browser wiederhergestellte Checkbox überschreiben

## Prüfungen

**Unit (6)** — u. a. die Unterscheidung „nie gewählt" gegen „bewusst seriös",
und ein defekter Speicher (privater Safari-Modus wirft beim Schreiben).

**E2E (2)** — umschalten → neu laden → weiterhin Beast; und ein **neuer Tab**
startet wieder seriös. Der zweite Test hält die didaktische Zusage fest: Ohne
ihn wäre ein späterer Wechsel auf `localStorage` eine stille Verschlechterung,
die niemandem auffiele.

**Rückbauprobe:** Fix entfernt → E2E rot mit `Received: "light"`; wieder
eingebaut → grün.

Frontend **209**, E2E **12**.

## Datenschutz

Unverändert: dieselbe Ablage, die schon die Job-Nummer nutzt, nichts
Personenbezogenes, endet mit dem Tab. Kein `localStorage` — das wird eigens
geprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)