### PR TITLE
chore: Release heißt 3.0.0 — Nummern-Regel gekippt + Buster 2026081107

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,42 +37,30 @@ jobs:
           fi
           TAG="v$VERSION"
           if gh release view "$TAG" >/dev/null 2>&1; then
-            # Release existiert schon. Entscheidung 2026-08-11 (Kurzaudit
-            # OPS-103): Veroeffentlichte CHANGELOG-Abschnitte duerfen weiter
-            # bearbeitet werden (Text-Korrekturen brauchen KEINE neue Nummer).
-            # Ein solcher Push aendert die oberste Versionsnummer nicht —
-            # dann ist hier nichts zu pruefen und der Lauf bleibt gruen.
-            # Genau so ein Doku-Nachzuegler (#78) hat am 2026-08-11 den ersten
-            # Fehlalarm dieser Pruefung ausgeloest.
-            # RESTLUECKE, bewusst getragen: Wer einen BESTEHENDEN Abschnitt
-            # komplett neu befuellt (Nummer gleich, Inhalt neu), wird hier
-            # nicht erkannt — dagegen schuetzt allein die Konvention "nie
-            # eine Nummer wiederverwenden".
+            # Release existiert schon. Zwei erlaubte Faelle:
+            # (a) Text-Korrektur an einem veroeffentlichten Abschnitt — die
+            #     oberste Nummer aendert sich nicht, nichts zu tun
+            #     (Entscheidung 2026-08-11, Kurzaudit OPS-103; Fehlalarm #78).
+            # (b) Die oberste Nummer wurde auf eine schon vergebene Nummer
+            #     GEAENDERT. Entscheidung des Inhabers vom 2026-08-11: Nummern
+            #     DUERFEN wiederverwendet werden — der fruehere Kollisions-
+            #     Fehler entfaellt. Damit Tag und CHANGELOG nicht auseinander-
+            #     laufen (die OPS-002-Falle vom 2026-08-10), wird der Tag samt
+            #     Release hier auf DIESEN Stand umgehaengt statt zu scheitern.
             VORHER="$(git show "$GITHUB_SHA^:CHANGELOG.md" 2>/dev/null | grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' | tr -d '#[] ' || true)"
             if [ "$VORHER" = "$VERSION" ]; then
               echo "Release $TAG existiert; der Push aendert die oberste Version nicht (Doku-Korrektur) — nichts zu tun."
               exit 0
             fi
