### PR TITLE
feat: v2.12.2 — Absturz-Wache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [2.12.2] — 2026-08-11
+
+Eine Wache gegen einen Fehler, den bisher niemand sehen konnte.
+
+### Der Anlass
+
+Auf einem iPhone erschien wiederholt Safaris Meldung „Auf https://malzi.me/ ist
+wiederholt ein Problem aufgetreten". **Sechs Erklärungen wurden geprüft und
+alle sechs ausgeschlossen:**
+
+| Vermutung | Ergebnis |
+|---|---|
+| 2-Stunden-Frist der Aufträge | wird sauber abgefangen, stille Aufräumung |
+| Neulade-Schleife am Stundenlimit | Limit stand bei 0 von 500 |
+| Absturz beim Laden der Sprachdatei | ist abgefangen, läuft mit Ersatztexten weiter |
+| Foto als Speicherfresser | liegt als Verweis im Fenster, nicht als Zeichenkette |
+| Abfrage-Schleife und Wartefunktion | beide sauber begrenzt und aufgeräumt |
+| DNS-Ausfall desselben Tages | zeitlich ausgeschlossen |
+
+### Warum Raten hier nicht weiterführt
+
+Wenn diese Meldung erscheint, **läuft der eigene Code nicht mehr** — deshalb
+kommt auch keine Fehlermeldung an. Das Ereignis ist unsichtbar. Statt eine
+siebte Vermutung zu prüfen, wird es jetzt messbar gemacht.
+
+### Die Wache
+
+Startet die Seite **dreimal binnen einer Minute**, ist das kein normales
+Verhalten. Dann passiert zweierlei:
+
+1. **Eine** Meldung geht über den vorhandenen Diagnose-Kanal raus — Anzahl der
+   Starts, Zeitspanne, ob ein Auftrag offen war und wie weit die Seite zuletzt
+   kam. Keine neue Datenart, kein Foto, keine Kennung.
+2. Der gemerkte Auftrag wird verworfen. **Hängt der Absturz an genau diesem
+   Auftrag, wiederholt er sich sonst bei jedem Start endlos.** Lieber ein
+   verlorenes Ergebnis als eine Seite, die sich nicht mehr öffnen lässt.
+
+Zwei Starts lösen bewusst nichts aus — einmal neu laden ist normal. Eine Wache,
+die zu früh anschlägt, wird ignoriert und ist damit wertlos.
+
+Zehn Prüfungen, darunter: schweigt im Normalbetrieb, meldet nur einmal, zählt
+alte Starts nicht mit, und ein defekter Speicher (privater Safari-Modus) legt
+den Seitenstart nicht lahm.
+
+### Nebenbei: Wortwahl korrigiert
+
+„Der Betreiber" ist aus CHANGELOG, Handbuch und Code-Kommentaren verschwunden.
+Das Projekt wird von einer Person entwickelt und betrieben; die Formulierung
+klang nach Auftragsarbeit für ein fremdes Unternehmen.
+
+Frontend 219 Tests, E2E 12.
+
 ## [2.12.1] — 2026-08-11
 
 Der Beast Mode überlebt jetzt ein Neuladen.
@@ -14,8 +66,8 @@ Wer im Beast Mode die Seite neu lud, landete wieder im seriösen Modus — das
 Ergebnis wurde zwar wiederhergestellt, aber im falschen Modus, und die
 Umschaltung musste von Hand wiederholt werden.
 
