### PR TITLE
feat: v3.0.3 — Blick-Führung: Auge, Karte und letzte Zeile immer im Bild; Töne +20 %

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [3.0.3] — 2026-08-11
+
+Blick-Führung von Anfang an — dein Blick ist immer dort, wo gerade etwas
+passiert:
+
+- **Nach der Foto-Wahl ist das Auge im Bild:** Sobald die Analyse startet,
+  holt die Seite das arbeitende Auge sanft ins Sichtfeld. Vorher sah man am
+  Handy oft nur das gewählte Foto — aber nicht, dass schon etwas passiert.
+  Auf großen Bildschirmen, wo das Auge ohnehin zu sehen ist, bewegt sich
+  nichts.
+- **Beim Tipp-Start ist die Karte im Bild:** In dem Moment, in dem die KI
+  zu tippen beginnt, wird die Schreib-Karte sanft ins Sichtfeld geholt —
+  wieder nur, wenn das nötig ist.
+- **Die letzte Zeile bleibt beim Tippen sichtbar:** Wächst der getippte Text
+  auf kleinen Bildschirmen unten aus dem Bild, scrollt die Seite in kleinen,
+  sanften Schritten mit — nur nach unten, damit du immer siehst, was gerade
+  geschrieben wird.
+- **Die Enthüllung führt ab der ersten Box:** Jede aufpoppende Box wird von
+  Anfang an in die Bildmitte geholt — die Führung ist vom ersten Moment an
+  spürbar, nicht erst weiter unten auf der Seite.
+- **Töne etwas lauter:** Tipp- und Pop-Klang sind um rund 20 Prozent lauter.
+- **Du behältst die Kontrolle:** Sobald du selbst scrollst (Finger, Mausrad
+  oder Scroll-Taste), stoppt jede automatische Bewegung sofort — und bleibt
+  für den Rest dieser Analyse aus. Wer im System „Bewegung reduzieren"
+  eingestellt hat, bekommt weiterhin gar kein automatisches Scrollen.
+
 ## [3.0.2] — 2026-08-11
 
 Dramaturgie-Feinschliff nach dem ersten Live-Tag:

--- a/e2e/live-anzeige.test.js
+++ b/e2e/live-anzeige.test.js
@@ -208,6 +208,93 @@ test("Modus-Wechsel mitten im Stream: die Live-Karte springt auf den Beast-Text 
   await expect(page.locator("#scanAnim")).not.toHaveClass(/active/);
 });
 
