### PR TITLE
fix: Dramaturgie-Nachschliff — Zeit-Anlauf, Tempo, Scroll, Ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,14 @@ immer sichtbar etwas in Bewegung:
 
 - Die Scan-Animation (Auge + rotierende Meldungen) bleibt, bis das **erste
   Zeichen** wirklich getippt wird — nie eine leere Karte mit blinkendem
-  Cursor.
+  Cursor. Vor dem ersten Zeichen sammelt ein **~10-Sekunden-Anlauf**
+  Material, damit das Tippen danach flüssig wirkt statt zäh.
 - Getippt wird **im Takt der Analyse**: Das Tempo passt sich laufend an den
-  noch wartenden Text an — wenig Nachschub tippt langsam und gut lesbar,
+  noch wartenden Text an — wenig Nachschub tippt ruhig und gut lesbar,
   viel Nachschub schneller. So trägt das Tippen die Wartezeit, statt nach
   Sekunden fertig zu sein. Meldet der Server „fertig", tippt der Rest im
-  Schnellvorlauf aus.
+  Schnellvorlauf aus — und die Seite bleibt dabei, wo du gerade liest,
+  statt ans Seiten-Ende oder nach oben zu springen.
 - Läuft der Text doch einmal aus, rotieren ehrliche Status-Zeilen
   („Kategorien werden berechnet …") statt eines eingefrorenen Fensters.
 - Danach die **Enthüllung Schritt für Schritt**: Foto-Daten, Standort-Karte,
@@ -45,8 +47,8 @@ immer sichtbar etwas in Bewegung:
 jedem echten Menschen-Profil erscheint eine Karte mit sechs Fragen: Sie
 zitiert, was die KI zu Alter, Geschlecht, Interessen, Charakter, Werbung
 und Manipulation behauptet hat, und du antwortest ehrlich mit **Getroffen /
-Knapp / Daneben**. Ein animierter Ring zeigt deine persönliche
-KI-Trefferquote samt Einordnung — Treffer beweisen die Macht der
+Knapp / Daneben**. Ein animierter, freigestellter Ring zeigt deine
+persönliche KI-Trefferquote samt Einordnung — Treffer beweisen die Macht der
 Algorithmen, Fehler ihre Gefahr. Dazu der **anonyme Vergleich mit allen
 anderen**: Beim Absenden gehen ausschließlich die Antwort-Stufen an den
 Server — kein Foto, kein Profil, nichts Verknüpfbares — und der

--- a/public/__tests__/live-anzeige.test.js
+++ b/public/__tests__/live-anzeige.test.js
@@ -64,6 +64,10 @@ describe("Live-Anzeige (v3.0)", () => {
     elements.realCheck.hidden = true;
     elements.realCheck.className = "";
 
+    /* Zeit-Anlauf für die Tests abschalten — nur der eigene Anlauf-Test
+       stellt ihn gezielt wieder an. */
+    liveAnzeige._setzeTippAnlaufMsFuerTest(0);
+
     echteMatchMedia = window.matchMedia;
   });
 
@@ -91,17 +95,23 @@ describe("Live-Anzeige (v3.0)", () => {
 
   /* ── Tippen (Matrix-Dekodierung) ─────────────────────────────────────── */
 
-  it("Sofort-Start (v3.0.0): getippt wird ab dem ersten gelieferten Zeichen — kein Anlauf-Puffer mehr", async () => {
+  it("Zeit-Anlauf (Nachschliff 11.08.): erst trägt die Scan-Animation ~10 s, dann tippt es — kein Kriech-Start", async () => {
+    liveAnzeige._setzeTippAnlaufMsFuerTest(10000);
     /* Vor der ersten Welle: nichts sichtbar. */
     expect(elements.liveKarte.classList.contains("active")).toBe(false);
 
-    /* Schon eine kurze erste Welle bringt die Karte samt erstem Zeichen —
-       der frühere 200-Zeichen-Anlauf ließ hier noch den Spinner stehen. */
-    w("Hallo");
-    await vi.advanceTimersByTimeAsync(50);
+    /* Erste Welle: Der Puffer sammelt Material, die Karte bleibt zu — die
+       Scan-Animation trägt die Wartezeit. (Diese Erwartung wird ROT, wenn
+       jemand den Sofort-Start zurückbaut.) */
+    w("Hallo, hier entsteht gerade ein Profiltext.");
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(elements.liveKarte.classList.contains("active")).toBe(false);
+    expect(elements.liveTextFest.textContent.length).toBe(0);
+
+    /* Nach Ablauf des Anlaufs übernimmt die Karte und tippt sofort los. */
+    await vi.advanceTimersByTimeAsync(5300);
     expect(elements.liveKarte.classList.contains("active")).toBe(true);
     expect(elements.liveTextFest.textContent.length).toBeGreaterThan(0);
-    expect("Hallo".startsWith(elements.liveTextFest.textContent)).toBe(true);
   });
 
   it("Adaptives Tempo: viel Puffer tippt am Deckel (~90 Z/s) — deutlich schneller als das alte Festtempo", async () => {
@@ -114,14 +124,14 @@ describe("Live-Anzeige (v3.0)", () => {
     expect(getippt).toBeLessThanOrEqual(100);
   });
 
-  it("Adaptives Tempo: wenig Puffer tippt am Boden (~6 Z/s) — langsam, aber sichtbar in Bewegung", async () => {
+  it("Adaptives Tempo: wenig Puffer tippt am Boden (~12 Z/s) — ruhig, aber sichtbar in Bewegung", async () => {
     /* Kleiner Rest → Untergrenze MIN_ZEICHEN_PRO_SEKUNDE. Mit festem Tempo
        (70 Z/s) wäre der Puffer hier nach unter einer halben Sekunde leer. */
     w("A".repeat(30));
     await vi.advanceTimersByTimeAsync(1000);
     const getippt = elements.liveTextFest.textContent.length;
-    expect(getippt).toBeGreaterThanOrEqual(5);
-    expect(getippt).toBeLessThanOrEqual(10);
+    expect(getippt).toBeGreaterThanOrEqual(10);
+    expect(getippt).toBeLessThanOrEqual(16);
   });
 
   it("Entkopplung: eine nachgeschobene Welle verlängert den Puffer, ohne das Tippen zu unterbrechen", async () => {
@@ -278,17 +288,17 @@ describe("Live-Anzeige (v3.0)", () => {
   /* ── Warte-Rotation nach dem fertig getippten Text (FIX 2, v3.0.1) ──────
      Seit v3.0.0 nur noch der FALLBACK für einen vorzeitig leeren Puffer —
      den Normalfall trägt jetzt das adaptive Tippen selbst. Die kurzen Texte
-     hier (12 Zeichen, Boden-Tempo 6 Z/s ≈ 2 s) tippen bewusst schnell leer. */
+     hier (24 Zeichen, Boden-Tempo 12 Z/s ≈ 2 s) tippen bewusst schnell leer. */
 
   it("FIX 2 (Fallback): die Warte-Rotation startet erst nach dem Tipp-Ende — nicht schon, wenn die Lieferung fertig ist", async () => {
-    w("A".repeat(12));
+    w("A".repeat(24));
     await vi.advanceTimersByTimeAsync(1000);
     expect(elements.liveStatusText.textContent).toBe("live.statusSchreibt");
 
     /* Nächste Poll-Welle OHNE neue Zeichen → Lieferung abgeschlossen. Getippt
-       wird aber noch (~12 Zeichen / 6 pro s ≈ 2 s) — die Status-Zeile
+       wird aber noch (~24 Zeichen / 12 pro s ≈ 2 s) — die Status-Zeile
        bleibt beim Schreib-Status. */
-    w("A".repeat(12));
+    w("A".repeat(24));
     await vi.advanceTimersByTimeAsync(500);
     expect(elements.liveStatusText.textContent).toBe("live.statusSchreibt");
 

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -514,13 +514,17 @@ async function renderQueueResult(data, myId, traceId, timings) {
        (Flag aus, Tier-Profil, blocked, Resume nach Reload), räumt abbrechen()
        höchstens eine verwaiste Live-Karte weg — der heutige Pfad bleibt
        Pixel für Pixel unverändert. */
-    if (liveAnzeige.hatLiveGelaufen() && data.profiles && data.meta?.mode !== "animal") {
+    const liveEnthuellung = liveAnzeige.hatLiveGelaufen() && data.profiles && data.meta?.mode !== "animal";
+    if (liveEnthuellung) {
       liveAnzeige.starteEnthuellung();
     } else {
       liveAnzeige.abbrechen();
     }
     setStatus("");
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    /* Kein Sprung nach oben mitten in der Enthüllung — der Blick bleibt bei
+       der Live-Karte („das wirkt irgendwie unnatürlich", Live-Test 11.08.).
+       Ohne Live-Lauf bleibt das alte Verhalten unverändert. */
+    if (!liveEnthuellung) window.scrollTo({ top: 0, behavior: "smooth" });
     setTimeout(() => {
       if (elements.resultsPanel) elements.resultsPanel.focus({ preventScroll: true });
     }, 300);

--- a/public/js/live-anzeige.js
+++ b/public/js/live-anzeige.js
@@ -4,9 +4,11 @@
  * (compare-prototype-streaming.html, 2026-08-11) auf der echten Seite um:
  *
  *   1. Die bestehende Scan-Animation bleibt, bis das ERSTE Zeichen getippt
- *      wird — dann übernimmt die Live-Karte. Getippt wird ab dem ersten
- *      gelieferten Zeichen (v3.0.0: der frühere 200-Zeichen-Anlauf ist weg —
- *      er ließ die Karte je nach Timing mit leer blinkendem Cursor stehen).
+ *      wird — dann übernimmt die Live-Karte. Das Tippen beginnt erst nach
+ *      einem ZEIT-Anlauf (TIPP_ANLAUF_MS): Sofort-Start bei dünnem Puffer
+ *      kroch an der Untergrenze dahin — „wirkt sehr gequält" (Live-Test
+ *      11.08.). Die Anlauf-Zeit trägt die Scan-Animation, nie ein leerer
+ *      Cursor.
  *   2. GETIPPT (Matrix-Dekodierung: fester Text + Rausch-Schweif + Cursor)
  *      wird AUSSCHLIESSLICH der Zusammenfassungstext, gespeist aus den
  *      liveText-Wellen der 2-s-Polls (api.js → welle()). Seit Phase 3 führt
@@ -68,13 +70,22 @@ const SCHWEIF_LAENGE = 7;
    Rest ÷ ZIEL_ABTROPF_SEKUNDEN — wenig Puffer tippt langsam und lesbar,
    viel Puffer schneller, und das Tippen streckt sich über einen Großteil
    der Analyse. */
-const ZIEL_ABTROPF_SEKUNDEN = 30;
+const ZIEL_ABTROPF_SEKUNDEN = 20;
 /* Untergrenze: Darunter wirkt das Tippen wie ein Hänger statt wie Schreiben —
-   auch ein fast leerer Puffer muss sichtbar in Bewegung bleiben. */
-const MIN_ZEICHEN_PRO_SEKUNDE = 6;
+   auch ein fast leerer Puffer muss sichtbar in Bewegung bleiben. 12 statt
+   anfangs 6: Das Kriech-Tempo des ersten Livegangs wirkte „sehr gequält"
+   (Live-Test 11.08.) — der Zeit-Anlauf unten sorgt dafür, dass beim Start
+   schon genug Material für dieses Tempo im Puffer liegt. */
+const MIN_ZEICHEN_PRO_SEKUNDE = 12;
 /* Obergrenze: Darüber ist der Text nicht mehr mitlesbar — schneller darf nur
    der Schnellvorlauf nach der Fertig-Meldung des Servers sein. */
 const MAX_ZEICHEN_PRO_SEKUNDE = 90;
+/* Zeit-Anlauf vor dem ersten getippten Zeichen: Der Stream liefert anfangs
+   nur wenige Zeichen pro Sekunde — sofort loszutippen hieße, minutenlang an
+   der Untergrenze zu kriechen. Solange trägt die Scan-Animation die Zeit.
+   Meldet der Server vorher „fertig", greift sofort der Schnellvorlauf.
+   (let statt const wegen des Test-Hooks _setzeTippAnlaufMsFuerTest.) */
+let TIPP_ANLAUF_MS = 10000;
 /* Schnellvorlauf, sobald der Server „fertig" meldet: Der Rest-Puffer wird
    zügig, aber noch als Tippen erkennbar ausgetippt — erst danach beginnt die
    Enthüllung. So endet der Lauf ohne harten Textsprung. */
@@ -148,6 +159,8 @@ function neuerLauf() {
     /* v3.0.0: Der Server hat „fertig" gemeldet — der Rest wird im
        Schnellvorlauf ausgetippt (schnellVorlauf() setzt das). */
     schnellvorlauf: false,
+    /* Vor diesem Zeitpunkt tippt die Schleife nicht (Zeit-Anlauf). */
+    tippStartAb: 0,
     /* FIX 2: Läuft gerade die Warte-Rotation? (rotationRunde entwertet eine
        alte Rotations-Schleife, wenn eine neue startet.) */
     rotationLaeuft: false,
@@ -269,6 +282,12 @@ function aktuellesTempo(mein, rest) {
 async function tippSchleife(mein) {
   let naechsterTon = 3;
   while (!mein.stop) {
+    /* Zeit-Anlauf: Noch nicht tippen — draußen trägt die Scan-Animation die
+       Wartezeit. Der Schnellvorlauf (Server fertig) bricht den Anlauf ab. */
+    if (!mein.schnellvorlauf && Date.now() < mein.tippStartAb) {
+      if (!(await warte(LEERLAUF_MS, mein))) return;
+      continue;
+    }
     /* Immer der Puffer des AKTUELL gewählten Modus — modusWechsel() stellt
        `aktiv` um, der nächste Tick tippt nahtlos am anderen Stand weiter. */
     const p = mein.puffer[mein.aktiv];
@@ -358,12 +377,13 @@ export function welle(texte) {
     return;
   }
 
-  /* v3.0.0: Getippt wird ab dem ERSTEN gelieferten Zeichen — kein Anlauf-
-     Puffer mehr. Das adaptive Tempo übernimmt dessen Aufgabe: Bei wenig
-     Material tippt es langsam genug, dass der Nachschub der 2-s-Wellen
-     locker reicht, statt eine leere Karte blinken zu lassen. */
+  /* Die Tipp-Schleife startet mit der ersten Lieferung, tippt aber erst nach
+     dem Zeit-Anlauf los — bis dahin sammelt der Puffer Material und die
+     Scan-Animation trägt die Wartezeit (Nachschliff nach dem Live-Test
+     11.08.: Sofort-Start bedeutete minutenlanges Kriech-Tempo). */
   if (!lauf.tippt && (lauf.puffer.standard.text.length > 0 || lauf.puffer.beast.text.length > 0)) {
     lauf.tippt = true;
+    lauf.tippStartAb = Date.now() + TIPP_ANLAUF_MS;
     tippSchleife(lauf);
   }
 }
@@ -380,7 +400,14 @@ export function welle(texte) {
 export function schnellVorlauf() {
   return new Promise((aufloesen) => {
     const mein = lauf;
-    if (!mein || !liveLief || enthuellungGestartet) {
+    /* Zuständig, sobald ein Lauf mit geliefertem Text existiert — AUCH wenn
+       noch kein Zeichen getippt wurde (Fertig-Meldung mitten im Zeit-Anlauf):
+       Der Schnellvorlauf bricht den Anlauf ab und tippt sichtbar aus, statt
+       die Live-Dramaturgie komplett zu überspringen. Ohne gelieferten Text
+       (z. B. Wiederaufnahme nach Neuladen — die tippt bewusst nie) sofort
+       auflösen. */
+    const geliefert = mein && mein.puffer[mein.aktiv].text.length > 0;
+    if (!mein || !geliefert || enthuellungGestartet) {
       aufloesen();
       return;
     }
@@ -656,4 +683,10 @@ export function abbrechen() {
 export function zuruecksetzen() {
   abbrechen();
   liveLief = false;
+}
+
+/* Nur für Tests: verkürzt oder verlängert den Zeit-Anlauf gezielt —
+   echte 10 s wären mit Fake-Timern umständlich und ohne sie unbezahlbar. */
+export function _setzeTippAnlaufMsFuerTest(ms) {
+  TIPP_ANLAUF_MS = ms;
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -3053,7 +3053,8 @@ html[lang="en"] .rc-zitat::after {
   stroke-linecap: round;
   stroke-dasharray: 326.7;
   stroke-dashoffset: 326.7;
-  filter: drop-shadow(0 0 8px currentColor);
+  /* Bewusst KEIN drop-shadow-Glow: Browser rastern den Filter als Rechteck —
+     hinter dem Ring stand ein sichtbares Quadrat (Live-Test 11.08.). */
   transition: stroke-dashoffset 0.08s linear;
 }
 


### PR DESCRIPTION
Drei Befunde aus dem Live-Test des Inhabers (11.08. abends):

- **Tippen wirkte gequält:** ~10-Sekunden-Zeit-Anlauf vor dem ersten Zeichen (die Scan-Animation trägt die Zeit), dafür Untergrenze 6→12 Z/s und Abtropf-Ziel 30→20 s. Fertig-Meldung bricht den Anlauf ab und tippt sichtbar aus.
- **Sprung nach oben am Ende:** entfällt, wenn die Live-Enthüllung läuft — der Blick bleibt bei der Karte. Ohne Live-Lauf unverändert.
- **Quadrat hinter dem Score-Ring:** drop-shadow-Glow entfernt (Browser rastern den Filter als Rechteck).

Tests: Frontend 280/280, betroffene E2E 5/5, Lint + Format sauber. CHANGELOG-Eintrag [3.0.0] textlich angepasst (Nummer unverändert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)