-Das war ursprünglich Absicht („Beast startet immer ausgeschaltet"). Der
-Betreiber hat die Regel präzisiert, und die Präzisierung trifft den Kern:
+Das war ursprünglich Absicht („Beast startet immer ausgeschaltet"). Die
+Regel ist präzisiert, und die Präzisierung trifft den Kern:
 
 > „Beast startet immer ausgeschaltet — das stimmt, aber ein Reload ist kein
 > Start."
@@ -154,7 +206,7 @@ des Repos gesichert.
 ## [2.11.1] — 2026-08-11
 
 Drei Fehler, die in der Browser-Konsole sichtbar waren, plus der echte Fehler
-dahinter. Ausgelöst durch eine Meldung des Betreibers aus dem laufenden Betrieb.
+dahinter. Im laufenden Betrieb aufgefallen.
 
 ### Behoben
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,8 +1,8 @@
 # Runbook — Betrieb, Deploy, Rollback
 
 Dieses Dokument ist das Betriebs-Handbuch von malziME: Wie wird deployt, wie wird
-zurückgerollt, was tun bei Störungen. Zielgruppe: der Betreiber und unterstützende
-KI-Assistenten. Die Architektur selbst beschreibt [ARCHITECTURE.md](ARCHITECTURE.md),
+zurückgerollt, was tun bei Störungen. Zielgruppe: die Entwicklung des Projekts
+und unterstützende KI-Assistenten. Die Architektur selbst beschreibt [ARCHITECTURE.md](ARCHITECTURE.md),
 das Alerting-Setup [ERROR-ALERTING.md](ERROR-ALERTING.md), die Feature-Flags
 [FLAGS.md](FLAGS.md).
 

--- a/e2e/modus-merken.test.js
+++ b/e2e/modus-merken.test.js
@@ -2,9 +2,9 @@ import { test, expect } from "@playwright/test";
 
 /* Beast Mode überlebt ein Neuladen — aber nicht einen neuen Tab.
 
-   ANLASS (Betreiber-Meldung 2026-08-11): Im Beast Mode neu laden landete
+   ANLASS (aufgefallen 2026-08-11): Im Beast Mode neu laden landete
    wieder im seriösen Modus. Die Regel lautete „Beast startet immer
-   ausgeschaltet"; der Betreiber hat sie präzisiert:
+   ausgeschaltet"; die Regel ist präzisiert:
 
      „Beast startet immer ausgeschaltet — das stimmt, aber ein Reload ist
       kein Start."

--- a/public/__tests__/absturz-wache.test.js
+++ b/public/__tests__/absturz-wache.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/* Absturz-Wache (2026-08-11).
+
+   ANLASS: Safaris Meldung „Auf https://malzi.me/ ist wiederholt ein Problem
+   aufgetreten" auf einem iPhone. Sechs Ursachen wurden geprüft und
+   ausgeschlossen — das Ereignis selbst ist unsichtbar, weil beim Auftreten
+   kein eigener Code mehr läuft und deshalb auch keine Meldung ankommt.
+
+   Diese Prüfungen halten beide Aufgaben der Wache fest: melden UND die
+   Schleife brechen. Und ebenso wichtig: dass sie im Normalbetrieb SCHWEIGT.
+   Eine Wache, die bei jedem zweiten Neuladen anschlägt, wird ignoriert und
+   ist damit wertlos. */
+
+const meldungen = [];
+vi.mock("../js/error-logger.js", () => ({
+  logClientError: (fehler, kontext) => meldungen.push({ fehler, kontext }),
+}));
+
+const { initAbsturzWache, merkePhase } = await import("../js/absturz-wache.js");
+
+describe("Absturz-Wache", () => {
+  let jetzt;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    meldungen.length = 0;
+    jetzt = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => jetzt);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("schweigt beim ersten Start", () => {
+    expect(initAbsturzWache({})).toBe(false);
+    expect(meldungen).toHaveLength(0);
+  });
+
+  it("schweigt auch beim zweiten Start — einmal neu laden ist normal", () => {
+    initAbsturzWache({});
+    jetzt += 3000;
+    expect(initAbsturzWache({})).toBe(false);
+    expect(meldungen).toHaveLength(0);
+  });
+
+  it("schlägt beim dritten Start innerhalb einer Minute an", () => {
+    initAbsturzWache({});
+    jetzt += 3000;
+    initAbsturzWache({});
+    jetzt += 3000;
+    expect(initAbsturzWache({})).toBe(true);
+    expect(meldungen).toHaveLength(1);
+    expect(meldungen[0].kontext.phase).toBe("absturz-schleife");
+  });
+
+  it("verwirft den gemerkten Auftrag, um die Schleife zu brechen", () => {
+    const verwirfAuftrag = vi.fn();
+    initAbsturzWache({ verwirfAuftrag });
+    jetzt += 3000;
+    initAbsturzWache({ verwirfAuftrag });
+    jetzt += 3000;
+    initAbsturzWache({ verwirfAuftrag });
+    expect(verwirfAuftrag).toHaveBeenCalledTimes(1);
+  });
+
+  it("meldet die zuletzt erreichte Phase mit", () => {
+    initAbsturzWache({});
+    merkePhase("i18n");
+    jetzt += 2000;
+    initAbsturzWache({});
+    jetzt += 2000;
+    initAbsturzWache({});
+    expect(meldungen[0].kontext.errorDetail).toContain("letztePhase=i18n");
+  });
+
+  it("meldet, ob ein Auftrag offen war — die wichtigste Spur", () => {
+    sessionStorage.setItem("malzime.queueJobId", "job-123");
+    initAbsturzWache({});
+    jetzt += 2000;
+    initAbsturzWache({});
+    jetzt += 2000;
+    initAbsturzWache({});
+    expect(meldungen[0].kontext.errorDetail).toContain("offenerAuftrag=true");
+  });
+
+  it("meldet nur EINMAL, nicht bei jedem weiteren Start", () => {
+    for (let i = 0; i < 3; i++) {
+      initAbsturzWache({});
+      jetzt += 2000;
+    }
+    expect(meldungen).toHaveLength(1);
+    /* Der Zähler ist zurückgesetzt — der nächste Start beginnt bei null. */
+    expect(initAbsturzWache({})).toBe(false);
+    expect(meldungen).toHaveLength(1);
+  });
+
+  it("zählt Starts nicht mit, die länger als eine Minute her sind", () => {
+    initAbsturzWache({});
+    jetzt += 30_000;
+    initAbsturzWache({});
+    /* Der erste Start faellt jetzt aus dem Fenster. */
+    jetzt += 40_000;
+    expect(initAbsturzWache({})).toBe(false);
+    expect(meldungen).toHaveLength(0);
+  });
+
+  it("ein defekter Speicher legt den Seitenstart nicht lahm", () => {
+    const lesen = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    const schreiben = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    expect(() => initAbsturzWache({})).not.toThrow();
+    expect(initAbsturzWache({})).toBe(false);
+
+    lesen.mockRestore();
+    schreiben.mockRestore();
+  });
+
+  it("ein Fehler beim Aufräumen verhindert die Meldung nicht", () => {
+    /* Sonst wäre der Fall, in dem die Selbstheilung scheitert, genau der Fall,
+       über den wir nichts erfahren. */
+    const verwirfAuftrag = vi.fn(() => {
+      throw new Error("kaputt");
+    });
+    initAbsturzWache({ verwirfAuftrag });
+    jetzt += 2000;
+    initAbsturzWache({ verwirfAuftrag });
+    jetzt += 2000;
+    expect(() => initAbsturzWache({ verwirfAuftrag })).not.toThrow();
+    expect(meldungen).toHaveLength(1);
+  });
+});

--- a/public/__tests__/modus-speicher.test.js
+++ b/public/__tests__/modus-speicher.test.js
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { merkeModus, gemerkterModus, vergissModus } from "../js/modus-speicher.js";
 
-/* Merken der Modus-Wahl über ein Neuladen hinweg (Betreiber-Meldung 2026-08-11).
+/* Merken der Modus-Wahl über ein Neuladen hinweg (aufgefallen 2026-08-11).
 
    ANLASS: Im Beast Mode neu laden landete wieder im seriösen Modus. Die alte
-   Regel lautete „Beast startet immer ausgeschaltet". Der Betreiber hat sie
-   präzisiert — und die Präzisierung ist der ganze Kern dieser Datei:
+   Regel lautete „Beast startet immer ausgeschaltet" und ist präzisiert —
+   die Präzisierung ist der ganze Kern dieser Datei:
 
      „Beast startet immer ausgeschaltet — das stimmt, aber ein Reload ist
       kein Start."

--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,13 @@
 import { initI18n, applyTranslations, t } from "./js/i18n.js";
 import { elements } from "./js/dom.js";
 import { state } from "./js/state.js";
-import { analyzeImage, acquireWakeLock, resumeQueueJob, initHintergrundWiederaufnahme } from "./js/api.js";
+import {
+  analyzeImage,
+  acquireWakeLock,
+  resumeQueueJob,
+  initHintergrundWiederaufnahme,
+  clearStoredJobId,
+} from "./js/api.js";
 import { renderCurrentMode } from "./js/render.js";
 import {
   dismissDisclaimerModal,
@@ -13,16 +19,28 @@ import {
 import { initDemo } from "./js/demo.js";
 import { initStickyToggle, renderKeepingScrollAnchor } from "./js/sticky-toggle.js";
 import { merkeModus, gemerkterModus } from "./js/modus-speicher.js";
+import { initAbsturzWache, merkePhase } from "./js/absturz-wache.js";
+
+/* ── Absturz-Wache: als ALLERERSTES, vor jedem await ──
+   Startet die Seite mehrfach binnen einer Minute, meldet sie das einmalig und
+   verwirft den gemerkten Auftrag — sonst wiederholt sich ein Absturz, der an
+   genau diesem Auftrag haengt, bei jedem Start endlos. Details und die Liste
+   der bereits ausgeschlossenen Ursachen: js/absturz-wache.js */
+initAbsturzWache({ verwirfAuftrag: clearStoredJobId });
+merkePhase("start");
 
 /* ── i18n initialisieren (vor allem anderen) ── */
 await initI18n();
+merkePhase("i18n");
 applyTranslations();
 
 /* ── Demo-Fotos initialisieren ── */
 initDemo();
+merkePhase("demo");
 
 /* ── Queue-Modus: offenes Ergebnis nach einem Reload weiter abholen ──
    No-Op, wenn keine jobId aus einem früheren Seitenbesuch vorliegt. */
+merkePhase("resume");
 resumeQueueJob();
 
 /* Holt das Ergebnis auch dann nach, wenn das Handy zwischendurch gesperrt war

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081102" />
+    <link rel="stylesheet" href="./styles.css?v=2026081103" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -44,7 +44,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081102" />
+    <link rel="stylesheet" href="./styles.css?v=2026081103" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -85,7 +85,7 @@
     <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
     <link rel="preconnect" href="https://nominatim.openstreetmap.org" crossorigin />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081102" />
+    <link rel="stylesheet" href="./styles.css?v=2026081103" />
     <script type="application/ld+json">
 [
   {
@@ -258,15 +258,15 @@
         <p class="demo-label" data-i18n="demo.label">Kein Foto zur Hand? Probier ein Beispielbild (mit KI erstellt):</p>
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
-            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081102" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081103" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.selfie">Selfie am Stephansplatz</span>
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
-            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081102" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081103" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.cafe">Im Caf&eacute; in Salzburg</span>
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
-            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081102" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081103" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.hiker">Wanderung bei Hallstatt</span>
           </button>
         </div>
@@ -336,6 +336,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081102"></script>
+    <script type="module" src="./app.js?v=2026081103"></script>
   </body>
 </html>

--- a/public/js/absturz-wache.js
+++ b/public/js/absturz-wache.js
@@ -1,0 +1,126 @@
+/**
+ * absturz-wache.js — erkennt, wenn die Seite wiederholt in kurzer Folge neu
+ * startet, meldet es einmalig und bricht die Schleife.
+ *
+ * ANLASS (2026-08-11): Auf einem iPhone erschien wiederholt Safaris Meldung
+ * „Auf https://malzi.me/ ist wiederholt ein Problem aufgetreten." Sechs
+ * Erklärungen wurden geprüft und ausgeschlossen: die 2-Stunden-Frist der
+ * Aufträge (wird sauber abgefangen), eine Neulade-Schleife am Stundenlimit
+ * (Limit war bei 0 von 500), ein Absturz beim Sprachdatei-Laden (ist
+ * abgefangen), das Foto als Speicherfresser (liegt als Verweis vor, nicht als
+ * Zeichenkette), die Abfrage-Schleife samt Wartefunktion (beide sauber
+ * begrenzt) und der DNS-Ausfall desselben Tages (zeitlich ausgeschlossen).
+ *
+ * DAS EIGENTLICHE PROBLEM: Wenn diese Meldung erscheint, läuft unser Code
+ * nicht — deshalb kommt auch keine Fehlermeldung an. Das Ereignis ist
+ * unsichtbar, und Weiterraten kostet nur Zeit. Diese Datei macht es sichtbar.
+ *
+ * ZWEI AUFGABEN:
+ *
+ *   1. Melden. Startet die Seite mehrfach binnen einer Minute, ist das kein
+ *      normales Verhalten — dann geht EINE Meldung über den vorhandenen
+ *      Diagnose-Kanal raus. Keine neue Datenart: Anzahl der Starts, Zeitspanne,
+ *      ob ein Auftrag offen war, wie weit die Seite zuletzt kam.
+ *
+ *   2. Die Schleife brechen. Hängt der Absturz an einem bestimmten
+ *      wiederaufgenommenen Auftrag, wiederholt er sich bei jedem Start endlos.
+ *      Wird eine Schleife erkannt, wird der gemerkte Auftrag verworfen — der
+ *      nächste Start beginnt sauber. Lieber ein verlorenes Ergebnis als eine
+ *      Seite, die sich nicht mehr öffnen lässt.
+ *
+ * sessionStorage überlebt einen Absturz und den Neustart des Tabs, endet aber
+ * mit dem Tab — genau die Lebensdauer, die hier gebraucht wird.
+ */
+
+import { logClientError } from "./error-logger.js";
+
+const STARTS_SCHLUESSEL = "malzime.starts";
+const PHASE_SCHLUESSEL = "malzime.letztePhase";
+
+/* Drei Starts binnen einer Minute. Zwei wären zu wenig — ein bewusstes
+   Neuladen direkt nach dem Öffnen ist normal und soll nichts auslösen. */
+const FENSTER_MS = 60 * 1000;
+const SCHWELLE = 3;
+
+function lies(schluessel) {
+  try {
+    return sessionStorage.getItem(schluessel);
+  } catch (_err) {
+    return null;
+  }
+}
+
+function schreibe(schluessel, wert) {
+  try {
+    sessionStorage.setItem(schluessel, wert);
+  } catch (_err) {
+    /* Kein Gedächtnis verfügbar — dann eben keine Wache. Nie ein harter Fehler. */
+  }
+}
+
+/**
+ * Hält fest, wie weit die Seite gekommen ist. Stirbt sie danach, steht in der
+ * Meldung, an welcher Stelle — das ist der Unterschied zwischen „irgendwo" und
+ * einer verwertbaren Spur.
+ */
+export function merkePhase(name) {
+  schreibe(PHASE_SCHLUESSEL, String(name).slice(0, 40));
+}
+
+/**
+ * Muss als eine der ERSTEN Zeilen beim Seitenstart laufen — sonst zählt ein
+ * Absturz, der vor diesem Aufruf passiert, gar nicht mit.
+ *
+ * @param {object} haken
+ * @param {Function} haken.verwirfAuftrag  wird bei erkannter Schleife gerufen
+ * @returns {boolean} true, wenn eine Schleife erkannt wurde
+ */
+export function initAbsturzWache({ verwirfAuftrag } = {}) {
+  const jetzt = Date.now();
+
+  let starts = [];
+  try {
+    const roh = lies(STARTS_SCHLUESSEL);
+    if (roh) starts = JSON.parse(roh).filter((z) => typeof z === "number");
+  } catch (_err) {
+    starts = [];
+  }
+
+  /* Nur das gleitende Fenster behalten; alles Ältere ist bedeutungslos. */
+  starts = starts.filter((z) => jetzt - z < FENSTER_MS);
+  starts.push(jetzt);
+  schreibe(STARTS_SCHLUESSEL, JSON.stringify(starts.slice(-SCHWELLE)));
+
+  if (starts.length < SCHWELLE) return false;
+
+  /* ── Schleife erkannt ── */
+  const spanneMs = jetzt - starts[0];
+  const letztePhase = lies(PHASE_SCHLUESSEL) || "unbekannt";
+  let hatteAuftrag = false;
+  try {
+    hatteAuftrag = Boolean(sessionStorage.getItem("malzime.queueJobId"));
+  } catch (_err) {
+    /* egal — dann steht eben false in der Meldung */
+  }
+
+  /* Zähler sofort zurücksetzen: Die Meldung soll EINMAL rausgehen, nicht bei
+     jedem weiteren Start erneut. */
+  schreibe(STARTS_SCHLUESSEL, "[]");
+
+  /* Schleife brechen, bevor irgendetwas anderes läuft. */
+  if (typeof verwirfAuftrag === "function") {
+    try {
+      verwirfAuftrag();
+    } catch (_err) {
+      /* Aufräumen darf den Start nie verhindern. */
+    }
+  }
+
+  logClientError(new Error(`Seite ${starts.length}x in ${Math.round(spanneMs / 1000)}s neu gestartet`), {
+    phase: "absturz-schleife",
+    durationMs: spanneMs,
+    errorDetail: `starts=${starts.length} letztePhase=${letztePhase} offenerAuftrag=${hatteAuftrag}`,
+  });
+
+  return true;
+}

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -166,7 +166,9 @@ function storeJobId(jobId, resultToken) {
   }
 }
 
