### PR TITLE
fix: Auge-Nachwache — Layout-Schub der Foto-Vorschau eingefangen

### DIFF
--- a/public/__tests__/live-anzeige.test.js
+++ b/public/__tests__/live-anzeige.test.js
@@ -820,6 +820,36 @@ describe("Live-Anzeige (v3.0)", () => {
     }
   });
 
+  it("Auge-Nachwache: rutscht das Auge NACH der ersten Prüfung aus dem Bild (Foto-Vorschau lädt), holt die Wache es zurück — genau einmal je Episode", async () => {
+    const spy = vi.fn();
+    elements.scanAnim.scrollIntoView = spy;
+    elements.scanAnim.classList.add("active");
+    /* Beim Aufruf steht das Auge noch im Bild — exakt der Handy-Befund. */
+    elements.scanAnim.getBoundingClientRect = imFenster;
+    try {
+      liveAnzeige.fuehrungStarten();
+      liveAnzeige.augeInsBild();
+      await vi.advanceTimersByTimeAsync(850);
+      expect(spy).not.toHaveBeenCalled();
+
+      /* Jetzt lädt die Vorschau fertig und schiebt das Auge unter die
+         Sichtkante. (RUECKBAUPROBE: Ohne die Nachwache bleibt der Spy für
+         immer still — der dreimal durchgerutschte Handy-Fehler.) */
+      elements.scanAnim.getBoundingClientRect = unterDerSichtkante;
+      await vi.advanceTimersByTimeAsync(850);
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      /* Bleibt es (im Test-Mock) „unsichtbar", wird NICHT dauernd weiter
+         gezogen — eine Episode, ein Scroll. */
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      delete elements.scanAnim.scrollIntoView;
+      delete elements.scanAnim.getBoundingClientRect;
+      elements.scanAnim.classList.remove("active");
+    }
+  });
+
   it("v3.0.5 Übernahme: bloßes Antippen (touchstart) beendet die Führung NICHT — erst echtes Wischen (touchmove)", () => {
     const spy = vi.fn();
     elements.scanAnim.scrollIntoView = spy;

--- a/public/js/live-anzeige.js
+++ b/public/js/live-anzeige.js
@@ -303,23 +303,32 @@ function sanftZentrieren(el) {
   }
 }
 
+/* Takt und Dauer der Auge-Nachwache: ~44 s decken jede Scan-Phase ab. */
+const AUGE_WACHE_TAKT_MS = 400;
+const AUGE_WACHE_VERSUCHE_MAX = 110;
+
 /**
- * Holt das Scan-Auge nach der Foto-/Demo-Wahl ins Sichtfeld (api.js ruft das
+ * Hält das Scan-Auge nach der Foto-/Demo-Wahl im Sichtfeld (api.js ruft das
  * beim Analyse-Beginn, direkt nach fuehrungStarten). Grund (User, 11.08.
  * abends): „Am Handy sieht man das Foto, aber nicht, dass etwas passiert."
- * NUR wenn das Auge nicht ohnehin mehrheitlich sichtbar ist — auf dem
- * Desktop, wo es längst im Bild steht, darf sich NICHTS bewegen.
+ *
+ * WICHTIG — eine Einmal-Prüfung genügt NICHT (Innenleben-Protokoll 11.08.
+ * spätabends): Beim Aufruf steht das Auge oft noch im Bild (top≈518), dann
+ * lädt die Foto-Vorschau asynchron fertig, das Layout wächst und schiebt das
+ * Auge unter die Sichtkante (top≈783+) — und niemand schaute mehr hin. Genau
+ * so blieb der Handy-Scroll dreimal aus. Deshalb WACHT diese Funktion bis
+ * zum Tipp-Start: alle AUGE_WACHE_TAKT_MS prüfen, und je „aus dem Bild
+ * gerutscht"-Episode genau EIN sanfter Scroll (kein Dauer-Ziehen — erst wenn
+ * das Auge zwischendurch wieder sichtbar war, darf erneut gescrollt werden).
+ * Nutzer-Übernahme (Wischen/Rad/Tasten) beendet die Wache sofort; übernimmt
+ * die Live-Karte (Tippen), ist die Wache fertig. Desktop, Auge dauerhaft im
+ * Bild: es bewegt sich weiterhin NICHTS.
  */
-export function augeInsBild(versuch = 0) {
+export function augeInsBild(versuch = 0, zustand = { gescrollt: false }) {
   if (!fuehrungAktiv()) return;
+  /* Tipp-Phase erreicht: Ab hier führen Karte und Tipp-Nachscrollen. */
+  if (elements.liveKarte && elements.liveKarte.classList.contains("active")) return;
   const auge = elements.scanAnim;
-  /* v3.0.5 (Handy-Befund 11.08., 18:15): Beim Analyse-Start ist das Auge oft
-     noch gar nicht aufgebaut (ohne .active, Höhe 0) — und ein Null-Höhen-
-     Element gilt der Sichtfeld-Regel als „sichtbar" (0 ≥ 0), der Scroll
-     unterblieb kommentarlos. Deshalb: erst NACHFASSEN, bis das Auge wirklich
-     steht (aktiv UND gemessene Höhe), dann genau einmal anfahren. Bricht der
-     Nutzer die Führung ab, sterben auch die Nachfass-Versuche (fuehrungAktiv
-     wird je Versuch frisch geprüft). */
   const steht = (() => {
     try {
       return !!auge && auge.classList.contains("active") && auge.getBoundingClientRect().height > 0;
@@ -327,12 +336,17 @@ export function augeInsBild(versuch = 0) {
       return false;
     }
   })();
-  if (!steht) {
-    if (versuch < 10) setTimeout(() => augeInsBild(versuch + 1), 200);
-    return;
+  if (steht) {
+    if (imSichtfeld(auge)) {
+      zustand.gescrollt = false;
+    } else if (!zustand.gescrollt) {
+      sanftZentrieren(auge);
+      zustand.gescrollt = true;
+    }
   }
-  if (imSichtfeld(auge)) return;
-  sanftZentrieren(auge);
+  if (versuch < AUGE_WACHE_VERSUCHE_MAX) {
+    setTimeout(() => augeInsBild(versuch + 1, zustand), AUGE_WACHE_TAKT_MS);
+  }
 }
 
 /* Tipp-Nachscrollen (v3.0.3): hält die letzte getippte Zeile im Bild. Nur


### PR DESCRIPTION
Innenleben-Protokoll (Live-Seite, iPhone-Maße, echter Upload) zeigte die Wurzel des dreimal durchgerutschten Handy-Befunds: Beim augeInsBild-Aufruf steht das Auge noch im Bild (top≈518) — DANACH lädt die Foto-Vorschau fertig und schiebt es unter die Sichtkante (top≈783+); die Einmal-Prüfung sah das nie.

Fix: augeInsBild ist jetzt eine Nachwache bis zum Tipp-Start (400-ms-Takt, ~44 s Deckel): je „aus dem Bild gerutscht"-Episode genau EIN sanfter Scroll; Auge wieder sichtbar = Episode zu Ende. Nutzer-Übernahme beendet die Wache sofort; aktive Live-Karte ebenso; Desktop mit dauerhaft sichtbarem Auge bewegt sich weiterhin nicht.

Beweis VOR dem Merge: Live-Simulation mit lokal untergeschobenem Fix — scrollY 0→461 in ~1 s, Auge zentriert (top 322). Neuer Test „Layout-Schub…" als Rückbauprobe. Frontend 305/305, lint:frontend sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
