### PR TITLE
chore: auch den Ordner docs/audit/ aus dem Repo halten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ age-ab-v29-report.md
 # und gehoert nicht dorthin. Ablage stattdessen ausserhalb des Repos.
 docs/audit-*.md
 docs/sanierung-*.md
+# Auch der Ordner: Der Standardpfad der Audit-Prompts lautet
+# docs/audit/JJJJ-MM-TT-....md und wird vom Muster oben NICHT gefasst.
+# Ohne diese Zeile landet der naechste Bericht wieder im oeffentlichen Repo.
+docs/audit/


### PR DESCRIPTION
Die `.gitignore` fing bisher nur `docs/audit-*.md`. Der Standardpfad der Audit-Prompts lautet aber `docs/audit/JJJJ-MM-TT-....md` — ein **Ordner**, den das Muster nicht fasst.

Der nächste Bericht wäre damit wieder im öffentlichen Repo gelandet: genau der Fehler, der mit v2.11.0 passiert ist und heute aufgeräumt wurde.

**Gegenprobe:** beide Schreibweisen werden jetzt von `git check-ignore` erfasst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)