+/* v3.0.3 Blick-Führung: sehr langer Live-Text, damit der getippte Text am
+   Handy-Viewport sicher unter die Sichtkante wächst. `processing` hält an,
+   bis der Test fertigMachen() ruft — genug Zeit für die Scroll-Proben. */
+async function seiteMitLangemTextMocks(page) {
+  await basisRouten(page);
+  const langerText = (PROFIL_TEXT + " ").repeat(6);
+  let fertig = false;
+  let poll = 0;
+  await page.route("**/api/job-status**", (route) => {
+    poll += 1;
+    const body = fertig
+      ? { status: "done", result: MOCK_RESPONSE }
+      : {
+          status: "processing",
+          position: 0,
+          etaSeconds: 60,
+          liveText: langerText.slice(0, Math.min(langerText.length, poll * 400)),
+        };
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+
+  await page.goto("/");
+  await expect(page.locator("h1")).toBeVisible();
+  return {
+    fertigMachen() {
+      fertig = true;
+    },
+  };
+}
+
+test("v3.0.3 Blick-Führung am Handy: Auge nach der Foto-Wahl im Bild, die letzte Zeile bleibt beim Tippen sichtbar", async ({
+  page,
+}) => {
+  test.setTimeout(120000);
+  /* Handy-Viewport: hier liegt das Auge nach dem Antippen eines Demo-Fotos
+     außerhalb des Sichtfelds — genau der Befund des Inhabers („man sieht das
+     Foto, aber nicht, dass etwas passiert"). */
+  await page.setViewportSize({ width: 390, height: 660 });
+  const steuerung = await seiteMitLangemTextMocks(page);
+
+  await page.click('[data-demo="selfie"]');
+
+  /* Punkt 2: Kurz nach dem Start liegt das Auge mehrheitlich im Sichtfeld —
+     die Führung hat es dorthin geholt (ohne Führung bliebe der Blick beim
+     Demo-Foto weiter unten hängen). */
+  await expect(page.locator("#scanAnim")).toHaveClass(/active/);
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const r = document.getElementById("scanAnim").getBoundingClientRect();
+          const h = window.innerHeight;
+          return Math.min(r.bottom, h) - Math.max(r.top, 0) >= r.height / 2;
+        }),
+      { timeout: 10000 }
+    )
+    .toBe(true);
+
+  /* Tipp-Start (nach dem ~25-s-Anlauf): Die Karte übernimmt. */
+  await expect(page.locator("#liveKarte")).toHaveClass(/active/, { timeout: 45000 });
+
+  /* Punkt 4: Der Text wächst über die Sichtkante hinaus — ohne eigenes
+     Zutun scrollt die Seite nach unten mit. Erst das Anfahren der Karte
+     ausklingen lassen, damit hier wirklich das Nachscrollen gemessen wird. */
+  await page.waitForTimeout(1500);
+  const startScroll = await page.evaluate(() => window.scrollY);
+  await expect
+    .poll(() => page.evaluate(() => window.scrollY), { timeout: 40000 })
+    .toBeGreaterThan(startScroll + 40);
+
+  /* Dabei bleibt der Cursor (die letzte getippte Zeile) im Bild. */
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const r = document.getElementById("liveCursor").getBoundingClientRect();
+          return r.bottom <= window.innerHeight;
+        }),
+      { timeout: 10000 }
+    )
+    .toBe(true);
+
+  /* Punkt 5: done → die Enthüllung führt bis zum PDF-Knopf. */
+  steuerung.fertigMachen();
+  await expect(page.locator("#exportPdf")).not.toHaveClass(/export-btn--hidden/, { timeout: 60000 });
+});
+
 test("Live-Erlebnis mit reduced-motion: Text sofort vollständig, Enthüllung ohne Verzögerung", async ({ page }) => {
   test.setTimeout(90000);
   await page.emulateMedia({ reducedMotion: "reduce" });

--- a/public/__tests__/klang.test.js
+++ b/public/__tests__/klang.test.js
@@ -23,12 +23,17 @@ function baueMockAudioContext() {
       this.destination = {};
       this.quellen = 0;
       this.oszillatoren = 0;
+      /* Alle erzeugten Gain-Knoten in Reihenfolge — der ERSTE ist der Master
+         (klang.js legt ihn vor Echo-Rückführung und -Mix an). */
+      this.gains = [];
     }
     createBuffer(_kanaele, laenge) {
       return { getChannelData: () => new Float32Array(laenge) };
     }
     createGain() {
-      return new MockGain();
+      const g = new MockGain();
+      this.gains.push(g);
+      return g;
     }
     createDelay() {
       return { delayTime: { value: 0 }, connect() {} };
@@ -99,6 +104,18 @@ describe("Klang (v3.0)", () => {
     /* Mehrfach aktivieren erzeugt keinen zweiten Context. */
     klang.klangAktivieren();
     expect(Mock.instanzen.length).toBe(1);
+  });
+
+  it("v3.0.3: die Master-Lautstärke steht auf 0,96 — +20 % auf Ansage des Inhabers (11.08. abends)", async () => {
+    const Mock = baueMockAudioContext();
+    Mock.instanzen = [];
+    window.AudioContext = Mock;
+    const klang = await import("../js/klang.js");
+    klang.klangAktivieren();
+    /* Der Master ist der erste erzeugte Gain-Knoten (siehe klang.js).
+       (Rückbauprobe: Wird die Lautstärke auf die alten 0,8 zurückgesetzt,
+       wird diese Erwartung ROT.) */
+    expect(Mock.instanzen[0].gains[0].gain.value).toBeCloseTo(0.96, 5);
   });
 
   it("Ton-Funktionen schlucken interne Fehler — Audio darf nie etwas kaputt machen", async () => {

--- a/public/__tests__/live-anzeige.test.js
+++ b/public/__tests__/live-anzeige.test.js
@@ -763,4 +763,230 @@ describe("Live-Anzeige (v3.0)", () => {
       delete window.Element.prototype.scrollIntoView;
     }
   });
+
+  /* ── Blick-Führung über den gesamten Lauf (v3.0.3) ─────────────────────
+     „Der Blick ist immer dort, wo gerade etwas passiert": Auge nach der
+     Foto-Wahl, Karte beim Tipp-Start, letzte Zeile beim Tippen — und EIN
+     Übernahme-Zustand für den ganzen Lauf. Die Sichtfeld-Messungen werden
+     über getBoundingClientRect-Mocks gestellt (jsdom-Fensterhöhe: 768 px). */
+
+  const unterDerSichtkante = () => ({ top: 900, bottom: 1000, height: 100 });
+  const imFenster = () => ({ top: 100, bottom: 200, height: 100 });
+
+  it("v3.0.3 Auge ins Bild: ein Auge unterhalb der Sichtkante wird nach dem Analyse-Start sanft geholt", () => {
+    const spy = vi.fn();
+    elements.scanAnim.scrollIntoView = spy;
+    elements.scanAnim.getBoundingClientRect = unterDerSichtkante;
+    try {
+      /* Ohne gestartete Führung passiert nichts — api.js startet sie zuerst. */
+      liveAnzeige.augeInsBild();
+      expect(spy).not.toHaveBeenCalled();
+
+      liveAnzeige.fuehrungStarten();
+      liveAnzeige.augeInsBild();
+      /* (Diese Erwartung wird ROT, wenn jemand das Auge-Anfahren entfernt.) */
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+    } finally {
+      delete elements.scanAnim.scrollIntoView;
+      delete elements.scanAnim.getBoundingClientRect;
+    }
+  });
+
+  it("v3.0.3 Auge ins Bild: ein schon (mehrheitlich) sichtbares Auge wird NICHT angescrollt", () => {
+    const spy = vi.fn();
+    elements.scanAnim.scrollIntoView = spy;
+    elements.scanAnim.getBoundingClientRect = imFenster;
+    try {
+      liveAnzeige.fuehrungStarten();
+      liveAnzeige.augeInsBild();
+      /* Desktop-Fall: das Auge steht längst im Bild — NICHTS bewegt sich. */
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      delete elements.scanAnim.scrollIntoView;
+      delete elements.scanAnim.getBoundingClientRect;
+    }
+  });
+
+  it("v3.0.3 reduced-motion: auch das Auge wird nie automatisch angefahren", () => {
+    reduzierteBewegung();
+    const spy = vi.fn();
+    elements.scanAnim.scrollIntoView = spy;
+    elements.scanAnim.getBoundingClientRect = unterDerSichtkante;
+    try {
+      liveAnzeige.fuehrungStarten();
+      liveAnzeige.augeInsBild();
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      delete elements.scanAnim.scrollIntoView;
+      delete elements.scanAnim.getBoundingClientRect;
+    }
+  });
+
+  it("v3.0.3 Tipp-Start: die Karte wird beim ersten Zeichen ins Bild geholt — genau einmal", async () => {
+    const spy = vi.fn();
+    elements.liveKarte.scrollIntoView = spy;
+    elements.liveKarte.getBoundingClientRect = unterDerSichtkante;
+    try {
+      liveAnzeige.fuehrungStarten();
+      w("A".repeat(300));
+      await vi.advanceTimersByTimeAsync(300);
+      expect(elements.liveKarte.classList.contains("active")).toBe(true);
+      /* (Diese Erwartung wird ROT, wenn jemand das Karten-Anfahren entfernt.) */
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+      /* Die folgenden Zeichen fahren die Karte nicht immer wieder neu an. */
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      delete elements.liveKarte.scrollIntoView;
+      delete elements.liveKarte.getBoundingClientRect;
+    }
+  });
+
+  it("v3.0.3 Tipp-Start: eine schon sichtbare Karte wird NICHT angescrollt (Desktop-Fall)", async () => {
+    const spy = vi.fn();
+    elements.liveKarte.scrollIntoView = spy;
+    elements.liveKarte.getBoundingClientRect = imFenster;
+    try {
+      liveAnzeige.fuehrungStarten();
+      w("A".repeat(300));
+      await vi.advanceTimersByTimeAsync(500);
+      expect(elements.liveKarte.classList.contains("active")).toBe(true);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      delete elements.liveKarte.scrollIntoView;
+      delete elements.liveKarte.getBoundingClientRect;
+    }
+  });
+
+  it("v3.0.3 Tipp-Nachscrollen: rutscht der Cursor unter die Sichtkante, scrollt es gedrosselt nach unten", async () => {
+    const echteScrollBy = window.scrollBy;
+    window.scrollBy = vi.fn();
+    elements.liveCursor.getBoundingClientRect = () => ({ top: 800, bottom: 810, height: 10 });
+    try {
+      liveAnzeige.fuehrungStarten();
+      /* Riesiger Puffer → Tempo am Deckel (~90 Z/s) → ~90 Zeichen-Ticks in
+         der geprüften Sekunde. */
+      w("A".repeat(6000));
+      await vi.advanceTimersByTimeAsync(1000);
+      const aufrufe = window.scrollBy.mock.calls;
+      /* (Rückbauprobe: OHNE Tipp-Nachscrollen bleibt es bei 0 Aufrufen → ROT.) */
+      expect(aufrufe.length).toBeGreaterThanOrEqual(1);
+      /* Drossel: höchstens alle ~300 ms — NICHT bei jedem der ~90 Zeichen.
+         (Diese Obergrenze wird ROT, wenn jemand die Drossel entfernt.) */
+      expect(aufrufe.length).toBeLessThanOrEqual(5);
+      for (const [args] of aufrufe) {
+        expect(args.behavior).toBe("smooth");
+        /* Nur nach unten — nie gegen die Leserichtung nach oben ziehen. */
+        expect(args.top).toBeGreaterThan(0);
+      }
+    } finally {
+      window.scrollBy = echteScrollBy;
+      delete elements.liveCursor.getBoundingClientRect;
+    }
+  });
+
+  it("v3.0.3 Tipp-Nachscrollen: ein Cursor im Sichtfeld löst KEIN Scrollen aus", async () => {
+    const echteScrollBy = window.scrollBy;
+    window.scrollBy = vi.fn();
+    elements.liveCursor.getBoundingClientRect = () => ({ top: 100, bottom: 110, height: 10 });
+    try {
+      liveAnzeige.fuehrungStarten();
+      w("A".repeat(6000));
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(window.scrollBy).not.toHaveBeenCalled();
+    } finally {
+      window.scrollBy = echteScrollBy;
+      delete elements.liveCursor.getBoundingClientRect;
+    }
+  });
+
+  it("v3.0.3 NUTZER HAT VORRANG: die Übernahme stoppt auch das Tipp-Nachscrollen sofort und dauerhaft", async () => {
+    const echteScrollBy = window.scrollBy;
+    window.scrollBy = vi.fn();
+    elements.liveCursor.getBoundingClientRect = () => ({ top: 800, bottom: 810, height: 10 });
+    try {
+      liveAnzeige.fuehrungStarten();
+      w("A".repeat(6000));
+      await vi.advanceTimersByTimeAsync(500);
+      expect(window.scrollBy.mock.calls.length).toBeGreaterThanOrEqual(1);
+      const standVorher = window.scrollBy.mock.calls.length;
+
+      /* Der Nutzer greift ein — ab jetzt scrollt das Tippen nie wieder.
+         (Diese Erwartung wird ROT, wenn jemand die Übernahme-
+         Verallgemeinerung entfernt.) */
+      window.dispatchEvent(new Event("wheel"));
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(window.scrollBy.mock.calls.length).toBe(standVorher);
+    } finally {
+      window.scrollBy = echteScrollBy;
+      delete elements.liveCursor.getBoundingClientRect;
+    }
+  });
+
+  it("v3.0.3 EIN Zustand pro Lauf: eine Übernahme WÄHREND des Tippens stoppt auch die Enthüllungs-Führung", async () => {
+    const scrollSpy = vi.fn();
+    window.Element.prototype.scrollIntoView = scrollSpy;
+    try {
+      liveAnzeige.fuehrungStarten();
+      w("A".repeat(300));
+      await vi.advanceTimersByTimeAsync(500);
+      expect(elements.liveKarte.classList.contains("active")).toBe(true);
+
+      /* Übernahme mitten im Tippen — lange VOR der Enthüllung. */
+      window.dispatchEvent(new Event("wheel"));
+
+      baueGerendertesErgebnis();
+      liveAnzeige.starteEnthuellung();
+      await vi.advanceTimersByTimeAsync(16000);
+      /* (Diese Erwartung wird ROT, wenn die Enthüllung wieder eine EIGENE
+         frische Wache startet statt den Lauf-Zustand weiterzuführen.) */
+      expect(scrollSpy).not.toHaveBeenCalled();
+      /* Die Enthüllung selbst lief trotzdem zu Ende. */
+      expect(elements.exportPdf.classList.contains("export-btn--hidden")).toBe(false);
+    } finally {
+      delete window.Element.prototype.scrollIntoView;
+    }
+  });
+
+  it("v3.0.3 reduced-motion: weder Karten-Anfahren noch Tipp-Nachscrollen", async () => {
+    reduzierteBewegung();
+    const echteScrollBy = window.scrollBy;
+    window.scrollBy = vi.fn();
+    const spy = vi.fn();
+    elements.liveKarte.scrollIntoView = spy;
+    elements.liveKarte.getBoundingClientRect = unterDerSichtkante;
+    elements.liveCursor.getBoundingClientRect = () => ({ top: 800, bottom: 810, height: 10 });
+    try {
+      liveAnzeige.fuehrungStarten();
+      w("A".repeat(300));
+      expect(elements.liveKarte.classList.contains("active")).toBe(true);
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(spy).not.toHaveBeenCalled();
+      expect(window.scrollBy).not.toHaveBeenCalled();
+    } finally {
+      window.scrollBy = echteScrollBy;
+      delete elements.liveKarte.scrollIntoView;
+      delete elements.liveKarte.getBoundingClientRect;
+      delete elements.liveCursor.getBoundingClientRect;
+    }
+  });
+
+  it("v3.0.3 Enthüllung: schon die ERSTE gepoppte Box wird aktiv zentriert — die Führung fährt ab Pop 1", async () => {
+    const scrollSpy = vi.fn();
+    window.Element.prototype.scrollIntoView = scrollSpy;
+    try {
+      baueGerendertesErgebnis();
+      liveAnzeige.starteEnthuellung();
+      /* Pop 1 (Foto-Daten, ~700 ms): sofort zentriert — nicht erst, wenn
+         „nötig". (Diese Erwartung wird ROT, wenn jemand die Zentrierung der
+         ersten Pops entfernt.) */
+      await vi.advanceTimersByTimeAsync(750);
+      expect(scrollSpy).toHaveBeenCalledTimes(1);
+      expect(scrollSpy).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+    } finally {
+      delete window.Element.prototype.scrollIntoView;
+    }
+  });
 });

--- a/public/__tests__/queue-livetext.test.js
+++ b/public/__tests__/queue-livetext.test.js
@@ -38,6 +38,9 @@ vi.mock("../js/live-anzeige.js", () => ({
   enthuellungAbkuerzen: vi.fn(),
   abbrechen: vi.fn(),
   zuruecksetzen: vi.fn(),
+  /* v3.0.3 Blick-Führung: api.js ruft beides beim Analyse-Beginn. */
+  fuehrungStarten: vi.fn(),
+  augeInsBild: vi.fn(),
 }));
 
 const DONE_RESULT = {
@@ -272,5 +275,37 @@ describe("Queue-Verdrahtung des Live-Texts (v3.0)", () => {
     await vi.advanceTimersByTimeAsync(8000);
     await p;
     expect(liveAnzeige.zuruecksetzen).toHaveBeenCalled();
+  });
+
+  it("v3.0.3 Blick-Führung: der Analyse-Beginn startet die Führung und holt das Auge ins Bild", async () => {
+    mockeStatusFolge([{ status: "done", result: DONE_RESULT }]);
+    const p = analyzeImage();
+    await vi.advanceTimersByTimeAsync(8000);
+    await p;
+    /* (Rückbauprobe: Wird der Führungs-Start beim Analyse-Beginn entfernt —
+       die Verallgemeinerung der Übernahme-Wache auf den ganzen Lauf —,
+       werden diese Erwartungen ROT.) */
+    expect(liveAnzeige.fuehrungStarten).toHaveBeenCalledTimes(1);
+    expect(liveAnzeige.augeInsBild).toHaveBeenCalledTimes(1);
+    /* Erst die Wache, dann das Anfahren — ohne Wache darf nie gescrollt werden. */
+    expect(liveAnzeige.fuehrungStarten.mock.invocationCallOrder[0]).toBeLessThan(
+      liveAnzeige.augeInsBild.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("v3.0.3: die Wiederaufnahme nach einem Reload startet KEINE Blick-Führung", async () => {
+    /* Der Seitenstart ist keine Foto-Wahl — hier darf nichts von selbst
+       scrollen (die Wiederaufnahme bleibt beim heutigen, stillen Bild). */
+    sessionStorage.setItem("malzime.queueJobId", "job-resumed");
+    sessionStorage.setItem("malzime.queueResultToken", "tok-1");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (!String(url).includes("job-status")) return jsonResponse({ ok: true });
+      return jsonResponse({ status: "done", result: DONE_RESULT });
+    });
+    const p = resumeQueueJob();
+    await vi.advanceTimersByTimeAsync(8000);
+    await p;
+    expect(liveAnzeige.fuehrungStarten).not.toHaveBeenCalled();
+    expect(liveAnzeige.augeInsBild).not.toHaveBeenCalled();
   });
 });

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -592,6 +592,20 @@ async function analyzeImageQueued() {
   resetQueueWaiting();
   startScanAnim(false);
   elements.scanText.textContent = t("scan.upload");
+  /* v3.0.3 Blick-Führung: Ab jetzt gehört der Blick diesem Lauf — die
+     Übernahme-Wache startet EINMAL pro Analyse (ein eigener Scroll des
+     Nutzers stoppt alle automatischen Bewegungen dauerhaft), und das Auge
+     wird ins Bild geholt, falls es unter der Sichtkante liegt (am Handy
+     sieht man sonst nur das Foto, aber nicht, dass etwas passiert). Die
+     Wiederaufnahme nach einem Neuladen bleibt bewusst ohne Führung. */
+  /* v3.0.3 Blick-Führung: Ab jetzt gehört der Blick diesem Lauf — die
+     Übernahme-Wache startet EINMAL pro Analyse (ein eigener Scroll des
+     Nutzers stoppt alle automatischen Bewegungen dauerhaft), und das Auge
+     wird ins Bild geholt, falls es unter der Sichtkante liegt (am Handy
+     sieht man sonst nur das Foto, aber nicht, dass etwas passiert). Die
+     Wiederaufnahme nach einem Neuladen bleibt bewusst ohne Führung. */
+  liveAnzeige.fuehrungStarten();
+  liveAnzeige.augeInsBild();
 
   const file = state.lastFile || elements.fileInput.files[0];
   if (!file) {

--- a/public/js/klang.js
+++ b/public/js/klang.js
@@ -8,7 +8,7 @@
  *   2. popTon()   — weicher Sinus-Pop 340→240 Hz (~120 ms) für ankommende
  *                   Ergebnis-Boxen.
  *
- * Beide laufen durch denselben Master (Gain 0,8) plus einen dezenten
+ * Beide laufen durch denselben Master (Gain 0,96) plus einen dezenten
  * Echo-Bus (Delay 90 ms, Feedback 0,25, Mix 0,22) — ein Klangbild, kein Zoo.
  * JEDER Ton bekommt weiche Hüllkurven-Rampen (linearRamp an, exponentialRamp
  * aus): abrupte Oszillator-Starts erzeugen das billige Klicken.
@@ -42,9 +42,11 @@ export function klangAktivieren() {
       const daten = puffer.getChannelData(0);
       for (let i = 0; i < daten.length; i++) daten[i] = Math.random() * 2 - 1;
 
-      /* Gemeinsamer Bus: Master + dezentes Feedback-Echo (90 ms). */
+      /* Gemeinsamer Bus: Master + dezentes Feedback-Echo (90 ms).
+         0,96 statt 0,8: Die Töne waren dem Inhaber im Live-Test zu leise —
+         +20 % auf seine Ansage (11.08. abends, v3.0.3). */
       const master = ctx.createGain();
-      master.gain.value = 0.8;
+      master.gain.value = 0.96;
       master.connect(ctx.destination);
       const echo = ctx.createDelay(0.5);
       echo.delayTime.value = 0.09;

--- a/public/js/live-anzeige.js
+++ b/public/js/live-anzeige.js
@@ -42,15 +42,27 @@
  *      GPS-Karte → Kategorien (Gruppenkopf ~650 ms, Karten im ~280-ms-
  *      Stakkato) → Werbe-Box → Manipulations-Box → Datenwert-Box (nur der
  *      Euro-Betrag zählt hoch, die Balken fahren aus) → PDF-Knopf zuletzt.
- *      Dabei scrollt die Seite GEFÜHRT mit (v3.0.2): jede Box wird sanft ins
- *      Sichtfeld geholt. Der Nutzer hat Vorrang — beim ersten eigenen
- *      Eingriff (Rad, Touch, Scroll-Taste) endet die Führung sofort und
+ *      Dabei scrollt die Seite GEFÜHRT mit (v3.0.2): jede gepoppte Box wird
+ *      aktiv zentriert — ab dem ERSTEN Pop (v3.0.3, User-Befund: die Führung
+ *      schien sonst erst spät „loszufahren").
+ *   5. BLICK-FÜHRUNG über den GESAMTEN Lauf (v3.0.3): „Der Blick ist immer
+ *      dort, wo gerade etwas passiert." Nach der Foto-/Demo-Wahl wird das
+ *      Scan-Auge sanft ins Sichtfeld geholt (am Handy zeigt der Bildschirm
+ *      sonst nur das Foto, aber nicht, dass etwas passiert), beim ersten
+ *      getippten Zeichen die Live-Karte — beides NUR, wenn das Element nicht
+ *      ohnehin mehrheitlich sichtbar ist: Auf dem Desktop bewegt sich nichts.
+ *      Während des Tippens hält ein gedrosseltes Nachscrollen die letzte
+ *      Zeile im Bild (nur nach unten, nur wenn der Cursor unter die
+ *      Sichtkante rutscht). Der Nutzer hat Vorrang: EIN Übernahme-Zustand
+ *      pro Analyse-Lauf — der erste eigene Eingriff (Rad, Touch,
+ *      Scroll-Taste) stoppt ALLE automatischen Scroll-Bewegungen sofort und
  *      dauerhaft für diesen Lauf, und der Pop-Ton klingt ab da nur noch für
  *      Boxen, die wirklich im Sichtfeld liegen (keine Geräusche aus dem Off).
  *
  * Barrierefreiheit (Lehren aus v2.11):
  *   - prefers-reduced-motion: kein Tippen, kein Rausch — jede Welle erscheint
- *     sofort vollständig; die Enthüllung läuft ohne jede Verzögerung.
+ *     sofort vollständig; die Enthüllung läuft ohne jede Verzögerung. Und es
+ *     wird NIEMALS automatisch gescrollt (auch nicht von der Blick-Führung).
  *   - Screenreader: EINE Ankündigung am Ende über #srAnnounce — nie pro
  *     Zeichen, nie pro Box. Der Rausch-Span trägt aria-hidden (index.html),
  *     der wachsende Text bewusst KEIN aria-live.
@@ -110,6 +122,15 @@ const LEERLAUF_MS = 120;
 /* Takt der ehrlichen Warte-Zeilen im Warte-Auge (v3.0.2: oberhalb der
    Karte, nicht mehr in einer Status-Zeile). */
 const ROTATION_TAKT_MS = 2500;
+/* ── Tipp-Nachscrollen (v3.0.3) ──
+   Auf kleinen Bildschirmen wächst der getippte Text unten aus dem Sichtfeld
+   („in die Nichtsichtbarkeit gerutscht", User-Befund 11.08. abends). Die
+   Drossel prüft NICHT bei jedem Zeichen — bei ~90 Z/s wären das ~90 Messungen
+   und angestoßene Smooth-Scrolls pro Sekunde, ein ruckelndes Dauerzerren. */
+const NACHSCROLL_TAKT_MS = 300;
+/* Sichtkanten-Puffer: erst wenn der Cursor DARUNTER rutscht, wird gescrollt —
+   und genau bis zurück auf diese Kante, nie weiter (nur nach unten). */
+const NACHSCROLL_PUFFER_PX = 48;
 
 /* Aktueller Tipp-Lauf. `stop` beendet die Schleife beim nächsten Tick.
    `aktiv` benennt den Puffer des gerade gewählten Modus ("standard"/"beast");
@@ -167,11 +188,156 @@ function neuerLauf() {
     schnellvorlauf: false,
     /* Vor diesem Zeitpunkt tippt die Schleife nicht (Zeit-Anlauf). */
     tippStartAb: 0,
+    /* v3.0.3: letzte Sichtkanten-Prüfung des Tipp-Nachscrollens (Drossel). */
+    nachscrollZuletzt: 0,
     puffer: {
       standard: { text: "", fest: 0 },
       beast: { text: "", fest: 0 },
     },
   };
+}
+
+/* ── Blick-Führung über den gesamten Lauf (v3.0.3) ───────────────────────
+   „Der Blick ist immer dort, wo gerade etwas passiert" — Auge nach der
+   Foto-Wahl, Karte beim Tipp-Start, letzte Zeile beim Tippen, jede Box der
+   Enthüllung. Der NUTZER HAT VORRANG: Es gibt genau EINEN Übernahme-Zustand
+   pro Analyse-Lauf; der erste eigene Eingriff (Rad, Touch, Scroll-Taste)
+   stoppt ALLE automatischen Scroll-Bewegungen sofort und dauerhaft für
+   diesen Lauf — nichts ist unangenehmer als eine Seite, die gegen die
+   eigene Scroll-Richtung zieht. Bis v3.0.2 wachte die Übernahme nur über
+   die Enthüllung — seit dem Auge- und Tipp-Scrollen muss sie ab dem
+   Analyse-Beginn gelten. */
+
+/* Tasten, mit denen Menschen scrollen — nur diese gelten als Übernahme
+   (eine Tab-Taste z. B. ist Navigation, kein Scrollen). " " ist die
+   Space-Taste, "Spacebar" ihr Name in älteren Browsern. */
+const UEBERNAHME_TASTEN = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "PageUp",
+  "PageDown",
+  " ",
+  "Spacebar",
+  "Home",
+  "End",
+]);
+
+/* Der EINE Übernahme-Zustand des laufenden Analyse-Durchgangs — null heißt:
+   keine Führung unterwegs (und damit auch kein automatisches Scrollen). */
+let fuehrung = null;
+
+function fuehrungListenerEntfernen(mein) {
+  if (!mein.listener) return;
+  window.removeEventListener("wheel", mein.listener);
+  window.removeEventListener("touchstart", mein.listener);
+  window.removeEventListener("keydown", mein.listener);
+  mein.listener = null;
+}
+
+/**
+ * Startet die Blick-Führung des Analyse-Laufs (api.js ruft das beim
+ * Analyse-Beginn). Existiert für diesen Lauf schon ein Übernahme-Zustand,
+ * bleibt er unangetastet — insbesondere eine bereits erfolgte Übernahme:
+ * Der Nutzer soll die Führung EINMAL stoppen müssen, nicht in jeder Phase
+ * aufs Neue. Die Wache liest nur mit (passive) — sie darf das echte
+ * Scrollen niemals ausbremsen.
+ */
+export function fuehrungStarten() {
+  if (fuehrung) return;
+  const mein = { aktiv: true, listener: null };
+  const uebernahme = (ereignis) => {
+    if (ereignis.type === "keydown" && !UEBERNAHME_TASTEN.has(ereignis.key)) return;
+    mein.aktiv = false;
+    /* Die Wache hat ihren Dienst getan — sofort abbauen, nicht erst am
+       Ende des Laufs. Der Zustand selbst bleibt bis zum Lauf-Ende stehen
+       (die Ton-Sichtfeld-Regel der Enthüllung braucht ihn). */
+    fuehrungListenerEntfernen(mein);
+  };
+  mein.listener = uebernahme;
+  window.addEventListener("wheel", uebernahme, { passive: true });
+  window.addEventListener("touchstart", uebernahme, { passive: true });
+  window.addEventListener("keydown", uebernahme);
+  fuehrung = mein;
+}
+
+/* Lauf-Ende (Enthüllungs-Abschluss, Fehler, Abbruch): Wache und Zustand
+   restlos weg — der nächste Durchgang beginnt mit frischer Führung. */
+function fuehrungBeenden() {
+  if (!fuehrung) return;
+  fuehrungListenerEntfernen(fuehrung);
+  fuehrung = null;
+}
+
+/* Darf gerade automatisch gescrollt werden? (Die reduzierte Bewegung prüft
+   jede Scroll-Stelle zusätzlich selbst — frisch gelesen über reduziert().) */
+function fuehrungAktiv() {
+  return !!(fuehrung && fuehrung.aktiv);
+}
+
+/* „Mehrheitlich im Sichtfeld": mehr als die halbe Box-Höhe liegt im Fenster.
+   Degenerierte Messwerte (Höhe 0) gelten als sichtbar — im Zweifel lieber
+   ein Ton zu viel als eine stumm gewordene Enthüllung. */
+function imSichtfeld(el) {
+  try {
+    const rechteck = el.getBoundingClientRect();
+    const fensterHoehe = window.innerHeight || document.documentElement.clientHeight || 0;
+    const ueberlappung = Math.min(rechteck.bottom, fensterHoehe) - Math.max(rechteck.top, 0);
+    return ueberlappung >= rechteck.height / 2;
+  } catch (_e) {
+    return true;
+  }
+}
+
+/* Sanft in die Bildmitte holen. Der reduzierte Modus scrollt NIE automatisch;
+   die Vorgabe wird frisch gelesen, damit ein Umstellen mitten im Lauf sofort
+   greift. */
+function sanftZentrieren(el) {
+  if (reduziert()) return;
+  if (el && typeof el.scrollIntoView === "function") {
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+}
+
+/**
+ * Holt das Scan-Auge nach der Foto-/Demo-Wahl ins Sichtfeld (api.js ruft das
+ * beim Analyse-Beginn, direkt nach fuehrungStarten). Grund (User, 11.08.
+ * abends): „Am Handy sieht man das Foto, aber nicht, dass etwas passiert."
+ * NUR wenn das Auge nicht ohnehin mehrheitlich sichtbar ist — auf dem
+ * Desktop, wo es längst im Bild steht, darf sich NICHTS bewegen.
+ */
+export function augeInsBild() {
+  if (!fuehrungAktiv()) return;
+  const auge = elements.scanAnim;
+  if (!auge || imSichtfeld(auge)) return;
+  sanftZentrieren(auge);
+}
+
+/* Tipp-Nachscrollen (v3.0.3): hält die letzte getippte Zeile im Bild. Nur
+   nach unten, nur wenn der Cursor unter die Sichtkante (mit Puffer) gerutscht
+   ist, und gedrosselt — nicht bei jedem Zeichen (NACHSCROLL_TAKT_MS). */
+function tippNachscrollen(mein) {
+  if (!fuehrungAktiv() || reduziert()) return;
+  const jetzt = Date.now();
+  if (jetzt - mein.nachscrollZuletzt < NACHSCROLL_TAKT_MS) return;
+  mein.nachscrollZuletzt = jetzt;
+  const cursor = elements.liveCursor;
+  if (!cursor) return;
+  try {
+    const rechteck = cursor.getBoundingClientRect();
+    const fensterHoehe = window.innerHeight || document.documentElement.clientHeight || 0;
+    /* Wie weit steht der Cursor unter der Sichtkante? Negativ/null = noch im
+       Bild → nichts tun. Es wird NIE nach oben gescrollt — wer hochgeblättert
+       hat, hat übernommen und die Führung ist ohnehin beendet. */
+    const ueberhang = rechteck.bottom - (fensterHoehe - NACHSCROLL_PUFFER_PX);
+    if (ueberhang <= 0) return;
+    if (typeof window.scrollBy === "function") {
+      window.scrollBy({ top: ueberhang, behavior: "smooth" });
+    }
+  } catch (_e) {
+    /* Eine misslungene Messung darf das Tippen nie stören. */
+  }
 }
 
 /* ── Warte-Auge oberhalb der Karte (v3.0.2, ersetzt die Status-Zeile) ─────
@@ -257,6 +423,10 @@ function karteZeigen() {
   /* „Noch nicht fertig"-Dauerstatus, solange getippt wird. */
   if (elements.liveWarten) elements.liveWarten.textContent = t("live.nochNichtFertig");
   stopScanAnim(true);
+  /* v3.0.3: In dem Moment, in dem die Karte übernimmt, gehört ihr der Blick —
+     aber nur, wenn sie nicht ohnehin mehrheitlich im Bild steht (auf dem
+     Desktop bewegt sich nichts). */
+  if (fuehrungAktiv() && !imSichtfeld(karte)) sanftZentrieren(karte);
 }
 
 /* Setzt die Karte vollständig zurück (unsichtbar, ohne Text). */
@@ -314,6 +484,9 @@ async function tippSchleife(mein) {
       let rausch = "";
       for (let i = 0; i < rest; i++) rausch += zufallsZeichen();
       if (elements.liveTextRausch) elements.liveTextRausch.textContent = rausch;
+      /* v3.0.3: Die letzte Zeile bleibt im Bild — gedrosselt, nie bei jedem
+         Zeichen (Details bei tippNachscrollen). */
+      tippNachscrollen(mein);
       naechsterTon -= 1;
       if (naechsterTon <= 0) {
         naechsterTon = 3 + Math.floor(Math.random() * 12);
@@ -345,6 +518,11 @@ export function welle(texte) {
   /* Späte Wellen nach Beginn der Enthüllung ändern nichts mehr. */
   if (enthuellungGestartet) return;
   if (!lauf) lauf = neuerLauf();
+  /* Sicherheitsnetz: Normalerweise startet api.js die Blick-Führung beim
+     Analyse-Beginn — kam der Aufruf nicht (direkter Modul-Gebrauch, Tests),
+     beginnt sie spätestens mit der ersten Welle. Ein bestehender
+     Übernahme-Zustand bleibt dabei unangetastet. */
+  fuehrungStarten();
   /* Je Puffer monoton wachsend übernehmen — kürzere oder gleiche Stände sind
      alte Antworten. Ob eine Lieferung „fertig" ist, spielt seit v3.0.2 keine
      Rolle mehr: Das Warte-Auge richtet sich allein danach, ob gerade getippt
@@ -458,80 +636,15 @@ export function hatLiveGelaufen() {
 
 /* ── Gestaffelte Enthüllung ──────────────────────────────────────────────── */
 
-/* ── Geführtes Mitscrollen (v3.0.2) ──
-   Die Enthüllung wird von oben nach unten immer länger — wer nicht selbst
-   scrollt, sah vom Stakkato der unteren Boxen nur noch die Pop-Töne. Deshalb
-   holt die Führung jede Box sanft ins Sichtfeld. Der NUTZER HAT VORRANG:
-   Beim ersten eigenen Eingriff endet die Führung sofort und dauerhaft für
-   diesen Lauf — nichts ist unangenehmer als eine Seite, die gegen die eigene
-   Scroll-Richtung zieht. */
-
-/* Tasten, mit denen Menschen scrollen — nur diese gelten als Übernahme
-   (eine Tab-Taste z. B. ist Navigation, kein Scrollen). " " ist die
-   Space-Taste, "Spacebar" ihr Name in älteren Browsern. */
-const UEBERNAHME_TASTEN = new Set([
-  "ArrowUp",
-  "ArrowDown",
-  "ArrowLeft",
-  "ArrowRight",
-  "PageUp",
-  "PageDown",
-  " ",
-  "Spacebar",
-  "Home",
-  "End",
-]);
-
-function fuehrungListenerEntfernen(mein) {
-  if (!mein.uebernahmeListener) return;
-  window.removeEventListener("wheel", mein.uebernahmeListener);
-  window.removeEventListener("touchstart", mein.uebernahmeListener);
-  window.removeEventListener("keydown", mein.uebernahmeListener);
-  mein.uebernahmeListener = null;
-}
-
-/* Wacht über den ersten Nutzereingriff. passive: die Wache liest nur mit —
-   sie darf das echte Scrollen niemals ausbremsen. */
-function fuehrungBewachen(mein) {
-  const uebernahme = (ereignis) => {
-    if (ereignis.type === "keydown" && !UEBERNAHME_TASTEN.has(ereignis.key)) return;
-    mein.fuehrungAktiv = false;
-    /* Die Wache hat ihren Dienst getan — sofort abbauen, nicht erst am
-       Enthüllungs-Ende. */
-    fuehrungListenerEntfernen(mein);
-  };
-  mein.uebernahmeListener = uebernahme;
-  window.addEventListener("wheel", uebernahme, { passive: true });
-  window.addEventListener("touchstart", uebernahme, { passive: true });
-  window.addEventListener("keydown", uebernahme);
-}
-
-/* „Mehrheitlich im Sichtfeld": mehr als die halbe Box-Höhe liegt im Fenster.
-   Degenerierte Messwerte (Höhe 0) gelten als sichtbar — im Zweifel lieber
-   ein Ton zu viel als eine stumm gewordene Enthüllung. */
-function imSichtfeld(el) {
-  try {
-    const rechteck = el.getBoundingClientRect();
-    const fensterHoehe = window.innerHeight || document.documentElement.clientHeight || 0;
-    const ueberlappung = Math.min(rechteck.bottom, fensterHoehe) - Math.max(rechteck.top, 0);
-    return ueberlappung >= rechteck.height / 2;
-  } catch (_e) {
-    return true;
-  }
-}
-
-function boxZeigen(el, mein) {
+function boxZeigen(el) {
   if (!el) return;
   el.classList.remove("lv-verdeckt");
   el.classList.add("pop-rein");
-  if (mein.fuehrungAktiv) {
-    /* Führung aktiv: Box sanft ins Sichtfeld holen — erst NACH dem Aufdecken,
-       eine verdeckte Box (display:none) hat keinen Ort, zu dem man scrollen
-       könnte. Der reduzierte Modus scrollt NIE automatisch; die Vorgabe wird
-       frisch gelesen, damit ein Umstellen mitten im Lauf sofort greift. */
-    if (!reduziert() && typeof el.scrollIntoView === "function") {
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
-    }
+  if (fuehrung && fuehrung.aktiv) {
+    /* Führung aktiv: JEDE gepoppte Box wird aktiv zentriert — ab dem ERSTEN
+       Pop (v3.0.3). Erst NACH dem Aufdecken, eine verdeckte Box
+       (display:none) hat keinen Ort, zu dem man scrollen könnte. */
+    sanftZentrieren(el);
     popTon();
     return;
   }
@@ -608,8 +721,9 @@ function abschlussAnzeigen() {
 }
 
 function abschluss(mein) {
-  /* Enthüllungs-Ende: die Übernahme-Wache in jedem Fall sauber abbauen. */
-  fuehrungListenerEntfernen(mein);
+  /* Enthüllungs-Abschluss = Lauf-Ende: die Blick-Führung samt Wache in jedem
+     Fall sauber abbauen (v3.0.3: der Zustand gilt für den ganzen Lauf). */
+  fuehrungBeenden();
   if (mein.stop) return;
   enthuellung = null;
   abschlussAnzeigen();
@@ -630,13 +744,15 @@ export function starteEnthuellung() {
     spinnerVerstecken(lauf);
     lauf = null;
   }
-  if (enthuellung) {
-    enthuellung.stop = true;
-    fuehrungListenerEntfernen(enthuellung);
-  }
-  const mein = { stop: false, fuehrungAktiv: false, uebernahmeListener: null };
+  if (enthuellung) enthuellung.stop = true;
+  const mein = { stop: false };
   enthuellung = mein;
   enthuellungGestartet = true;
+  /* v3.0.3: Die Blick-Führung des Laufs läuft hier einfach WEITER — hat der
+     Nutzer schon während des Tippens übernommen, scrollt auch die Enthüllung
+     nicht mehr. Ohne laufende Führung (direkter Aufruf, Tests) startet sie
+     jetzt. */
+  fuehrungStarten();
 
   karteEntfernen();
   /* Die Ankündigung von eben leeren: Nur so ist der Abschluss-Text am Ende
@@ -678,18 +794,12 @@ export function starteEnthuellung() {
     return;
   }
 
-  /* Geführtes Mitscrollen nur im bewegten Modus — bei reduzierter Bewegung
-     wird NIE automatisch gescrollt (die Enthüllung oben ist dort ohnehin
-     sofort fertig, ganz ohne Effekte). */
-  mein.fuehrungAktiv = true;
-  fuehrungBewachen(mein);
-
   (async () => {
     /* 1) Foto-Daten + Standort. */
     if (!(await warte(700, mein))) return;
-    boxZeigen(privacy, mein);
+    boxZeigen(privacy);
     if (!(await warte(1100, mein))) return;
-    boxZeigen(gps, mein);
+    boxZeigen(gps);
     gpsKarteNachmessen();
     if (!(await warte(1400, mein))) return;
 
@@ -697,25 +807,25 @@ export function starteEnthuellung() {
     for (const kind of faktenKinder) {
       const istKopf = kind.classList.contains("cat-group-head");
       if (!(await warte(istKopf ? 650 : 280, mein))) return;
-      boxZeigen(kind, mein);
+      boxZeigen(kind);
     }
 
     /* 3) Werbung + Manipulation — nur noch ganze, fertige Boxen. */
     if (!(await warte(600, mein))) return;
-    boxZeigen(adsKarte, mein);
+    boxZeigen(adsKarte);
     if (!(await warte(1200, mein))) return;
-    boxZeigen(triggerKarte, mein);
+    boxZeigen(triggerKarte);
     if (!(await warte(1200, mein))) return;
 
     /* 3b) Realitäts-Check (v3.1): direkt nach der Manipulations-Box und VOR
        dem Datenwert — mit demselben Pop wie alle anderen Boxen. */
     if (rcKarte) {
-      boxZeigen(rcKarte, mein);
+      boxZeigen(rcKarte);
       if (!(await warte(1200, mein))) return;
     }
 
     /* 4) Datenwert: Box komplett, nur der Betrag zählt hoch, Balken fahren aus. */
-    boxZeigen(dvKarte, mein);
+    boxZeigen(dvKarte);
     if (dvKarte) {
       balkenAusfahren(dvKarte, false);
       if (dvZahl && !(await betragHochzaehlen(dvZahl, 1200, mein))) return;
@@ -736,7 +846,8 @@ export function enthuellungAbkuerzen() {
   if (!enthuellung) return;
   const mein = enthuellung;
   mein.stop = true;
-  fuehrungListenerEntfernen(mein);
+  /* Abgekürzt heißt beendet: die Blick-Führung des Laufs endet hier mit. */
+  fuehrungBeenden();
   enthuellung = null;
   const e = mein.einheiten || {};
   (e.boxen || []).forEach((el) => el && el.classList.remove("lv-verdeckt"));
@@ -764,9 +875,12 @@ export function abbrechen() {
   }
   if (enthuellung) {
     enthuellung.stop = true;
-    fuehrungListenerEntfernen(enthuellung);
     enthuellung = null;
   }
+  /* Fehler/Abbruch = Lauf-Ende: Blick-Führung samt Übernahme-Wache immer mit
+     abbauen — auch wenn weder getippt noch enthüllt wurde (v3.0.3: die
+     Führung startet schon beim Analyse-Beginn). */
+  fuehrungBeenden();
   enthuellungGestartet = false;
   karteEntfernen();
   allesAufdecken();


### PR DESCRIPTION
Fünf Feinschliffe aus dem Live-Test des Inhabers (11.08. spätabends):

- **Blick-Führung über den ganzen Lauf:** Auge nach Foto-Wahl ins Bild (nur wenn nötig), Live-Karte beim Tipp-Start ins Bild, letzte Zeile bleibt beim Tippen sichtbar (gedrosseltes Nachscrollen, nur nach unten), Enthüllung zentriert jede Box ab dem ersten Pop
- **EIN Übernahme-Zustand pro Analyse-Lauf:** Rad/Touch/Tasten stoppen ALLE automatischen Bewegungen sofort und dauerhaft; reduced-motion scrollt nie; Wiederaufnahme nach Reload ohne Führung
- **Töne +20 %** (Master 0,8 → 0,96)

Tests: 697 / 302 (+14) / 18 (+1), Lint + Format sauber, vier wörtliche Rückbauproben im Bau-Protokoll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)