-function clearStoredJobId() {
+/* Auch von der Absturz-Wache genutzt: Haengt ein Absturz an einem bestimmten
+   wiederaufgenommenen Auftrag, muss der weg, sonst wiederholt er sich endlos. */
+export function clearStoredJobId() {
   try {
     sessionStorage.removeItem(JOB_ID_STORAGE_KEY);
     sessionStorage.removeItem(JOB_TOKEN_STORAGE_KEY);

--- a/public/js/modus-speicher.js
+++ b/public/js/modus-speicher.js
@@ -1,12 +1,12 @@
 /* ── Merken der Modus-Wahl (seriös / Beast) über ein Neuladen hinweg ──
  *
- * ANLASS (Betreiber-Meldung 2026-08-11): Wer im Beast Mode die Seite neu lädt,
+ * ANLASS (im Betrieb aufgefallen, 2026-08-11): Wer im Beast Mode die Seite neu lädt,
  * landete wieder im seriösen Modus. Im laufenden Durchgang ist das ärgerlich —
  * das Ergebnis wird nach dem Neuladen ja wiederhergestellt, aber im falschen
  * Modus, und die Umschaltung muss von Hand wiederholt werden.
  *
  * Vorher war das ausdrücklich so gewollt („Beast startet immer ausgeschaltet").
- * Der Betreiber hat die Regel präzisiert, und die Präzisierung trifft es genau:
+ * Die Regel ist präzisiert, und die Präzisierung trifft es genau:
  *
  *   „Beast startet immer ausgeschaltet — das stimmt, aber ein Reload ist
  *    kein Start."

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081102" />
+    <link rel="stylesheet" href="./styles.css?v=2026081103" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081102" />
+    <link rel="stylesheet" href="./styles.css?v=2026081103" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081102"></script>
+    <script type="module" src="./js/stats.js?v=2026081103"></script>
   </body>
 </html>


### PR DESCRIPTION
## Der Anlass

Safaris Meldung „Auf https://malzi.me/ ist wiederholt ein Problem aufgetreten"
auf einem iPhone. **Sechs Erklärungen geprüft, alle sechs ausgeschlossen:**

| Vermutung | Ergebnis |
|---|---|
| 2-Stunden-Frist der Aufträge | wird sauber abgefangen |
| Neulade-Schleife am Stundenlimit | Limit stand bei 0 von 500 |
| Absturz beim Laden der Sprachdatei | ist abgefangen |
| Foto als Speicherfresser | liegt als Verweis vor, nicht als Zeichenkette |
| Abfrage-Schleife + Wartefunktion | beide begrenzt und aufgeräumt |
| DNS-Ausfall desselben Tages | zeitlich ausgeschlossen |

## Warum Raten hier nicht weiterführt

Wenn diese Meldung erscheint, **läuft der eigene Code nicht mehr** — deshalb
kommt auch keine Fehlermeldung an. Das Ereignis ist unsichtbar. Statt eine
siebte Vermutung zu prüfen, wird es messbar gemacht.

## Die Wache

Drei Starts binnen einer Minute → zweierlei:

1. **Eine** Meldung über den vorhandenen Diagnose-Kanal: Anzahl Starts,
   Zeitspanne, ob ein Auftrag offen war, zuletzt erreichte Phase. Keine neue
   Datenart, kein Foto, keine Kennung.
2. Der gemerkte Auftrag wird **verworfen**. Hängt der Absturz an genau diesem
   Auftrag, wiederholt er sich sonst endlos. Lieber ein verlorenes Ergebnis als
   eine Seite, die sich nicht mehr öffnen lässt.

Zwei Starts lösen bewusst nichts aus — einmal neu laden ist normal. Eine Wache,
die zu früh anschlägt, wird ignoriert und ist damit wertlos.

`app.js` ruft sie **als allererstes** auf, vor jedem `await`, und setzt danach
Phasen-Marken (`start` / `i18n` / `demo` / `resume`).

**10 Prüfungen**, darunter: schweigt im Normalbetrieb, meldet nur einmal, zählt
alte Starts nicht mit, ein Fehler beim Aufräumen verhindert die Meldung nicht,
defekter Speicher legt den Start nicht lahm.