-            # Der Push hat die oberste Nummer geaendert, ihr Release existiert
-            # aber schon. Zeigt der Tag auch auf DIESEN Stand? Wenn nicht,
-            # wurde eine bereits veroeffentlichte Nummer wiederverwendet — dann
-            # beschreibt der CHANGELOG-Abschnitt anderen Code als der gleich-
-            # namige Tag, und ein Rollback ueber den Tag landet am falschen
-            # Stand. Genau das ist am 2026-08-10 passiert: v2.9.2 zeigte auf
-            # einen Stand, der Minuten spaeter zurueckgenommen wurde
-            # (Audit 2026-08-10, OPS-002). Frueher stieg der Lauf hier still
-            # mit Erfolg aus und hat die Fehlzuordnung nie gemeldet.
-            # --verify ist wichtig: ohne das gibt git bei unbekanntem Tag den
-            # Suchbegriff selbst aus statt zu scheitern, und die Pruefung
-            # schluege faelschlich an.
             TAG_SHA="$(git rev-parse --verify --quiet "refs/tags/$TAG^{commit}" || echo "")"
             if [ -n "$TAG_SHA" ] && [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
-              echo "::error::Version $VERSION steht oben im CHANGELOG, aber Tag $TAG zeigt auf $TAG_SHA statt auf $GITHUB_SHA."
-              echo "::error::Eine veroeffentlichte Versionsnummer darf nicht wiederverwendet werden — bitte die naechste freie Nummer vergeben."
-              exit 1
+              echo "Nummer $VERSION wird wiederverwendet — Tag und Release werden auf diesen Stand umgehaengt."
+              gh release delete "$TAG" --yes
+              git push origin ":refs/tags/$TAG"
+            else
+              echo "Release $TAG existiert bereits und zeigt auf diesen Stand — nichts zu tun."
+              exit 0
             fi
-            echo "Release $TAG existiert bereits und zeigt auf diesen Stand — nichts zu tun."
-            exit 0
           fi
           # Release-Notizen = der Abschnitt genau dieser Version
           awk -v v="## [$VERSION]" '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,9 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [3.0.2] — 2026-08-11
+## [3.0.0] — 2026-08-11
 
 v3.0 — Das Live-Erlebnis.
-
-(Warum 3.0.2? 3.0.0 und 3.0.1 waren kurzlebige Zwischenstände desselben
-Tages — und einmal vergebene Nummern werden nie wiederverwendet.)
 
 ### Was sich ändert
 

--- a/e2e/a11y.test.js
+++ b/e2e/a11y.test.js
@@ -105,7 +105,7 @@ test("A11y: Profil-Ansicht ohne ernste Verstöße", async ({ page }) => {
 
   await page.emulateMedia({ reducedMotion: "reduce" });
   await page.goto("/");
-  /* v3.0.2: Die Analyse startet direkt bei der Demo-Wahl (kein Hinweis-
+  /* v3.0.0: Die Analyse startet direkt bei der Demo-Wahl (kein Hinweis-
      Pop-up mehr) — das Timeout deckt Bild-Prep + Mindest-Interaktionszeit. */
   await page.click('[data-demo="selfie"]');
   await expect(page.locator("#simulation")).not.toBeEmpty({ timeout: 15000 });

--- a/e2e/keyboard.test.js
+++ b/e2e/keyboard.test.js
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 /* Tastatur-Smoketest des kritischsten Nutzerflusses (Profilpflicht UI,
    docs/VERIFICATION.md): Der komplette Weg Demo-Foto → Profil muss ohne
    Maus funktionieren — nur mit Tab und Enter — und der Fokus muss dabei
-   sichtbar sein. Seit v3.0.2 startet die Analyse direkt bei der Foto-Wahl
+   sichtbar sein. Seit v3.0.0 startet die Analyse direkt bei der Foto-Wahl
    (kein Hinweis-Pop-up mehr). */
 
 const MOCK_RESPONSE = {
@@ -93,7 +93,7 @@ test("Tastatur: Demo-Foto → Profil, nur mit Tab + Enter", async ({ page }) => 
   expect(await tabToElement(page, '[data-demo="selfie"]'), "Demo-Button per Tab erreichbar").toBe(true);
   expect(await focusIsVisible(page), "Fokus auf dem Demo-Button sichtbar").toBe(true);
 
-  /* 2. Enter startet die Analyse DIREKT (v3.0.2: kein Hinweis-Dialog mehr)
+  /* 2. Enter startet die Analyse DIREKT (v3.0.0: kein Hinweis-Dialog mehr)
      und das Profil wird angezeigt */
   await page.keyboard.press("Enter");
   await expect(page.locator("#simulation")).not.toBeEmpty({ timeout: 15000 });

--- a/e2e/live-anzeige.test.js
+++ b/e2e/live-anzeige.test.js
@@ -124,12 +124,12 @@ test("Live-Erlebnis: Karte tippt wachsenden Text, danach Enthüllung bis zum PDF
   test.setTimeout(90000);
   await seiteMitLiveMocks(page);
 
-  /* v3.0.2: Die Demo-Wahl startet die Analyse direkt — kein Pop-up mehr. */
+  /* v3.0.0: Die Demo-Wahl startet die Analyse direkt — kein Pop-up mehr. */
   await page.click('[data-demo="selfie"]');
 
   /* Die Live-Karte übernimmt mit dem ERSTEN getippten Zeichen — im selben
      Moment verschwindet die Scan-Animation. Eine aktive Karte trägt dabei
-     immer schon Text: kein Leerlauf-Cursor mehr (v3.0.2). */
+     immer schon Text: kein Leerlauf-Cursor mehr (v3.0.0). */
   await expect(page.locator("#liveKarte")).toHaveClass(/active/, { timeout: 20000 });
   await expect(page.locator("#scanAnim")).not.toHaveClass(/active/);
   expect((await page.locator("#liveTextFest").textContent()).length).toBeGreaterThan(0);
@@ -164,7 +164,7 @@ test("Modus-Wechsel mitten im Stream: die Live-Karte springt auf den Beast-Text 
   test.setTimeout(90000);
   const steuerung = await seiteMitBeastMocks(page);
 
-  /* v3.0.2: Die Demo-Wahl startet die Analyse direkt — kein Pop-up mehr. */
+  /* v3.0.0: Die Demo-Wahl startet die Analyse direkt — kein Pop-up mehr. */
   await page.click('[data-demo="selfie"]');
 
   /* Erst tippt der seriöse Text wie gewohnt. */
@@ -199,7 +199,7 @@ test("Live-Erlebnis mit reduced-motion: Text sofort vollständig, Enthüllung oh
   await page.emulateMedia({ reducedMotion: "reduce" });
   await seiteMitLiveMocks(page);
 
-  /* v3.0.2: Die Demo-Wahl startet die Analyse direkt — kein Pop-up mehr. */
+  /* v3.0.0: Die Demo-Wahl startet die Analyse direkt — kein Pop-up mehr. */
   await page.click('[data-demo="selfie"]');
 
   await expect(page.locator("#liveKarte")).toHaveClass(/active/, { timeout: 20000 });

--- a/e2e/queue-walkthrough.mjs
+++ b/e2e/queue-walkthrough.mjs
@@ -48,7 +48,7 @@ await page.waitForTimeout(2800);
 console.log("→ Foto hochladen (landet hinter den Füll-Jobs)");
 await page.setInputFiles("#fileInput", "public/img/demo/demo-selfie.jpg");
 
-/* v3.0.2: Die Analyse startet direkt bei der Foto-Wahl — es gibt kein
+/* v3.0.0: Die Analyse startet direkt bei der Foto-Wahl — es gibt kein
    Hinweis-Pop-up mehr. Gewartet wird nur noch auf Warteschlange + Ergebnis. */
 let resultSeen = false;
 let positionShot = false;

--- a/e2e/realitaets-check.test.js
+++ b/e2e/realitaets-check.test.js
@@ -92,7 +92,7 @@ test("Realitäts-Check: tippen → absenden → Ring mit richtiger Prozentzahl �
   test.setTimeout(90000);
   const telemetrie = await seiteMitMocks(page);
 
-  /* v3.0.2: Die Analyse startet direkt bei der Demo-Wahl — ohne Pop-up. */
+  /* v3.0.0: Die Analyse startet direkt bei der Demo-Wahl — ohne Pop-up. */
   await page.click('[data-demo="selfie"]');
 
   /* Das Ergebnis erscheint — die Check-Karte steht zwischen Manipulations-

--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -26,7 +26,7 @@ const MOCK_RESPONSE = {
 };
 
 /* Voller Durchklick über den QUEUE-Pfad (Live-Pfad seit v2.0): Demo-Foto →
-   /api/enqueue → /api/job-status (done) → Profil. Seit v3.0.2 startet die
+   /api/enqueue → /api/job-status (done) → Profil. Seit v3.0.0 startet die
    Analyse direkt bei der Foto-Wahl — ohne Hinweis-Pop-up. Die drei
    Queue-Endpunkte werden gemockt, damit der Test ohne echtes Backend läuft. */
 test("Smoke: Demo-Foto → Queue → Profil wird angezeigt", async ({ page }) => {
@@ -69,7 +69,7 @@ test("Smoke: Demo-Foto → Queue → Profil wird angezeigt", async ({ page }) =>
   await expect(page.locator("h1")).toBeVisible();
   await expect(page.locator('[data-demo="selfie"]')).toBeVisible();
 
-  /* Demo-Foto klicken → die Queue-Analyse startet DIREKT (v3.0.2: kein
+  /* Demo-Foto klicken → die Queue-Analyse startet DIREKT (v3.0.0: kein
      Hinweis-Pop-up mehr). Bild-Prep, Mindest-Interaktionszeit 2s und
      Poll-Intervall 2s brauchen trotzdem ein grosszuegiges Timeout. */
   await page.click('[data-demo="selfie"]');

--- a/e2e/start-ohne-hinweis.test.js
+++ b/e2e/start-ohne-hinweis.test.js
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-/* v3.0.2: Das Hinweis-Pop-up vor der Analyse ist ersatzlos entfernt
+/* v3.0.0: Das Hinweis-Pop-up vor der Analyse ist ersatzlos entfernt
  * (Entscheidung des Inhabers: „dieses Pop-Up liest sowieso keiner durch").
  *
  * Dieser Test belegt den modallosen Fluss: Die Foto-/Demo-Wahl startet die

--- a/e2e/sticky-toggle.test.js
+++ b/e2e/sticky-toggle.test.js
@@ -93,7 +93,7 @@ async function mockBackend(page) {
 
 async function runAnalysis(page) {
   await page.goto("/");
-  /* v3.0.2: Die Analyse startet direkt bei der Demo-Wahl (kein Hinweis-
+  /* v3.0.0: Die Analyse startet direkt bei der Demo-Wahl (kein Hinweis-
      Pop-up mehr) — Timeout großzügig wegen Bild-Prep + Poll-Takt. */
   await page.click('[data-demo="selfie"]');
   await expect(page.locator(".cat-card").first()).toBeVisible({ timeout: 15000 });
@@ -140,7 +140,7 @@ test("Sticky: Umschalter klebt erst, wenn ein Ergebnis vorliegt", async ({ page 
   const before = await page.locator("#biasToggleWrap").evaluate((el) => getComputedStyle(el).position);
   expect(before).not.toBe("sticky");
 
-  /* v3.0.2: Die Analyse startet direkt bei der Demo-Wahl. */
+  /* v3.0.0: Die Analyse startet direkt bei der Demo-Wahl. */
   await page.click('[data-demo="selfie"]');
   await expect(page.locator(".cat-card").first()).toBeVisible({ timeout: 15000 });
 

--- a/public/__tests__/a11y.test.js
+++ b/public/__tests__/a11y.test.js
@@ -85,7 +85,7 @@ describe("Safari keyboard accessibility (index.html)", () => {
     expect(btn.getAttribute("tabindex")).toBe("0");
   });
 
-  it("v3.0.2: das Hinweis-Modal existiert nicht mehr im Markup (Analyse startet direkt)", () => {
+  it("v3.0.0: das Hinweis-Modal existiert nicht mehr im Markup (Analyse startet direkt)", () => {
     expect(document.getElementById("disclaimerModal")).toBeNull();
     expect(document.getElementById("disclaimerConfirm")).toBeNull();
   });

--- a/public/__tests__/live-anzeige.test.js
+++ b/public/__tests__/live-anzeige.test.js
@@ -91,7 +91,7 @@ describe("Live-Anzeige (v3.0)", () => {
 
   /* ── Tippen (Matrix-Dekodierung) ─────────────────────────────────────── */
 
-  it("Sofort-Start (v3.0.2): getippt wird ab dem ersten gelieferten Zeichen — kein Anlauf-Puffer mehr", async () => {
+  it("Sofort-Start (v3.0.0): getippt wird ab dem ersten gelieferten Zeichen — kein Anlauf-Puffer mehr", async () => {
     /* Vor der ersten Welle: nichts sichtbar. */
     expect(elements.liveKarte.classList.contains("active")).toBe(false);
 
@@ -224,7 +224,7 @@ describe("Live-Anzeige (v3.0)", () => {
     await vi.advanceTimersByTimeAsync(100);
     expect(elements.scanAnim.classList.contains("active")).toBe(false);
     /* Beim Wechsel steht bereits Text in der Karte — nie ein leer blinkender
-       Cursor (v3.0.2, Befund des ersten Live-Tests). */
+       Cursor (v3.0.0, Befund des ersten Live-Tests). */
     expect(elements.liveTextFest.textContent.length).toBeGreaterThan(0);
     /* Das erste Zeichen ist KEIN Abschluss — die srEnd-Ansage darf hier
        nicht fallen (die kommt erst am Ende des Durchgangs). */
@@ -238,7 +238,7 @@ describe("Live-Anzeige (v3.0)", () => {
     /* Der einzige Fall, in dem trotz gelieferter Wellen noch nichts tippbar
        ist: Beast ist aktiv, das Modell schreibt aber erst den Standard-Teil.
        Dann bleibt die Scan-Animation — eine Karte, in der nur der Cursor
-       blinkt, darf es nicht mehr geben (v3.0.2). */
+       blinkt, darf es nicht mehr geben (v3.0.0). */
     ui.startScanAnim(false);
     elements.biasSwitch.checked = true;
     w("S".repeat(300));
@@ -276,7 +276,7 @@ describe("Live-Anzeige (v3.0)", () => {
   });
 
   /* ── Warte-Rotation nach dem fertig getippten Text (FIX 2, v3.0.1) ──────
-     Seit v3.0.2 nur noch der FALLBACK für einen vorzeitig leeren Puffer —
+     Seit v3.0.0 nur noch der FALLBACK für einen vorzeitig leeren Puffer —
      den Normalfall trägt jetzt das adaptive Tippen selbst. Die kurzen Texte
      hier (12 Zeichen, Boden-Tempo 6 Z/s ≈ 2 s) tippen bewusst schnell leer. */
 
@@ -393,7 +393,7 @@ describe("Live-Anzeige (v3.0)", () => {
     expect(elements.liveStatusText.textContent).toBe("live.statusSchreibt");
   });
 
-  it("v3.0.2: auch ein kurzer Beast-Stand tippt nach dem Wechsel sofort — kein Anlauf-Puffer je Puffer mehr", async () => {
+  it("v3.0.0: auch ein kurzer Beast-Stand tippt nach dem Wechsel sofort — kein Anlauf-Puffer je Puffer mehr", async () => {
     w("S".repeat(250), "B".repeat(50));
     await vi.advanceTimersByTimeAsync(1000);
     schalte(true);

--- a/public/__tests__/queue-livetext.test.js
+++ b/public/__tests__/queue-livetext.test.js
@@ -156,7 +156,7 @@ describe("Queue-Verdrahtung des Live-Texts (v3.0)", () => {
     );
   });
 
-  it("v3.0.2: bei done wird ERST der Rest-Puffer schnell ausgetippt, DANN gerendert", async () => {
+  it("v3.0.0: bei done wird ERST der Rest-Puffer schnell ausgetippt, DANN gerendert", async () => {
     /* Der Schnellvorlauf muss VOR dem Rendern abgewartet werden — sonst
        stünde das fertige Ergebnis schon unverdeckt auf der Seite, während
        die Karte noch tippt (harter Sprung statt sauberem Abschluss). */

--- a/public/__tests__/queue.test.js
+++ b/public/__tests__/queue.test.js
@@ -107,7 +107,7 @@ describe("Queue-Modus", () => {
     const p = analyzeImage();
     await vi.advanceTimersByTimeAsync(12000);
     await p;
-    /* Kein Modal mehr im Weg (seit v3.0.2 restlos entfernt) — direkt gerendert. */
+    /* Kein Modal mehr im Weg (seit v3.0.0 restlos entfernt) — direkt gerendert. */
     expect(renderCurrentMode).toHaveBeenCalled();
   });
 
@@ -368,7 +368,7 @@ describe("Queue-Modus", () => {
     await p;
     const urls = globalThis.fetch.mock.calls.map((c) => String(c[0]));
     expect(urls.some((u) => u.includes("/api/job-status?jobId=job-resumed"))).toBe(true);
-    /* Seit v3.0.2 gibt es kein Hinweis-Modal mehr → immer direkt gerendert. */
+    /* Seit v3.0.0 gibt es kein Hinweis-Modal mehr → immer direkt gerendert. */
     expect(renderCurrentMode).toHaveBeenCalled();
   });
 
@@ -561,13 +561,13 @@ describe("Queue-Modus", () => {
     await p;
   });
 
-  /* ── v3.0.2: Das Hinweis-Pop-up ist ersatzlos entfernt ────────────────────
+  /* ── v3.0.0: Das Hinweis-Pop-up ist ersatzlos entfernt ────────────────────
      Entscheidung des Inhabers („dieses Pop-Up liest sowieso keiner durch"):
      Die Analyse startet direkt bei der Foto-/Demo-Wahl. Diese Tests belegen
      den modallosen Fluss — sie werden ROT, wenn jemand wieder einen Dialog
      zwischen Foto-Wahl und Upload schiebt. */
 
-  it("v3.0.2: die Analyse startet ohne Modal — der Upload geht direkt raus, nichts wartet auf eine Bestätigung", async () => {
+  it("v3.0.0: die Analyse startet ohne Modal — der Upload geht direkt raus, nichts wartet auf eine Bestätigung", async () => {
     renderCurrentMode.mockClear();
     vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
       if (String(url).includes("/api/enqueue")) return jsonResponse({ jobId: "job-direkt" });
@@ -586,7 +586,7 @@ describe("Queue-Modus", () => {
     expect(renderCurrentMode).toHaveBeenCalled();
   });
 
-  it("v3.0.2: auch die Wiederaufnahme eines alten Auftrags rendert direkt — ohne jede gemerkte Bestätigung", async () => {
+  it("v3.0.0: auch die Wiederaufnahme eines alten Auftrags rendert direkt — ohne jede gemerkte Bestätigung", async () => {
     /* Alter Tab-Stand aus der Modal-Ära: nur die Job-Nummer liegt vor, keine
        der früheren Bestätigungs-Marken. Das Ergebnis erscheint trotzdem
        sofort — es gibt keinen Dialog mehr, der es aufhalten könnte. */

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081106" />
+    <link rel="stylesheet" href="./styles.css?v=2026081107" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -44,7 +44,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081106" />
+    <link rel="stylesheet" href="./styles.css?v=2026081107" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -85,7 +85,7 @@
     <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
     <link rel="preconnect" href="https://nominatim.openstreetmap.org" crossorigin />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081106" />
+    <link rel="stylesheet" href="./styles.css?v=2026081107" />
     <script type="application/ld+json">
 [
   {
@@ -298,15 +298,15 @@
         <p class="demo-label" data-i18n="demo.label">Kein Foto zur Hand? Probier ein Beispielbild (mit KI erstellt):</p>
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
-            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081106" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081107" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.selfie">Selfie am Stephansplatz</span>
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
-            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081106" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081107" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.cafe">Im Caf&eacute; in Salzburg</span>
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
-            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081106" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081107" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.hiker">Wanderung bei Hallstatt</span>
           </button>
         </div>
@@ -362,6 +362,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081106"></script>
+    <script type="module" src="./app.js?v=2026081107"></script>
   </body>
 </html>

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -78,7 +78,7 @@ function releaseWakeLock() {
   wakeLock = null;
 }
 
-/* v3.0.2: Das frühere Hinweis-Pop-up vor der Analyse ist ersatzlos entfernt
+/* v3.0.0: Das frühere Hinweis-Pop-up vor der Analyse ist ersatzlos entfernt
    (Entscheidung des Inhabers: „dieses Pop-Up liest sowieso keiner durch") —
    die Analyse startet direkt bei der Foto-/Demo-Wahl. Die Einordnung „nichts
    davon ist wahr" trägt weiterhin die Disclaimer-Box auf der Seite, im
@@ -475,7 +475,7 @@ function showPhotoDeletedNotice() {
 
 /**
  * Rendert das fertige Queue-Ergebnis (renderCurrentMode → Success-Telemetrie).
- * v3.0.2: Lief Live-Text, wird VOR dem Rendern der Rest-Puffer im
+ * v3.0.0: Lief Live-Text, wird VOR dem Rendern der Rest-Puffer im
  * Schnellvorlauf ausgetippt — deshalb async. Das Rendern samt Verdecken der
  * Enthüllung bleibt danach synchron im selben Frame.
  */
@@ -539,7 +539,7 @@ async function renderQueueResult(data, myId, traceId, timings) {
     });
   };
 
-  /* v3.0.2: Erst den ungetippten Rest im Schnellvorlauf zu Ende tippen (ohne
+  /* v3.0.0: Erst den ungetippten Rest im Schnellvorlauf zu Ende tippen (ohne
      Live-Lauf löst das sofort auf), DANN rendern — sonst bricht das Tippen
      mitten im Wort ab und das Ergebnis springt hart ins Bild. */
   await liveAnzeige.schnellVorlauf();
@@ -744,7 +744,7 @@ async function analyzeImageQueued() {
        resumeQueueJob beim nächsten Seitenstart still auf. */
     timings.totalMs = Date.now() - analyzeStartTime;
     /* Das Ergebnis rendert direkt in die Dramaturgie hinein — nach dem
-       Schnellvorlauf des restlichen Live-Texts (v3.0.2, daher await). */
+       Schnellvorlauf des restlichen Live-Texts (v3.0.0, daher await). */
     await renderQueueResult(outcome.result, myId, traceId, timings);
   } catch (err) {
     if (state.requestId !== myId) return;

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -5,9 +5,9 @@ import { klangAktivieren } from "./klang.js";
 import { t } from "./i18n.js";
 
 const DEMO_IMAGES = {
-  selfie: "./img/demo/demo-selfie.jpg?v=2026081106",
-  cafe: "./img/demo/demo-cafe.jpg?v=2026081106",
-  hiker: "./img/demo/demo-hiker.jpg?v=2026081106",
+  selfie: "./img/demo/demo-selfie.jpg?v=2026081107",
+  cafe: "./img/demo/demo-cafe.jpg?v=2026081107",
+  hiker: "./img/demo/demo-hiker.jpg?v=2026081107",
 };
 
 export function initDemo() {

--- a/public/js/live-anzeige.js
+++ b/public/js/live-anzeige.js
@@ -5,7 +5,7 @@
  *
  *   1. Die bestehende Scan-Animation bleibt, bis das ERSTE Zeichen getippt
  *      wird — dann übernimmt die Live-Karte. Getippt wird ab dem ersten
- *      gelieferten Zeichen (v3.0.2: der frühere 200-Zeichen-Anlauf ist weg —
+ *      gelieferten Zeichen (v3.0.0: der frühere 200-Zeichen-Anlauf ist weg —
  *      er ließ die Karte je nach Timing mit leer blinkendem Cursor stehen).
  *   2. GETIPPT (Matrix-Dekodierung: fester Text + Rausch-Schweif + Cursor)
  *      wird AUSSCHLIESSLICH der Zusammenfassungstext, gespeist aus den
@@ -17,7 +17,7 @@
  *      Neustart von vorn. Ist der Beast-Puffer noch leer (das Modell
  *      schreibt Beast NACH dem Standard-Profil — Reihenfolge der Antwort,
  *      keine Schwäche), zeigt die Karte einen Warte-Status mit blinkendem
- *      Cursor. Tempo-Prinzip (v3.0.2, ADAPTIV statt fester 70 Zeichen/s):
+ *      Cursor. Tempo-Prinzip (v3.0.0, ADAPTIV statt fester 70 Zeichen/s):
  *      Das Tempo richtet sich bei jedem Tick nach dem ungetippten Rest —
  *      das Tippen soll die Wartezeit der Analyse TRAGEN, nicht in ~7 s
  *      durchrauschen und dann 40+ s Leere hinterlassen (Befund des ersten
@@ -59,7 +59,7 @@ import { tippTon, popTon } from "./klang.js";
 const RAUSCH_ZEICHEN = "01ｱｶｻﾀﾅﾊﾏﾔﾗ<>#/*+=~$%&";
 /* Länge des Rausch-Schweifs hinter dem zuletzt getippten Zeichen. */
 const SCHWEIF_LAENGE = 7;
-/* ── Adaptives Tipp-Tempo (v3.0.2) ──
+/* ── Adaptives Tipp-Tempo (v3.0.0) ──
    Der Puffer soll über ungefähr diese Spanne abtropfen: Eine echte Analyse
    dauert 50–80 s, der Stream liefert den Text aber schon in den ersten
    ~20–30 s — ein festes Tempo tippte deshalb in ~7 s alles leer und ließ
@@ -145,7 +145,7 @@ function neuerLauf() {
     tippt: false,
     aktiv: aktiverModus(),
     statusZustand: null,
-    /* v3.0.2: Der Server hat „fertig" gemeldet — der Rest wird im
+    /* v3.0.0: Der Server hat „fertig" gemeldet — der Rest wird im
        Schnellvorlauf ausgetippt (schnellVorlauf() setzt das). */
     schnellvorlauf: false,
     /* FIX 2: Läuft gerade die Warte-Rotation? (rotationRunde entwertet eine
@@ -358,7 +358,7 @@ export function welle(texte) {
     return;
   }
 
-  /* v3.0.2: Getippt wird ab dem ERSTEN gelieferten Zeichen — kein Anlauf-
+  /* v3.0.0: Getippt wird ab dem ERSTEN gelieferten Zeichen — kein Anlauf-
      Puffer mehr. Das adaptive Tempo übernimmt dessen Aufgabe: Bei wenig
      Material tippt es langsam genug, dass der Nachschub der 2-s-Wellen
      locker reicht, statt eine leere Karte blinken zu lassen. */

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081106" />
+    <link rel="stylesheet" href="./styles.css?v=2026081107" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081106" />
+    <link rel="stylesheet" href="./styles.css?v=2026081107" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081106"></script>
+    <script type="module" src="./js/stats.js?v=2026081107"></script>
   </body>
 </html>


### PR DESCRIPTION
## Release heißt 3.0.0 + Cache-Buster 2026081107

Entscheidung des Inhabers (2026-08-11): Die Regel „einmal vergebene Nummern werden nie wiederverwendet" ist dauerhaft gekippt. Der heute veröffentlichte Stand ist **v3.0.0** — es gibt kein 3.0.2 ohne 3.0.

- CHANGELOG: oberster Eintrag heißt jetzt `[3.0.0]`; der Erklär-Absatz zur Nummernvergabe ist gestrichen
- Release-Wächter (`release.yml`): Kollisions-Fehler ersetzt durch Umhängen — wird eine Nummer wiederverwendet, wandern Tag und GitHub-Release automatisch auf den neuen Stand (verhindert weiterhin die OPS-002-Falle „Tag zeigt auf fremden Code", nur ohne zu blockieren)
- Alle `v3.0.2`-Verweise in Code-Kommentaren und Testnamen auf `v3.0.0` umgestellt
- Cache-Buster 2026081107 aus dem heutigen Deploy

Frontend-Tests nach der Umstellung: 280/280 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
