### PR TITLE
fix: v3.0.1 — 20-s-Anlauf, flotteres Tippen, Live-Karte in Endfarbe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [3.0.1] — 2026-08-11
+
+Feinschliff nach dem Abend-Test des Live-Erlebnisses:
+
+- **Länger sammeln, flotter tippen:** Vor dem ersten Zeichen trägt die
+  Scan-Animation jetzt rund 20 Sekunden (statt 10) — dafür tippt der Text
+  danach spürbar schneller. Das zähe Kriech-Tempo ist weg.
+- **Kein Farbwechsel mehr:** Die Live-Karte trägt von Anfang an die Farbe
+  der späteren Zusammenfassungs-Box — am Ende wechselt der Text nur noch
+  den Platz, nicht mehr das Kleid.
+
 ## [3.0.0] — 2026-08-11
 
 v3.0 — Das Live-Erlebnis.

--- a/e2e/live-anzeige.test.js
+++ b/e2e/live-anzeige.test.js
@@ -130,7 +130,7 @@ test("Live-Erlebnis: Karte tippt wachsenden Text, danach Enthüllung bis zum PDF
   /* Die Live-Karte übernimmt mit dem ERSTEN getippten Zeichen — im selben
      Moment verschwindet die Scan-Animation. Eine aktive Karte trägt dabei
      immer schon Text: kein Leerlauf-Cursor mehr (v3.0.0). */
-  await expect(page.locator("#liveKarte")).toHaveClass(/active/, { timeout: 20000 });
+  await expect(page.locator("#liveKarte")).toHaveClass(/active/, { timeout: 35000 });
   await expect(page.locator("#scanAnim")).not.toHaveClass(/active/);
   expect((await page.locator("#liveTextFest").textContent()).length).toBeGreaterThan(0);
 
@@ -168,7 +168,7 @@ test("Modus-Wechsel mitten im Stream: die Live-Karte springt auf den Beast-Text 
   await page.click('[data-demo="selfie"]');
 
   /* Erst tippt der seriöse Text wie gewohnt. */
-  await expect(page.locator("#liveKarte")).toHaveClass(/active/, { timeout: 20000 });
+  await expect(page.locator("#liveKarte")).toHaveClass(/active/, { timeout: 35000 });
   await expect
     .poll(async () => (await page.locator("#liveTextFest").textContent()).length, { timeout: 15000 })
     .toBeGreaterThan(10);
@@ -202,7 +202,7 @@ test("Live-Erlebnis mit reduced-motion: Text sofort vollständig, Enthüllung oh
   /* v3.0.0: Die Demo-Wahl startet die Analyse direkt — kein Pop-up mehr. */
   await page.click('[data-demo="selfie"]');
 
-  await expect(page.locator("#liveKarte")).toHaveClass(/active/, { timeout: 20000 });
+  await expect(page.locator("#liveKarte")).toHaveClass(/active/, { timeout: 35000 });
   /* Kein Tippen: kurz nach dem Erscheinen steht bereits eine KOMPLETTE Welle
      da (beim Tippen wären nach 200 ms erst ~14 Zeichen sichtbar). */
   await page.waitForTimeout(200);

--- a/public/__tests__/live-anzeige.test.js
+++ b/public/__tests__/live-anzeige.test.js
@@ -95,7 +95,7 @@ describe("Live-Anzeige (v3.0)", () => {
 
   /* ── Tippen (Matrix-Dekodierung) ─────────────────────────────────────── */
 
-  it("Zeit-Anlauf (Nachschliff 11.08.): erst trägt die Scan-Animation ~10 s, dann tippt es — kein Kriech-Start", async () => {
+  it("Zeit-Anlauf (Nachschliff 11.08.): erst trägt die Scan-Animation, dann tippt es — kein Kriech-Start", async () => {
     liveAnzeige._setzeTippAnlaufMsFuerTest(10000);
     /* Vor der ersten Welle: nichts sichtbar. */
     expect(elements.liveKarte.classList.contains("active")).toBe(false);
@@ -124,14 +124,14 @@ describe("Live-Anzeige (v3.0)", () => {
     expect(getippt).toBeLessThanOrEqual(100);
   });
 
-  it("Adaptives Tempo: wenig Puffer tippt am Boden (~12 Z/s) — ruhig, aber sichtbar in Bewegung", async () => {
+  it("Adaptives Tempo: wenig Puffer tippt am Boden (~20 Z/s) — flott, aber mitlesbar", async () => {
     /* Kleiner Rest → Untergrenze MIN_ZEICHEN_PRO_SEKUNDE. Mit festem Tempo
        (70 Z/s) wäre der Puffer hier nach unter einer halben Sekunde leer. */
     w("A".repeat(30));
     await vi.advanceTimersByTimeAsync(1000);
     const getippt = elements.liveTextFest.textContent.length;
-    expect(getippt).toBeGreaterThanOrEqual(10);
-    expect(getippt).toBeLessThanOrEqual(16);
+    expect(getippt).toBeGreaterThanOrEqual(17);
+    expect(getippt).toBeLessThanOrEqual(24);
   });
 
   it("Entkopplung: eine nachgeschobene Welle verlängert den Puffer, ohne das Tippen zu unterbrechen", async () => {
@@ -288,17 +288,17 @@ describe("Live-Anzeige (v3.0)", () => {
   /* ── Warte-Rotation nach dem fertig getippten Text (FIX 2, v3.0.1) ──────
      Seit v3.0.0 nur noch der FALLBACK für einen vorzeitig leeren Puffer —
      den Normalfall trägt jetzt das adaptive Tippen selbst. Die kurzen Texte
-     hier (24 Zeichen, Boden-Tempo 12 Z/s ≈ 2 s) tippen bewusst schnell leer. */
+     hier (48 Zeichen, Boden-Tempo 20 Z/s ≈ 2,4 s) tippen bewusst schnell leer. */
 
   it("FIX 2 (Fallback): die Warte-Rotation startet erst nach dem Tipp-Ende — nicht schon, wenn die Lieferung fertig ist", async () => {
-    w("A".repeat(24));
+    w("A".repeat(48));
     await vi.advanceTimersByTimeAsync(1000);
     expect(elements.liveStatusText.textContent).toBe("live.statusSchreibt");
 
     /* Nächste Poll-Welle OHNE neue Zeichen → Lieferung abgeschlossen. Getippt
-       wird aber noch (~24 Zeichen / 12 pro s ≈ 2 s) — die Status-Zeile
+       wird aber noch (~48 Zeichen / 20 pro s ≈ 2,4 s) — die Status-Zeile
        bleibt beim Schreib-Status. */
-    w("A".repeat(24));
+    w("A".repeat(48));
     await vi.advanceTimersByTimeAsync(500);
     expect(elements.liveStatusText.textContent).toBe("live.statusSchreibt");
 

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081107" />
+    <link rel="stylesheet" href="./styles.css?v=2026081108" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -44,7 +44,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081107" />
+    <link rel="stylesheet" href="./styles.css?v=2026081108" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -85,7 +85,7 @@
     <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
     <link rel="preconnect" href="https://nominatim.openstreetmap.org" crossorigin />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081107" />
+    <link rel="stylesheet" href="./styles.css?v=2026081108" />
     <script type="application/ld+json">
 [
   {
@@ -298,15 +298,15 @@
         <p class="demo-label" data-i18n="demo.label">Kein Foto zur Hand? Probier ein Beispielbild (mit KI erstellt):</p>
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
-            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081107" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081108" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.selfie">Selfie am Stephansplatz</span>
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
-            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081107" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081108" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.cafe">Im Caf&eacute; in Salzburg</span>
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
-            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081107" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081108" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.hiker">Wanderung bei Hallstatt</span>
           </button>
         </div>
@@ -362,6 +362,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081107"></script>
+    <script type="module" src="./app.js?v=2026081108"></script>
   </body>
 </html>

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -5,9 +5,9 @@ import { klangAktivieren } from "./klang.js";
 import { t } from "./i18n.js";
 
 const DEMO_IMAGES = {
-  selfie: "./img/demo/demo-selfie.jpg?v=2026081107",
-  cafe: "./img/demo/demo-cafe.jpg?v=2026081107",
-  hiker: "./img/demo/demo-hiker.jpg?v=2026081107",
+  selfie: "./img/demo/demo-selfie.jpg?v=2026081108",
+  cafe: "./img/demo/demo-cafe.jpg?v=2026081108",
+  hiker: "./img/demo/demo-hiker.jpg?v=2026081108",
 };
 
 export function initDemo() {

--- a/public/js/live-anzeige.js
+++ b/public/js/live-anzeige.js
@@ -70,22 +70,23 @@ const SCHWEIF_LAENGE = 7;
    Rest ÷ ZIEL_ABTROPF_SEKUNDEN — wenig Puffer tippt langsam und lesbar,
    viel Puffer schneller, und das Tippen streckt sich über einen Großteil
    der Analyse. */
-const ZIEL_ABTROPF_SEKUNDEN = 20;
+const ZIEL_ABTROPF_SEKUNDEN = 10;
 /* Untergrenze: Darunter wirkt das Tippen wie ein Hänger statt wie Schreiben —
-   auch ein fast leerer Puffer muss sichtbar in Bewegung bleiben. 12 statt
-   anfangs 6: Das Kriech-Tempo des ersten Livegangs wirkte „sehr gequält"
-   (Live-Test 11.08.) — der Zeit-Anlauf unten sorgt dafür, dass beim Start
-   schon genug Material für dieses Tempo im Puffer liegt. */
-const MIN_ZEICHEN_PRO_SEKUNDE = 12;
+   auch ein fast leerer Puffer muss sichtbar in Bewegung bleiben. 20 nach
+   ausdrücklicher Ansage des Inhabers (Abend-Test 11.08.: 12 Z/s „wirkt
+   immer noch total zäh") — der lange Zeit-Anlauf unten sammelt vorher genug
+   Material, damit dieses Tempo durchgehalten werden kann. */
+const MIN_ZEICHEN_PRO_SEKUNDE = 20;
 /* Obergrenze: Darüber ist der Text nicht mehr mitlesbar — schneller darf nur
    der Schnellvorlauf nach der Fertig-Meldung des Servers sein. */
 const MAX_ZEICHEN_PRO_SEKUNDE = 90;
 /* Zeit-Anlauf vor dem ersten getippten Zeichen: Der Stream liefert anfangs
    nur wenige Zeichen pro Sekunde — sofort loszutippen hieße, minutenlang an
    der Untergrenze zu kriechen. Solange trägt die Scan-Animation die Zeit.
-   Meldet der Server vorher „fertig", greift sofort der Schnellvorlauf.
-   (let statt const wegen des Test-Hooks _setzeTippAnlaufMsFuerTest.) */
-let TIPP_ANLAUF_MS = 10000;
+   20 s auf ausdrückliche Ansage des Inhabers (11.08. abends): lieber länger
+   sammeln und dann flott tippen. Meldet der Server vorher „fertig", greift
+   sofort der Schnellvorlauf. (let wegen _setzeTippAnlaufMsFuerTest.) */
+let TIPP_ANLAUF_MS = 20000;
 /* Schnellvorlauf, sobald der Server „fertig" meldet: Der Rest-Puffer wird
    zügig, aber noch als Tippen erkennbar ausgetippt — erst danach beginnt die
    Enthüllung. So endet der Lauf ohne harten Textsprung. */

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081107" />
+    <link rel="stylesheet" href="./styles.css?v=2026081108" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081107" />
+    <link rel="stylesheet" href="./styles.css?v=2026081108" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081107"></script>
+    <script type="module" src="./js/stats.js?v=2026081108"></script>
   </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -769,11 +769,13 @@ html[data-has-result] {
 .live-karte {
   display: none;
   margin: 18px 0;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow);
-  padding: 16px;
+  /* Von Anfang an das Kleid der späteren Zusammenfassungs-Box (.verdict):
+     Der Text wandert nach dem Tippen genau dorthin — ein Farbwechsel der
+     Karte wirkte wie ein Bruch (Live-Test 11.08. abends). */
+  background: var(--tint-rust);
+  border-left: 2px solid var(--ml-rust);
+  border-radius: var(--radius-md);
+  padding: 16px 20px;
 }
 
 .live-karte.active {


### PR DESCRIPTION
Zwei Ansagen aus dem Abend-Test des Inhabers:

- **20 Sekunden warten, dann flotter:** Zeit-Anlauf 10→20 s (Scan-Animation trägt), Tempo-Untergrenze 12→20 Z/s, Abtropf-Ziel 20→10 s. Der zähe Eindruck ist damit weg.
- **Kein Farbwechsel der ersten Karte:** .live-karte trägt von Beginn an das Kleid der Zusammenfassungs-Box (tint-rust + Rost-Balken links).

Dazu E2E-Wartegrenzen der Live-Tests auf 35 s (der Anlauf lag exakt auf der alten 20-s-Grenze). CHANGELOG: neuer Eintrag [3.0.1].

Tests: Frontend 280/280, Live-E2E 3/3, Lint + Format sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)