### PR TITLE
fix: KURZAUDIT-Sanierung — Zähler-Härtung, Live-Text-Verankerung, Release-Wächter, Feinschliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ on:
     paths: ["CHANGELOG.md"]
   workflow_dispatch: {}
 
+# KA-03: Nie zwei Release-Laeufe gleichzeitig — zwei schnelle CHANGELOG-Pushes
+# koennten sich sonst beim Loeschen/Anlegen von Tag und Release ueberholen.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -53,14 +59,36 @@ jobs:
               exit 0
             fi
             TAG_SHA="$(git rev-parse --verify --quiet "refs/tags/$TAG^{commit}" || echo "")"
-            if [ -n "$TAG_SHA" ] && [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
-              echo "Nummer $VERSION wird wiederverwendet — Tag und Release werden auf diesen Stand umgehaengt."
-              gh release delete "$TAG" --yes
-              git push origin ":refs/tags/$TAG"
-            else
+            if [ -n "$TAG_SHA" ] && [ "$TAG_SHA" = "$GITHUB_SHA" ]; then
               echo "Release $TAG existiert bereits und zeigt auf diesen Stand — nichts zu tun."
               exit 0
             fi
+            # KA-03 (Kurzaudit 2026-08-12), zwei Haertungen:
+            #  1. Der alte Tag-Zeiger wird VOR jeder Loeschung protokolliert —
+            #     die einzige dauerhafte Spur, wohin die Nummer vorher zeigte
+            #     (Unfall- und Missbrauchs-Nachweis im Workflow-Log).
+            #  2. Reihenfolge gedreht: ERST der Tag, DANN der Release. Bricht
+            #     der Lauf dazwischen ab, bleibt "Tag weg, Release verwaist" —
+            #     dieser Zweig hier raeumt das beim naechsten Lauf von selbst
+            #     auf (TAG_SHA ist dann leer). Die alte Reihenfolge liess
+            #     stattdessen "Release weg, Tag zeigt auf alt" zurueck — und
+            #     ein Folgelauf haette den neuen Release still auf den ALTEN
+            #     Tag-Zeiger gelegt (gh ignoriert --target bei vorhandenem
+            #     Tag): exakt die OPS-002-Falle.
+            echo "Nummer $VERSION wird wiederverwendet — alter Tag-Zeiger: ${TAG_SHA:-<Tag fehlt bereits, nur verwaister Release>}"
+            if [ -n "$TAG_SHA" ]; then
+              git push origin ":refs/tags/$TAG"
+            fi
+            gh release delete "$TAG" --yes
+          fi
+          # KA-03, Wache vor dem Anlegen: Existiert der Tag auf origin noch
+          # (halber Durchlauf einer aelteren Workflow-Version, manuell
+          # angelegter Tag), wuerde `gh release create` das --target ignorieren
+          # und den Release-Text auf einen fremden Stand heften. Dann lieber
+          # laut scheitern — der Lauf ist gefahrlos wiederholbar.
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "FEHLER: Tag $TAG existiert noch auf origin, aber kein Release dazu passt zu diesem Stand — Abbruch statt Release auf falschen Zeiger. Tag pruefen/loeschen und Workflow erneut starten."
+            exit 1
           fi
           # Release-Notizen = der Abschnitt genau dieser Version
           awk -v v="## [$VERSION]" '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [3.0.2] — 2026-08-11
+
+Sanierung nach dem Kurzaudit des v3-Tags (unabhängige Prüfung von Code und
+Infrastruktur, Prüfstand 79ec393). Kein neues Feature — vier Härtungen und
+etwas Feinschliff:
+
+**Der anonyme Realitäts-Check-Zähler ist jetzt flutungssicher**
+
+- Die öffentliche Vergleichszahl („so gut lagen alle anderen") zählt eine
+  Stimme nur noch gegen ein Einmal-Ticket, das der Server bei der ersten
+  Auslieferung eines echten Ergebnisses ausgibt und beim Zählen entwertet —
+  eine echte Analyse, höchstens eine Stimme. Vorher hätte ein simples Skript
+  den Wert beliebig verstellen können. An der Anonymität ändert sich nichts:
+  Das Ticket ist ein bedeutungsloser Zufallswert, gespeichert wird weiterhin
+  ausschließlich die Selbsteinschätzung selbst; in der Datenbank liegt nur
+  ein Hash, und geloggt wird das Ticket nie.
+
+**Live-Text: Zuordnung abgesichert**
+
+- Der Live-Text-Strom verlässt sich nicht mehr auf die bloße Reihenfolge
+  der Profiltexte in der Modell-Antwort, sondern verankert jeden Text an
+  seinem Modus-Block („standard"/„beast"). Selbst wenn das Modell die Blöcke
+  je vertauschen sollte, kann der harte Beast-Text nie kurz als normales
+  Profil erscheinen.
+
+**Release-Automatik abbruchfest**
+
+- Der Release-Wächter protokolliert vor jedem Umhängen einer wiederverwendeten
+  Versionsnummer den alten Tag-Zeiger, löscht in verwechslungssicherer
+  Reihenfolge (erst Tag, dann Release), verweigert das Anlegen auf einen
+  fremden Tag-Zeiger und lässt keine zwei Läufe mehr parallel zu — ein halber
+  Durchlauf kann Tag und CHANGELOG nicht mehr auseinanderreißen.
+
+**Feinschliff**
+
+- Die Einordnung „Die KI-Profile sind erfunden … nichts davon ist wahr oder
+  bewiesen" steht am Bildschirm jetzt VOR der Foto-Wahl statt erst darunter
+  (im Druck stand sie schon immer oben).
+- Die Auge-Nachwache der Blick-Führung ist an ihren Analyse-Lauf gebunden:
+  Startet blitzschnell eine neue Analyse, kann keine alte Wache-Kette mehr
+  parallel weiterticken.
+- Bei Mistral-Überlastantworten (429) wird der ungenutzte Antwortrumpf sofort
+  verworfen statt bis zur Speicherbereinigung offen zu bleiben.
+- Veraltete „6 Anfragen/Sekunde"-Kommentare (Mai-Stand) im Code durch die
+  heutige Tier-Wahrheit ersetzt (Stufen-System, aktuell 0,25 Anfragen/s);
+  ein neues Skript legt die Analyse-Messwerte für die September-Auswertungen
+  30 Tage statt 1 Tag in den anonymen Diagnose-Speicher.
+
 ## [3.0.1] — 2026-08-11
 
 Feinschliff-Sammlung nach den Live-Tests des v3.0-Starts — Dramaturgie,

--- a/e2e/start-ohne-hinweis.test.js
+++ b/e2e/start-ohne-hinweis.test.js
@@ -76,6 +76,19 @@ test("Start ohne Hinweis-Pop-up: Demo-Wahl startet die Analyse direkt, kein Dial
   await expect(page.locator("#disclaimerModal")).toHaveCount(0);
   await expect(page.locator("#disclaimerConfirm")).toHaveCount(0);
 
+  /* KA-08 (Kurzaudit 2026-08-12): Der modallose Start ist nur sauber, wenn
+     die Einordnung VOR der Foto-Wahl sichtbar ist — „nichts davon ist wahr"
+     muss am Bildschirm ÜBER dem Upload stehen, nicht erst darunter. */
+  const einordnung = page.locator(".disclaimer--einordnung");
+  await expect(einordnung).toBeVisible();
+  await expect(einordnung).toContainText(/nichts davon ist wahr|none of it is true/);
+  const liegtUeberDemUpload = await page.evaluate(() => {
+    const einordnungBox = document.querySelector(".disclaimer--einordnung").getBoundingClientRect();
+    const uploadBox = document.querySelector(".upload-section").getBoundingClientRect();
+    return einordnungBox.bottom <= uploadBox.top;
+  });
+  expect(liegtUeberDemUpload).toBe(true);
+
   /* 1. Demo-Wahl → die Analyse startet SOFORT (Scan-Animation mit
      Upload-Text ab der ersten Sekunde), ohne dass irgendein Dialog
      dazwischen bestätigt werden müsste. */

--- a/functions/src/__tests__/handle-job-status.test.js
+++ b/functions/src/__tests__/handle-job-status.test.js
@@ -154,7 +154,9 @@ describe("handleJobStatus — Auslieferungs-Messung", () => {
     });
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, makeRes());
-    expect(jobs.markDelivered).toHaveBeenCalledWith("job-1");
+    /* KA-02: Mit der Erstauslieferung wird der HASH des Realitäts-Check-
+       Einmal-Tickets abgelegt (64 Hex-Zeichen = SHA-256, nie das Ticket). */
+    expect(jobs.markDelivered).toHaveBeenCalledWith("job-1", expect.stringMatching(/^[0-9a-f]{64}$/));
     const delivered = logSpy.mock.calls
       .map((c) => {
         try {
@@ -180,6 +182,49 @@ describe("handleJobStatus — Auslieferungs-Messung", () => {
       deliveredAt: 9999,
     });
     await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, makeRes());
+    expect(jobs.markDelivered).not.toHaveBeenCalled();
+  });
+});
+
+/* ── KA-02 (Kurzaudit 2026-08-12): Realitäts-Check-Einmal-Ticket ── */
+
+describe("handleJobStatus — KA-02 Realitäts-Check-Ticket", () => {
+  const doneJob = (extra = {}) => ({
+    id: "job-1",
+    status: "done",
+    result: { x: 1 },
+    resultToken: "ticket-abc",
+    createdAt: 1000,
+    finishedAt: 5000,
+    ...extra,
+  });
+
+  test("Erstauslieferung: Antwort trägt rcTicket, im Job landet exakt dessen SHA-256-Hash", async () => {
+    jobs.getJob.mockResolvedValue(doneJob());
+    const res = makeRes();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, res);
+    logSpy.mockRestore();
+    expect(typeof res.body.rcTicket).toBe("string");
+    expect(res.body.rcTicket.length).toBeGreaterThan(0);
+    const { sha256Hex } = require("../auth");
+    expect(jobs.markDelivered).toHaveBeenCalledWith("job-1", sha256Hex(res.body.rcTicket));
+  });
+
+  test("wiederholter Abruf (deliveredAt gesetzt): KEIN neues rcTicket — es gibt genau eins je Analyse", async () => {
+    jobs.getJob.mockResolvedValue(doneJob({ deliveredAt: 9999 }));
+    const res = makeRes();
+    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, res);
+    expect(res.body.status).toBe("done");
+    expect(res.body.rcTicket).toBeUndefined();
+  });
+
+  test("falsches Abhol-Ticket: weder Ergebnis noch rcTicket — dieselbe PRIV-003-Schranke", async () => {
+    jobs.getJob.mockResolvedValue(doneJob());
+    const res = makeRes();
+    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "falsch" } }, res);
+    expect(res.body.result).toBeNull();
+    expect(res.body.rcTicket).toBeUndefined();
     expect(jobs.markDelivered).not.toHaveBeenCalled();
   });
 });

--- a/functions/src/__tests__/handle-telemetry-realitaets-check.test.js
+++ b/functions/src/__tests__/handle-telemetry-realitaets-check.test.js
@@ -3,10 +3,17 @@
 /* Realitäts-Check (v3.1): Der Telemetrie-Endpunkt nimmt für das Ereignis
    `realitaets-check` AUSSCHLIESSLICH die Kategorie-Stufen an. Alles andere
    (falsche Schlüssel, falsche Werte, verknüpfbare Felder) wird verworfen —
-   die Privacy-Zusage hängt an genau dieser Strenge. */
+   die Privacy-Zusage hängt an genau dieser Strenge.
+
+   KA-02 (Kurzaudit 2026-08-12): Gezählt wird nur noch gegen ein gültiges
+   Einmal-Ticket aus einer echten Analyse — der Zähler war vorher von außen
+   flutbar (In-Memory-IP-Limit je Function-Instanz, Aggregat ohne Rückweg). */
 
 jest.mock("../counter");
+jest.mock("../jobs");
 const { zaehleRealitaetsCheck } = require("../counter");
+const { verbraucheRcTicket } = require("../jobs");
+const { sha256Hex } = require("../auth");
 const { handleTelemetry } = require("../handle-telemetry");
 
 function mockRes() {
@@ -38,12 +45,20 @@ function gueltigeStufen() {
   return { alter: 1, geschlecht: 0, interessen: 0.5, charakter: 0.5, werbung: 1, manipulation: 0 };
 }
 
+/* KA-02: Ein gültiges Einmal-Ticket gehört seit dem Kurzaudit zu jeder
+   zählenden Einreichung — die Alt-Tests schicken es deshalb mit. */
+const TICKET = "test-rc-ticket-1234";
+function gueltigerBody(extra = {}) {
+  return { eventType: "realitaets-check", stufen: gueltigeStufen(), ticket: TICKET, ...extra };
+}
+
 describe("handleTelemetry — Ereignis realitaets-check", () => {
   let logSpy;
 
   beforeEach(() => {
     jest.clearAllMocks();
     zaehleRealitaetsCheck.mockResolvedValue(undefined);
+    verbraucheRcTicket.mockResolvedValue(true);
     logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
   });
 
@@ -58,7 +73,7 @@ describe("handleTelemetry — Ereignis realitaets-check", () => {
 
   test("gültige Stufen (6 Zeilen): 204, Aggregat wird mit serverseitig berechnetem Score erhöht", async () => {
     const res = mockRes();
-    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen: gueltigeStufen() }), res);
+    await handleTelemetry(mockReq(gueltigerBody()), res);
     expect(res.statusCode).toBe(204);
     /* (1 + 0 + 0,5 + 0,5 + 1 + 0) / 6 = 0,5 → 50 */
     expect(zaehleRealitaetsCheck).toHaveBeenCalledTimes(1);
@@ -68,7 +83,7 @@ describe("handleTelemetry — Ereignis realitaets-check", () => {
   test("gültige Stufen OHNE Geschlecht (Weglass-Fall): Score aus 5 Zeilen", async () => {
     const res = mockRes();
     const stufen = { alter: 1, interessen: 1, charakter: 1, werbung: 1, manipulation: 0.5 };
-    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen }), res);
+    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen, ticket: TICKET }), res);
     expect(res.statusCode).toBe(204);
     /* 4,5 / 5 = 0,9 → 90 */
     expect(zaehleRealitaetsCheck).toHaveBeenCalledWith(90);
@@ -78,14 +93,14 @@ describe("handleTelemetry — Ereignis realitaets-check", () => {
     const res = mockRes();
     /* Ein mitgeschickter score wäre ein fremder Schlüssel im BODY (nicht in
        stufen) — die Stufen zählen, der Behauptung wird nicht gefolgt. */
-    await handleTelemetry(mockReq({ eventType: "realitaets-check", score: 100, stufen: gueltigeStufen() }), res);
+    await handleTelemetry(mockReq(gueltigerBody({ score: 100 })), res);
     expect(zaehleRealitaetsCheck).toHaveBeenCalledWith(50);
   });
 
   test("fremder Schlüssel in stufen → komplett verworfen, kein Inkrement, kein Log", async () => {
     const res = mockRes();
     const stufen = { ...gueltigeStufen(), einkommen: 1 };
-    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen }), res);
+    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen, ticket: TICKET }), res);
     expect(res.statusCode).toBe(204);
     expect(zaehleRealitaetsCheck).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalled();
@@ -94,7 +109,7 @@ describe("handleTelemetry — Ereignis realitaets-check", () => {
   test("unerlaubter Stufen-Wert (0,7) → verworfen, kein Inkrement", async () => {
     const res = mockRes();
     const stufen = { ...gueltigeStufen(), interessen: 0.7 };
-    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen }), res);
+    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen, ticket: TICKET }), res);
     expect(res.statusCode).toBe(204);
     expect(zaehleRealitaetsCheck).not.toHaveBeenCalled();
   });
@@ -102,7 +117,7 @@ describe("handleTelemetry — Ereignis realitaets-check", () => {
   test("Geschlecht ist binär — 0,5 dort ist ungültig und verwirft alles", async () => {
     const res = mockRes();
     const stufen = { ...gueltigeStufen(), geschlecht: 0.5 };
-    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen }), res);
+    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen, ticket: TICKET }), res);
     expect(zaehleRealitaetsCheck).not.toHaveBeenCalled();
   });
 
@@ -110,14 +125,14 @@ describe("handleTelemetry — Ereignis realitaets-check", () => {
     const res = mockRes();
     const stufen = gueltigeStufen();
     delete stufen.manipulation;
-    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen }), res);
+    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen, ticket: TICKET }), res);
     expect(zaehleRealitaetsCheck).not.toHaveBeenCalled();
   });
 
   test("stufen fehlt oder ist kein Objekt → verworfen", async () => {
     for (const stufen of [undefined, null, "alter=1", 42, [1, 0.5, 0]]) {
       const res = mockRes();
-      await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen }), res);
+      await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen, ticket: TICKET }), res);
       expect(res.statusCode).toBe(204);
     }
     expect(zaehleRealitaetsCheck).not.toHaveBeenCalled();
@@ -126,7 +141,7 @@ describe("handleTelemetry — Ereignis realitaets-check", () => {
   test('String-Werte statt Zahlen ("1") → verworfen, kein Inkrement', async () => {
     const res = mockRes();
     const stufen = { ...gueltigeStufen(), alter: "1" };
-    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen }), res);
+    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen, ticket: TICKET }), res);
     expect(zaehleRealitaetsCheck).not.toHaveBeenCalled();
   });
 
@@ -136,6 +151,7 @@ describe("handleTelemetry — Ereignis realitaets-check", () => {
       mockReq({
         eventType: "realitaets-check",
         stufen: gueltigeStufen(),
+        ticket: TICKET,
         traceId: "trace-123",
         jobId: "job-456",
         userAgent: "Mozilla/5.0",
@@ -157,7 +173,7 @@ describe("handleTelemetry — Ereignis realitaets-check", () => {
   test("Fehler beim Zählen wird still geschluckt — die Antwort bleibt 204", async () => {
     zaehleRealitaetsCheck.mockRejectedValue(new Error("Firestore weg"));
     const res = mockRes();
-    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen: gueltigeStufen() }), res);
+    await handleTelemetry(mockReq(gueltigerBody()), res);
     expect(res.statusCode).toBe(204);
     expect(res.ended).toBe(true);
   });
@@ -169,5 +185,88 @@ describe("handleTelemetry — Ereignis realitaets-check", () => {
     expect(zaehleRealitaetsCheck).not.toHaveBeenCalled();
     const ereignis = geloggtesEreignis();
     expect(ereignis.eventType).toBe("analyze-success");
+  });
+});
+
+/* ── KA-02 (Kurzaudit 2026-08-12): das Einmal-Ticket ─────────────── */
+
+describe("handleTelemetry — KA-02 Einmal-Ticket", () => {
+  let logSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    zaehleRealitaetsCheck.mockResolvedValue(undefined);
+    verbraucheRcTicket.mockResolvedValue(true);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  test("das Ticket wird GEHASHT entwertet — nie im Klartext an die Datenbank gereicht", async () => {
+    await handleTelemetry(mockReq(gueltigerBody()), mockRes());
+    expect(verbraucheRcTicket).toHaveBeenCalledTimes(1);
+    expect(verbraucheRcTicket).toHaveBeenCalledWith(sha256Hex(TICKET));
+  });
+
+  test("OHNE Ticket: 204, aber kein Inkrement und kein Log — die Flutungs-Lücke ist zu", async () => {
+    const res = mockRes();
+    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen: gueltigeStufen() }), res);
+    expect(res.statusCode).toBe(204);
+    expect(verbraucheRcTicket).not.toHaveBeenCalled();
+    expect(zaehleRealitaetsCheck).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  test("ungültiges/verbrauchtes Ticket (Entwertung schlägt fehl): kein Inkrement, kein Log", async () => {
+    verbraucheRcTicket.mockResolvedValue(false);
+    const res = mockRes();
+    await handleTelemetry(mockReq(gueltigerBody()), res);
+    expect(res.statusCode).toBe(204);
+    expect(zaehleRealitaetsCheck).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  test("zweite Einreichung mit demselben Ticket zählt nicht (Entwertung meldet false)", async () => {
+    await handleTelemetry(mockReq(gueltigerBody()), mockRes());
+    verbraucheRcTicket.mockResolvedValue(false); /* real: Transaktion sieht den Hash nicht mehr */
+    await handleTelemetry(mockReq(gueltigerBody()), mockRes());
+    expect(zaehleRealitaetsCheck).toHaveBeenCalledTimes(1);
+  });
+
+  test("ungültige Stufen verbrennen KEIN Ticket (erst Stufen prüfen, dann entwerten)", async () => {
+    const stufen = { ...gueltigeStufen(), interessen: 0.7 };
+    await handleTelemetry(mockReq({ eventType: "realitaets-check", stufen, ticket: TICKET }), mockRes());
+    expect(verbraucheRcTicket).not.toHaveBeenCalled();
+  });
+
+  test("absurd langes 'Ticket' (>100 Zeichen) gilt als fehlend — nichts wird gehasht oder gezählt", async () => {
+    await handleTelemetry(mockReq(gueltigerBody({ ticket: "x".repeat(101) })), mockRes());
+    expect(verbraucheRcTicket).not.toHaveBeenCalled();
+    expect(zaehleRealitaetsCheck).not.toHaveBeenCalled();
+  });
+
+  test("Nicht-String-Ticket (Objekt/Zahl) gilt als fehlend", async () => {
+    for (const ticket of [42, { x: 1 }, ["a"], true]) {
+      await handleTelemetry(mockReq(gueltigerBody({ ticket })), mockRes());
+    }
+    expect(verbraucheRcTicket).not.toHaveBeenCalled();
+  });
+
+  test("das Ticket landet NIE im Log-Ereignis", async () => {
+    await handleTelemetry(mockReq(gueltigerBody()), mockRes());
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const ereignis = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(ereignis.ticket).toBeUndefined();
+    expect(JSON.stringify(ereignis)).not.toContain(TICKET);
+  });
+
+  test("Firestore-Schluckauf beim Entwerten (Rejection): fail-closed, Antwort bleibt 204", async () => {
+    verbraucheRcTicket.mockRejectedValue(new Error("Firestore weg"));
+    const res = mockRes();
+    await handleTelemetry(mockReq(gueltigerBody()), res);
+    expect(res.statusCode).toBe(204);
+    expect(zaehleRealitaetsCheck).not.toHaveBeenCalled();
   });
 });

--- a/functions/src/__tests__/jobs-rc-ticket.test.js
+++ b/functions/src/__tests__/jobs-rc-ticket.test.js
@@ -1,0 +1,144 @@
+"use strict";
+
+/* KA-02 (Kurzaudit 2026-08-12): Tests fuer das Realitaets-Check-Einmal-Ticket
+   in jobs.js — markDelivered legt den Hash ab, verbraucheRcTicket entwertet
+   ihn in einer Transaktion. In-Memory-Firestore-Mock wie jobs-livetext, hier
+   zusaetzlich mit where()/limit()/get() und runTransaction. */
+
+const mockStore = new Map();
+
+jest.mock("firebase-admin/firestore", () => {
+  function docRef(id) {
+    return {
+      id,
+      async set(data) {
+        mockStore.set(id, { ...data });
+      },
+      async get() {
+        const data = mockStore.get(id);
+        return { exists: data !== undefined, id, data: () => data, ref: docRef(id) };
+      },
+      async update(patch) {
+        const cur = mockStore.get(id);
+        if (cur === undefined) throw new Error("update on missing doc");
+        mockStore.set(id, { ...cur, ...patch });
+      },
+    };
+  }
+  function query(feld, wert) {
+    return {
+      limit() {
+        return this;
+      },
+      async get() {
+        const docs = [];
+        for (const [id, data] of mockStore) {
+          if (data[feld] === wert) {
+            docs.push({ id, exists: true, data: () => data, ref: docRef(id) });
+          }
+        }
+        return { empty: docs.length === 0, docs };
+      },
+    };
+  }
+  return {
+    getFirestore: () => ({
+      collection() {
+        return {
+          doc(id) {
+            return docRef(id);
+          },
+          where(feld, op, wert) {
+            return query(feld, wert);
+          },
+        };
+      },
+      async runTransaction(fn) {
+        /* Der Mock ist single-threaded — get/update laufen direkt gegen den
+           Store; genau das braucht die Doppel-Entwertungs-Probe unten. */
+        return fn({
+          get: (ref) => ref.get(),
+          update: (ref, patch) => {
+            const cur = mockStore.get(ref.id);
+            if (cur === undefined) throw new Error("update on missing doc");
+            mockStore.set(ref.id, { ...cur, ...patch });
+          },
+        });
+      },
+    }),
+  };
+});
+
+const jobs = require("../jobs");
+const { sha256Hex } = require("../auth");
+
+beforeEach(() => {
+  mockStore.clear();
+});
+
+describe("markDelivered — legt den Ticket-Hash mit ab", () => {
+  test("mit Hash: deliveredAt UND rcTicketHash landen im Dokument", async () => {
+    mockStore.set("job-1", { status: "done" });
+    const hash = sha256Hex("mein-ticket");
+    await jobs.markDelivered("job-1", hash);
+    const doc = mockStore.get("job-1");
+    expect(typeof doc.deliveredAt).toBe("number");
+    expect(doc.rcTicketHash).toBe(hash);
+    /* Das Ticket selbst steht NIE im Dokument. */
+    expect(JSON.stringify(doc)).not.toContain("mein-ticket");
+  });
+
+  test("ohne Hash (alter Aufrufstil): nur deliveredAt — kein leeres Hash-Feld", async () => {
+    mockStore.set("job-1", { status: "done" });
+    await jobs.markDelivered("job-1");
+    const doc = mockStore.get("job-1");
+    expect(typeof doc.deliveredAt).toBe("number");
+    expect("rcTicketHash" in doc).toBe(false);
+  });
+});
+
+describe("verbraucheRcTicket — genau eine Stimme je Analyse", () => {
+  test("gueltiger Hash: true, und der Hash ist danach entwertet (null)", async () => {
+    const hash = sha256Hex("ticket-a");
+    mockStore.set("job-1", { status: "done", rcTicketHash: hash });
+    await expect(jobs.verbraucheRcTicket(hash)).resolves.toBe(true);
+    expect(mockStore.get("job-1").rcTicketHash).toBeNull();
+  });
+
+  test("zweite Entwertung desselben Hashes: false — die Suche findet null nie wieder", async () => {
+    const hash = sha256Hex("ticket-a");
+    mockStore.set("job-1", { status: "done", rcTicketHash: hash });
+    await expect(jobs.verbraucheRcTicket(hash)).resolves.toBe(true);
+    await expect(jobs.verbraucheRcTicket(hash)).resolves.toBe(false);
+  });
+
+  test("unbekannter Hash: false, nichts veraendert", async () => {
+    mockStore.set("job-1", { status: "done", rcTicketHash: sha256Hex("echt") });
+    await expect(jobs.verbraucheRcTicket(sha256Hex("geraten"))).resolves.toBe(false);
+    expect(mockStore.get("job-1").rcTicketHash).toBe(sha256Hex("echt"));
+  });
+
+  test("leerer/nicht-string Hash: false ohne Datenbank-Suche", async () => {
+    await expect(jobs.verbraucheRcTicket("")).resolves.toBe(false);
+    await expect(jobs.verbraucheRcTicket(null)).resolves.toBe(false);
+    await expect(jobs.verbraucheRcTicket(undefined)).resolves.toBe(false);
+  });
+
+  test("Job vom Reaper geloescht (PRIV-107b), Ticket kommt zu spaet: false statt Fehler", async () => {
+    const hash = sha256Hex("ticket-a");
+    mockStore.set("job-1", { status: "done", rcTicketHash: hash });
+    mockStore.delete("job-1"); /* 15-Minuten-Frist abgelaufen, Dokument weg */
+    await expect(jobs.verbraucheRcTicket(hash)).resolves.toBe(false);
+  });
+
+  test("Hash aendert sich zwischen Suche und Transaktion (Doppel-Einreichung): die Transaktion prueft erneut", async () => {
+    const hash = sha256Hex("ticket-a");
+    mockStore.set("job-1", { status: "done", rcTicketHash: hash });
+    /* Die parallele Einreichung hat gewonnen und den Hash schon entwertet —
+       nachgestellt ueber ein bereits-null-Feld mit noch auffindbarem Job:
+       Die Query unten findet nichts mehr, die Transaktions-Pruefung
+       (doc.data().rcTicketHash !== hash) waere die zweite Verteidigung. */
+    mockStore.set("job-1", { status: "done", rcTicketHash: null });
+    await expect(jobs.verbraucheRcTicket(hash)).resolves.toBe(false);
+  });
+});

--- a/functions/src/__tests__/mistral-livetext.test.js
+++ b/functions/src/__tests__/mistral-livetext.test.js
@@ -43,8 +43,9 @@ afterAll(() => {
 /* ── 1. Extraktor: _extrahiereLiveText ───────────────────────────── */
 
 /* Seit Phase 3 liefert der Extraktor BEIDE Texte: { standard, beast } —
-   standard = 1. Vorkommen von "profileText", beast = 2. Vorkommen; jeweils
-   null, solange der Wert noch nicht begonnen hat. */
+   seit KA-11 (Kurzaudit 2026-08-12) VERANKERT am jeweiligen Modus-Schluessel
+   ("standard"/"beast") statt an der blossen Reihenfolge der Vorkommen;
+   jeweils null, solange der Wert noch nicht begonnen hat. */
 const NICHTS = { standard: null, beast: null };
 
 describe("extrahiereLiveText — Feld noch nicht begonnen", () => {
@@ -105,7 +106,7 @@ describe("extrahiereLiveText — normale Faelle", () => {
   });
 
   test("Umlaute und Emojis als rohe Zeichen bleiben erhalten", () => {
-    expect(_extrahiereLiveText('{"profileText": "Grüße aus Österreich 🎉 und weiter').standard).toBe(
+    expect(_extrahiereLiveText('{"standard": {"profileText": "Grüße aus Österreich 🎉 und weiter').standard).toBe(
       "Grüße aus Österreich 🎉 und weiter"
     );
   });
@@ -113,37 +114,38 @@ describe("extrahiereLiveText — normale Faelle", () => {
 
 describe("extrahiereLiveText — Escapes", () => {
   test("Escapes werden zu echten Zeichen dekodiert", () => {
-    const praefix = '{"profileText": "Er sagt \\"Hallo\\" und macht\\neinen Umbruch\\tmit Tab und \\\\ Backslash';
+    const praefix =
+      '{"standard": {"profileText": "Er sagt \\"Hallo\\" und macht\\neinen Umbruch\\tmit Tab und \\\\ Backslash';
     expect(_extrahiereLiveText(praefix).standard).toBe(
       'Er sagt "Hallo" und macht\neinen Umbruch\tmit Tab und \\ Backslash'
     );
   });
 
   test("\\uXXXX-Escapes werden aufgeloest — auch Emoji-Surrogatpaare", () => {
-    const praefix = '{"profileText": "Umlaut \\u00e4, Gedankenstrich \\u2014, Emoji \\ud83d\\ude00!"';
+    const praefix = '{"standard": {"profileText": "Umlaut \\u00e4, Gedankenstrich \\u2014, Emoji \\ud83d\\ude00!"';
     expect(_extrahiereLiveText(praefix).standard).toBe("Umlaut ä, Gedankenstrich —, Emoji 😀!");
   });
 
   test('Praefix endet mitten in \\" — der nackte Backslash wird abgeschnitten', () => {
-    expect(_extrahiereLiveText('{"profileText": "Zitat: \\').standard).toBe("Zitat: ");
+    expect(_extrahiereLiveText('{"standard": {"profileText": "Zitat: \\').standard).toBe("Zitat: ");
   });
 
   test("Praefix endet mitten in \\u00 — das halbe Escape wird abgeschnitten", () => {
-    expect(_extrahiereLiveText('{"profileText": "Etwa 25\\u00').standard).toBe("Etwa 25");
-    expect(_extrahiereLiveText('{"profileText": "Etwa 25\\u').standard).toBe("Etwa 25");
-    expect(_extrahiereLiveText('{"profileText": "Etwa 25\\u00b').standard).toBe("Etwa 25");
+    expect(_extrahiereLiveText('{"standard": {"profileText": "Etwa 25\\u00').standard).toBe("Etwa 25");
+    expect(_extrahiereLiveText('{"standard": {"profileText": "Etwa 25\\u').standard).toBe("Etwa 25");
+    expect(_extrahiereLiveText('{"standard": {"profileText": "Etwa 25\\u00b').standard).toBe("Etwa 25");
   });
 
   test("ein komplettes \\uXXXX am Praefix-Ende bleibt erhalten", () => {
-    expect(_extrahiereLiveText('{"profileText": "25\\u00b0').standard).toBe("25°");
+    expect(_extrahiereLiveText('{"standard": {"profileText": "25\\u00b0').standard).toBe("25°");
   });
 
   test("einsame hohe Surrogathälfte am Ende (halbes Emoji) wird abgeschnitten", () => {
-    expect(_extrahiereLiveText('{"profileText": "Feier \\ud83d').standard).toBe("Feier ");
+    expect(_extrahiereLiveText('{"standard": {"profileText": "Feier \\ud83d').standard).toBe("Feier ");
   });
 
   test("ein escaptes Anfuehrungszeichen beendet den Wert NICHT", () => {
-    expect(_extrahiereLiveText('{"profileText": "Er sagt \\"Servus\\" und geht').standard).toBe(
+    expect(_extrahiereLiveText('{"standard": {"profileText": "Er sagt \\"Servus\\" und geht').standard).toBe(
       'Er sagt "Servus" und geht'
     );
   });
@@ -152,9 +154,46 @@ describe("extrahiereLiveText — Escapes", () => {
     const praefix = '{"standard": {"profileText": "Fertig."}, "beast": {"profileText": "Er sagt \\"Zack\\u2014';
     expect(_extrahiereLiveText(praefix).beast).toBe('Er sagt "Zack—');
     /* Und auch das Abschneiden halber Escapes am Praefix-Ende: */
-    expect(_extrahiereLiveText('{"profileText": "Fertig."}, "beast": {"profileText": "Etwa 25\\u00').beast).toBe(
-      "Etwa 25"
-    );
+    expect(
+      _extrahiereLiveText('{"standard": {"profileText": "Fertig."}, "beast": {"profileText": "Etwa 25\\u00').beast
+    ).toBe("Etwa 25");
+  });
+});
+
+/* ── KA-11 (Kurzaudit 2026-08-12): Verankerung am Modus-Schluessel ──
+   Die Reihenfolge „standard vor beast" haengt allein am Beispiel-Schema des
+   Prompts — keine Garantie. Jeder Wert zaehlt deshalb nur noch, wenn er
+   nachweislich zu SEINEM Modus-Block gehoert: Der harte Beast-Text darf nie
+   als Standard-Profil erscheinen, egal was das Modell anstellt. */
+describe("extrahiereLiveText — KA-11: Verankerung am Modus-Schluessel", () => {
+  test("ein profileText VOR jedem Modus-Schluessel zaehlt fuer niemanden", () => {
+    expect(_extrahiereLiveText('{"profileText": "Herrenlos und komplett."')).toEqual(NICHTS);
+  });
+
+  test("HAZARD-Fall: standard-Block OHNE profileText, beast MIT — der Beast-Text erscheint NICHT als Standard", () => {
+    const praefix = '{"standard": {"ad_targeting": ["x"]}, "beast": {"profileText": "Du bist ein zynisches Ziel';
+    expect(_extrahiereLiveText(praefix)).toEqual({
+      standard: null,
+      beast: "Du bist ein zynisches Ziel",
+    });
+  });
+
+  test("komplett vertauschte Reihenfolge (beast zuerst): beide Texte landen trotzdem im RICHTIGEN Feld", () => {
+    const praefix = '{"beast": {"profileText": "Boese Version."}, "standard": {"profileText": "Sachliche Vers';
+    expect(_extrahiereLiveText(praefix)).toEqual({
+      standard: "Sachliche Vers",
+      beast: "Boese Version.",
+    });
+  });
+
+  test("beast-Block offen ohne eigenen profileText, standard danach: nichts rutscht ins Beast-Feld", () => {
+    const praefix = '{"beast": {"ad_targeting": ["x"]}, "standard": {"profileText": "Echt."';
+    expect(_extrahiereLiveText(praefix)).toEqual({ standard: "Echt.", beast: null });
+  });
+
+  test("RUECKBAUPROBE Normalfall: gemessene Reihenfolge liefert byte-identisch dasselbe wie vor KA-11", () => {
+    const praefix = '{"standard": {"profileText": "Standard-Text."}, "beast": {"profileText": "Beast-Text."}}';
+    expect(_extrahiereLiveText(praefix)).toEqual({ standard: "Standard-Text.", beast: "Beast-Text." });
   });
 });
 

--- a/functions/src/__tests__/mistral.test.js
+++ b/functions/src/__tests__/mistral.test.js
@@ -183,6 +183,54 @@ describe("callMistralRaw 429 retry behavior", () => {
     expect(result.text).toBe("ok");
   }, 10000);
 
+  test("KA-09: der nie gelesene 429-Antwortrumpf wird aktiv verworfen (body.cancel)", async () => {
+    let attempts = 0;
+    const cancelSpy = jest.fn(async () => {});
+    setFetchForTest(async () => {
+      attempts++;
+      if (attempts === 1) {
+        return { ok: false, status: 429, text: async () => "rate limited", body: { cancel: cancelSpy } };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ choices: [{ message: { content: "ok" }, finish_reason: "stop" }], usage: {} }),
+      };
+    });
+
+    const result = await _callMistralRaw({ model: "x", messages: [], maxTokens: 1, temperature: 0 });
+    expect(result.text).toBe("ok");
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  }, 10000);
+
+  test("KA-09: ein werfendes body.cancel aendert am Retry NICHTS (best effort)", async () => {
+    let attempts = 0;
+    setFetchForTest(async () => {
+      attempts++;
+      if (attempts === 1) {
+        return {
+          ok: false,
+          status: 429,
+          text: async () => "rate limited",
+          body: {
+            cancel: async () => {
+              throw new Error("cancel kaputt");
+            },
+          },
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ choices: [{ message: { content: "ok" }, finish_reason: "stop" }], usage: {} }),
+      };
+    });
+
+    const result = await _callMistralRaw({ model: "x", messages: [], maxTokens: 1, temperature: 0 });
+    expect(attempts).toBe(2);
+    expect(result.text).toBe("ok");
+  }, 10000);
+
   test("gives up after exhausting retries on persistent 429", async () => {
     let attempts = 0;
     setFetchForTest(async () => {

--- a/functions/src/auth.js
+++ b/functions/src/auth.js
@@ -88,6 +88,16 @@ async function cleanupNonces() {
 }
 
 /**
+ * SHA-256 als Hex-String. Gebraucht fuer das Einmal-Ticket des
+ * Realitaets-Checks (KA-02): Im Job-Dokument liegt NUR der Hash, nie das
+ * Ticket selbst — wer die Datenbank liest, kann daraus kein gueltiges
+ * Ticket rekonstruieren (dieselbe Philosophie wie beim resultToken-Vergleich).
+ */
+function sha256Hex(value) {
+  return crypto.createHash("sha256").update(String(value)).digest("hex");
+}
+
+/**
  * SEC-01: Konstantzeitiger String-Vergleich fuer Secrets/Tokens.
  * Verhindert Timing-Seitenkanaele, ueber die ein Angreifer ein Secret
  * byteweise rekonstruieren koennte. Ein Laengen-Mismatch wird frueh und
@@ -109,6 +119,7 @@ module.exports = {
   consumeNonce,
   cleanupNonces,
   safeCompare,
+  sha256Hex,
   DEFAULT_TTL_MS,
   NONCE_TTL_MS,
 };

--- a/functions/src/config.js
+++ b/functions/src/config.js
@@ -27,24 +27,28 @@ const ALLOWED_MIME = ["image/jpeg", "image/png", "image/webp", "image/gif"];
      - mistral-large-2512: $0.50 / $1.50  in/out  (Large 3)
      - mistral-small-2603: $0.15 / $0.60  in/out  (Small 4)
 
-   Verifizierte Limits (Account-Dashboard 2026-05-19):
-     - mistral-small-2603: 100K TPM, 1.67 RPS  (absurd niedrig — deshalb
-       Single-Large als Standard-Pfad; vor Architektur-Entscheidungen IMMER
-       das Account-Dashboard pruefen, Limits variieren je Modellversion)
-     - mistral-large-2512: 2M TPM, 6 RPS
+   RATE-LIMITS — WICHTIG, STAND 2026-08-11 (KA-07): Die frueher hier
+   notierten Modell-Limits („6 RPS" Large, „1.67 RPS" Small, Dashboard-Stand
+   2026-05-19) sind UEBERHOLT. Mistral vergibt Limits heute als
+   STUFEN-SYSTEM nach kumuliertem Umsatz (org-weit, auch am EU-Endpunkt):
+   T1 = 0,25 req/s (bis 20 $), T2 ab 20 $, T3 ab 100 $, T4 ab 500 $ —
+   kein Vorkauf moeglich. Aktuell gilt T1: 0,25 req/s = die REALE
+   Durchsatzbremse (~7,5 Analysen/min bei 2 Calls je Analyse). In der
+   Praxis haelt die Cloud-Tasks-Nebenlaeufigkeit (7 gleichzeitige Jobs,
+   ~55 s je Analyse) den Durchsatz von selbst genau unter dieser Decke —
+   wer die Nebenlaeufigkeit hochdreht, MUSS vorher die Tier-Stufe im
+   Mistral-Dashboard pruefen, nicht diesen Kommentar.
 
-   Historie: v1.10.7 (2026-05-19) wich wegen der 2603-Limits voruebergehend
-   auf mistral-small-2506 (Small 3.2, 5M TPM) aus; seit der Queue-/Single-
-   Large-Architektur ist 2603 wieder aktiv. 2506 wurde von Mistral zum
+   Historie: v1.10.7 (2026-05-19) wich wegen der damaligen 2603-Limits
+   voruebergehend auf mistral-small-2506 (Small 3.2) aus; seit der Queue-/
+   Single-Large-Architektur ist 2603 wieder aktiv. 2506 wurde von Mistral zum
    31.07.2026 ZURUECKGEZOGEN (Retirement) — als Modell-Option dauerhaft tot.
 
    API-Key kommt aus `process.env.MISTRAL_API_KEY` (Firebase Secret). */
 /* v1.10.7: Large fest auf -2512 gepinnt statt -latest-Alias. Hintergrund:
    Mistral koennte das -latest-Alias jederzeit auf eine neuere Version
-   umlenken (z.B. ein hypothetisches Large -2603), die wie das aktuelle
-   Small-2603 mit brutalen Limits ausgestattet sein koennte. Mit dem Pin
-   kontrollieren wir Versions-Wechsel selbst.
-   Verifizierte Limits -2512 (Account-Dashboard 2026-05-19): 6 RPS, 2M TPM. */
+   umlenken, deren Konditionen wir nicht kennen. Mit dem Pin kontrollieren
+   wir Versions-Wechsel selbst. (Zu Rate-Limits: Stufen-System, s. oben.) */
 const MISTRAL_DESCRIBE_MODEL = "mistral-large-2512";
 const MISTRAL_PROFILE_MODEL = "mistral-small-2603";
 const MISTRAL_FALLBACK_MODEL = "mistral-large-2512";

--- a/functions/src/handle-job-status.js
+++ b/functions/src/handle-job-status.js
@@ -15,9 +15,10 @@
  * Ein Poll löst nur einen günstigen Firestore-Read aus.
  */
 
+const { randomUUID } = require("crypto");
 const { QUEUE_AVG_JOB_SECONDS, QUEUE_DISPATCH_CONCURRENCY } = require("./config");
 const { getJob, getQueuePosition, markFailedIfStale, touchJob, markDelivered } = require("./jobs");
-const { safeCompare } = require("./auth");
+const { safeCompare, sha256Hex } = require("./auth");
 
 /* Grobe Wartezeit-Schätzung aus der Warteschlangen-Position.
    Kalibrierung der Konstanten erfolgt in Phase 3/4 (config.js). */
@@ -108,9 +109,23 @@ async function handleJobStatus(req, res) {
        der best-effort Client-Telemetrie. Wiederholte Polls (Reload, zweiter
        Tab) loggen nicht erneut. Der Schreibvorgang läuft nebenläufig — er darf
        die Antwort an den wartenden Client nicht verzögern. */
+    const antwort = {
+      status: "done",
+      result: job.result || null,
+    };
     if (!job.deliveredAt) {
       const now = Date.now();
-      markDelivered(job.id).catch((err) =>
+      /* KA-02 (Kurzaudit 2026-08-12): Einmal-Ticket für den Realitäts-Check.
+         Es wird GENAU EINMAL ausgegeben — bei der ersten Auslieferung, hinter
+         derselben Ticket-Prüfung wie das Ergebnis selbst. Der Browser merkt
+         es sich (sessionStorage); in der Datenbank liegt nur der Hash. Der
+         Telemetrie-Endpunkt zählt eine Realitäts-Check-Stimme nur noch gegen
+         ein gültiges, unverbrauchtes Ticket — eine echte Analyse, eine
+         Stimme. Der Schreibvorgang läuft wie markDelivered nebenläufig;
+         schlägt er fehl, verfällt schlimmstenfalls diese eine Stimme. */
+      const rcTicket = randomUUID();
+      antwort.rcTicket = rcTicket;
+      markDelivered(job.id, sha256Hex(rcTicket)).catch((err) =>
         console.log(JSON.stringify({ warning: "markDelivered-error", jobId: job.id, error: err.message }))
       );
       console.log(
@@ -123,10 +138,7 @@ async function handleJobStatus(req, res) {
         })
       );
     }
-    res.status(200).json({
-      status: "done",
-      result: job.result || null,
-    });
+    res.status(200).json(antwort);
     return;
   }
 

--- a/functions/src/handle-telemetry.js
+++ b/functions/src/handle-telemetry.js
@@ -11,6 +11,8 @@
 
 const { checkRateLimit, getClientIp } = require("./middleware");
 const { zaehleRealitaetsCheck } = require("./counter");
+const { verbraucheRcTicket } = require("./jobs");
+const { sha256Hex } = require("./auth");
 
 const STRING_FIELDS = {
   eventType: 50,
@@ -107,21 +109,45 @@ function berechneRealitaetsCheckScore(stufen) {
   return Math.round((summe / werte.length) * 100);
 }
 
+/* KA-02: Ein Ticket ist eine UUID (36 Zeichen) — die Grenze ist nur ein
+   zweites Netz gegen absurd lange Strings vor dem Hashen. */
+const RC_TICKET_MAX_LAENGE = 100;
+
 /**
  * Behandelt das realitaets-check-Ereignis: strikt validieren, EIN anonymes
  * Log-Ereignis schreiben und das Aggregat in Firestore hochzählen. Bewusst
  * KEINE weiteren Felder aus dem Body (traceId, userAgent, timings, …) —
  * dieses Ereignis bleibt unverknüpfbar. Ungültige Eingaben werden still
  * verworfen; die Antwort ist in jedem Fall 204.
+ *
+ * KA-02 (Kurzaudit 2026-08-12): Gezählt wird NUR noch gegen ein gültiges
+ * Einmal-Ticket aus einer echten Analyse (ausgegeben vom job-status-Handler
+ * bei der ersten Auslieferung, entwertet in einer Transaktion). Vorher war
+ * der Zähler von außen flutbar: Das IP-Limit lebt je Function-Instanz (bis
+ * zu 3 Instanzen), und das Aggregat kennt keinen Rückweg. Reihenfolge
+ * bewusst: erst die Stufen prüfen, DANN das Ticket entwerten — eine kaputte
+ * Eingabe verbrennt kein gültiges Ticket. Das Ticket selbst wird weder
+ * geloggt noch gespeichert; das Log-Ereignis trägt unverändert nur
+ * {stufen, score} und bleibt unverknüpfbar.
  */
 async function handleRealitaetsCheckEvent(body, res) {
   const stufen = validiereRealitaetsCheckStufen(body.stufen);
   if (stufen) {
-    const score = berechneRealitaetsCheckScore(stufen);
-    console.log(JSON.stringify({ type: "client-telemetry", eventType: "realitaets-check", stufen, score }));
-    /* zaehleRealitaetsCheck schluckt Firestore-Fehler selbst (nur Warnung) —
-       Telemetrie darf nie mit einem 5xx antworten. */
-    await zaehleRealitaetsCheck(score);
+    const ticket =
+      typeof body.ticket === "string" && body.ticket.length > 0 && body.ticket.length <= RC_TICKET_MAX_LAENGE
+        ? body.ticket
+        : null;
+    /* Ein Firestore-Schluckauf beim Entwerten darf die Antwort nie kippen —
+       dann zählt diese Stimme eben nicht (fail-closed: lieber eine echte
+       Stimme verlieren als Flutung wieder öffnen). */
+    const gueltig = ticket ? await verbraucheRcTicket(sha256Hex(ticket)).catch(() => false) : false;
+    if (gueltig) {
+      const score = berechneRealitaetsCheckScore(stufen);
+      console.log(JSON.stringify({ type: "client-telemetry", eventType: "realitaets-check", stufen, score }));
+      /* zaehleRealitaetsCheck schluckt Firestore-Fehler selbst (nur Warnung) —
+         Telemetrie darf nie mit einem 5xx antworten. */
+      await zaehleRealitaetsCheck(score);
+    }
   }
   res.status(204).end();
 }

--- a/functions/src/jobs.js
+++ b/functions/src/jobs.js
@@ -232,9 +232,49 @@ async function touchJob(jobId) {
  * beim Client angekommen" — unabhängig von der best-effort Client-Telemetrie.
  * Der job-status-Handler ruft das genau einmal pro Job (Guard dort: nur wenn
  * `deliveredAt` noch nicht gesetzt ist).
+ *
+ * KA-02 (Kurzaudit 2026-08-12): Mit der Auslieferung wird — im selben
+ * Schreibvorgang — der HASH des Realitäts-Check-Einmal-Tickets abgelegt.
+ * Das Ticket selbst geht nur an den Browser; die Datenbank kennt nur den
+ * Hash und kann daraus kein gültiges Ticket machen.
  */
-async function markDelivered(jobId) {
-  await jobsRef().doc(jobId).update({ deliveredAt: Date.now() });
+async function markDelivered(jobId, rcTicketHash) {
+  const patch = { deliveredAt: Date.now() };
+  if (typeof rcTicketHash === "string" && rcTicketHash.length > 0) {
+    patch.rcTicketHash = rcTicketHash;
+  }
+  await jobsRef().doc(jobId).update(patch);
+}
+
+/**
+ * KA-02: Entwertet ein Realitäts-Check-Einmal-Ticket (per Hash) und meldet,
+ * ob es gültig war. Jede echte Analyse gibt bei der ersten Auslieferung genau
+ * EIN Ticket aus — damit zählt jede Analyse höchstens eine Stimme, egal wie
+ * viele Function-Instanzen laufen (das frühere In-Memory-IP-Limit vervielfacht
+ * sich je Instanz und schützt den öffentlichen Vergleichswert nicht).
+ *
+ * Ablauf: Job per Hash-Gleichheit suchen (automatischer Einzelfeld-Index,
+ * kein zusammengesetzter nötig), dann in einer TRANSAKTION erneut lesen und
+ * den Hash auf null setzen. Zwei gleichzeitige Einreichungen desselben
+ * Tickets können so nie beide zählen: Die zweite Transaktion sieht den Hash
+ * nicht mehr. Läuft die 15-Minuten-Löschfrist (PRIV-107b) vorher ab, ist das
+ * Dokument weg und das Ticket damit von selbst wertlos.
+ */
+async function verbraucheRcTicket(rcTicketHash) {
+  if (typeof rcTicketHash !== "string" || rcTicketHash.length === 0) return false;
+  const snap = await jobsRef().where("rcTicketHash", "==", rcTicketHash).limit(1).get();
+  if (snap.empty) return false;
+  const ref = snap.docs[0].ref;
+  const db = datenbank();
+  return db.runTransaction(async (tx) => {
+    const doc = await tx.get(ref);
+    if (!doc.exists || doc.data().rcTicketHash !== rcTicketHash) return false;
+    /* null statt FieldValue.delete(): Zeitstempel/Werte sind in dieser Datei
+       bewusst plain (s. Datei-Kopf), und die Gleichheits-Suche oben findet
+       ein null-Feld nie wieder — entwertet ist entwertet. */
+    tx.update(ref, { rcTicketHash: null });
+    return true;
+  });
 }
 
 /**
@@ -403,6 +443,7 @@ module.exports = {
   markFailedIfStale,
   touchJob,
   markDelivered,
+  verbraucheRcTicket,
   setLiveText,
   abandonJob,
   isAbandoned,

--- a/functions/src/mistral.js
+++ b/functions/src/mistral.js
@@ -67,8 +67,9 @@ function isRateLimitError(err) {
    was den Burst zusätzlich entzerrt.
 
    v1.10.8: modelClass ("large"/"small") wird an withMistralSlot durchgereicht,
-   damit der modell-bewusste Token-Bucket den richtigen Rate-Bucket waehlt —
-   Large darf schneller feuern (6 RPS) als Small (1.67 RPS). */
+   damit der modell-bewusste Token-Bucket den richtigen Rate-Bucket waehlt
+   (Large-Bucket taktet schneller als Small — Details und die heutige
+   Tier-Wahrheit: throttle.js-Kopf, KA-07). */
 function modelClassOf(model) {
   return /large/i.test(model || "") ? "large" : "small";
 }
@@ -130,12 +131,16 @@ const PROFILE_TEXT_SCHLUESSEL = '"profileText"';
  * Rueckgabe:
  *   - `null`, solange der Wert noch nicht begonnen hat (Schluessel fehlt oder
  *     das oeffnende `"` ist noch nicht da),
- *   - sonst `{ text, ende, abgeschlossen }`:
+ *   - sonst `{ text, schluesselIdx, ende, abgeschlossen }`:
  *       text          DEKODIERTER Klartext (JSON-Escapes wie \n, \" oder
  *                     \uXXXX sind zu echten Zeichen aufgeloest). Ein
  *                     UNVOLLSTAENDIGES Escape am Praefix-Ende (z.B. `\` oder
  *                     `\u00`) wird abgeschnitten — lieber ein Zeichen zu
  *                     wenig zeigen als kaputte Reste.
+ *       schluesselIdx Index des gefundenen `"profileText"`-Schluessels —
+ *                     der Verankerungs-Pruefpunkt (KA-11): Der Aufrufer
+ *                     stellt damit sicher, dass zwischen Modus-Schluessel
+ *                     und Fund kein ANDERER Modus-Schluessel liegt.
  *       ende          Index des schliessenden `"` (bzw. Praefix-Ende) — der
  *                     Startpunkt fuer die Suche nach dem naechsten Vorkommen.
  *       abgeschlossen true, wenn das schliessende `"` schon angekommen ist.
@@ -185,30 +190,62 @@ function findeProfileTextWert(jsonPraefix, abIdx) {
     i += 1;
   }
 
-  return { text: dekodiereJsonEscapes(jsonPraefix.slice(start, ende)), ende, abgeschlossen };
+  return { text: dekodiereJsonEscapes(jsonPraefix.slice(start, ende)), schluesselIdx, ende, abgeschlossen };
 }
+
+/* KA-11: Die Modus-Schluessel, an denen die beiden profileText-Werte verankert
+   werden. In gueltigem JSON koennen diese Zeichenfolgen INNERHALB eines
+   String-Werts nie roh auftauchen (die Anfuehrungszeichen waeren dort `\"`) —
+   dieselbe Escape-Garantie, auf der schon der profileText-Scanner beruht. */
+const STANDARD_SCHLUESSEL = '"standard"';
+const BEAST_SCHLUESSEL = '"beast"';
 
 /**
  * Extrahiert aus einem JSON-PRAEFIX (der noch mitten im Satz abbrechen kann)
  * die bereits vollstaendig angekommenen Teile BEIDER `profileText`-Werte.
- * Nach der gemessenen Schluessel-Reihenfolge der Antwort ist das erste
- * Vorkommen das Standard-Profil (`standard.profileText`), das zweite das
- * Beast-Profil (`beast.profileText`) — das Modell schreibt sequenziell,
- * Beast beginnt deshalb deutlich spaeter.
+ *
+ * KA-11 (Kurzaudit 2026-08-12): Frueher galt schlicht „erstes Vorkommen =
+ * Standard, zweites = Beast" — das hing allein am BEISPIEL-Schema im Prompt
+ * (keine Garantie durch response_format). Haette das Modell die Bloecke je
+ * vertauscht, waere der harte Beast-Text kurz als Standard-Profil erschienen.
+ * Jetzt wird jeder Wert an seinem Modus-Schluessel VERANKERT: Der
+ * Standard-Text zaehlt nur, wenn zwischen `"standard"` und dem Fund kein
+ * `"beast"` liegt (und umgekehrt). Dreht das Modell die Reihenfolge, zeigt
+ * der Live-Weg schlicht nichts Falsches — schlimmstenfalls bleibt das
+ * Warte-Auge stehen; das Endergebnis parst ohnehin das komplette JSON.
+ * Fuer die gemessene Normal-Reihenfolge ist das Ergebnis byte-identisch
+ * zum bisherigen Verhalten.
  *
  * Rueckgabe: `{ standard, beast }` — jeweils der DEKODIERTE Klartext, oder
  * `null`, solange der jeweilige Wert noch nicht begonnen hat.
  */
 function extrahiereLiveText(jsonPraefix) {
   if (typeof jsonPraefix !== "string") return { standard: null, beast: null };
-  const erster = findeProfileTextWert(jsonPraefix, 0);
-  if (!erster) return { standard: null, beast: null };
-  /* Das zweite Vorkommen kann erst NACH dem abgeschlossenen ersten Wert
-     stehen (sequenzielles Schreiben) — vorher gar nicht erst suchen. Die
-     Suche startet hinter dem schliessenden `"` des ersten Werts, damit ein
-     `"profileText"` IM Standard-Text nie als zweites Feld zaehlt. */
-  const zweiter = erster.abgeschlossen ? findeProfileTextWert(jsonPraefix, erster.ende + 1) : null;
-  return { standard: erster.text, beast: zweiter ? zweiter.text : null };
+
+  const standardIdx = jsonPraefix.indexOf(STANDARD_SCHLUESSEL);
+  const beastIdx = jsonPraefix.indexOf(BEAST_SCHLUESSEL);
+
+  /* Standard: erst ab dem eigenen Modus-Schluessel suchen — ein profileText
+     VOR `"standard"` kann nie das Standard-Profil sein. Liegt zwischen dem
+     Schluessel und dem Fund ein `"beast"`, gehoert der Fund zum Beast-Block
+     (Standard hat dann selbst noch keinen profileText geliefert). */
+  let erster = standardIdx >= 0 ? findeProfileTextWert(jsonPraefix, standardIdx) : null;
+  if (erster) {
+    const beastDazwischen = jsonPraefix.indexOf(BEAST_SCHLUESSEL, standardIdx + 1);
+    if (beastDazwischen >= 0 && beastDazwischen < erster.schluesselIdx) erster = null;
+  }
+
+  /* Beast: symmetrisch verankert. */
+  let zweiter = null;
+  if (beastIdx >= 0) {
+    const kandidat = findeProfileTextWert(jsonPraefix, beastIdx);
+    if (kandidat) {
+      const standardDazwischen = jsonPraefix.indexOf(STANDARD_SCHLUESSEL, beastIdx + 1);
+      if (!(standardDazwischen >= 0 && standardDazwischen < kandidat.schluesselIdx)) zweiter = kandidat;
+    }
+  }
+
+  return { standard: erster ? erster.text : null, beast: zweiter ? zweiter.text : null };
 }
 
 /* Loest JSON-String-Escapes zu echten Zeichen auf. Bewusst von Hand statt
@@ -442,6 +479,14 @@ async function callMistralRawUnthrottled({
 
     if (res.status === 429 && attempt < backoffs.length) {
       if (streamen) clearTimeout(timeoutId);
+      /* KA-09 (Kurzaudit 2026-08-12): Den nie gelesenen Antwortrumpf aktiv
+         verwerfen, sonst bleibt die Verbindung bis zum Speicherbereiniger
+         offen — bei Workshop-Bursts mit vielen 429ern unnötiger Ballast. */
+      try {
+        if (res.body && typeof res.body.cancel === "function") await res.body.cancel();
+      } catch (_) {
+        /* Verwerfen ist best effort — ein Fehler hier ändert nichts am Retry. */
+      }
       lastError = new Error("Mistral 429 rate limited");
       lastError.status = 429;
       await new Promise((r) => setTimeout(r, backoffs[attempt]));

--- a/functions/src/throttle.js
+++ b/functions/src/throttle.js
@@ -3,10 +3,18 @@
 /**
  * throttle.js — Per-Instance-Semaphore für Mistral-Bursts.
  *
- * Mistral-Scale-Tier hat 6 RPS Sustained-Limit. Wenn eine Cloud-Function-
- * Instanz mehrere Hybrid-Analysen parallel verarbeitet (Workshop-Klasse mit
- * 25 Schülern, alle laden gleichzeitig hoch), entstehen Burst-Spitzen die
- * 429-Errors triggern.
+ * RATE-LIMITS, STAND 2026-08-11 (KA-07): Mistral vergibt Limits als
+ * STUFEN-SYSTEM nach kumuliertem Umsatz (T1 = 0,25 req/s bis 20 $; T2/T3/T4
+ * darüber) — die früher hier notierten „6 RPS" stammen vom Mai-Dashboard und
+ * sind ÜBERHOLT. Die reale Durchsatzbremse ist heute die Tier-Stufe, in der
+ * Praxis gehalten durch die Cloud-Tasks-Nebenläufigkeit (7 gleichzeitige
+ * Jobs à ~55 s ≈ 0,25 req/s). Vor jeder Änderung an Nebenläufigkeit oder
+ * den Intervallen unten: Tier-Stufe im Mistral-Dashboard prüfen, nicht
+ * Kommentare zitieren.
+ *
+ * Wenn eine Cloud-Function-Instanz mehrere Analysen parallel verarbeitet
+ * (Workshop-Klasse mit 25 Schülern, alle laden gleichzeitig hoch), entstehen
+ * Burst-Spitzen, die 429-Errors triggern.
  *
  * Lösung: pro Instanz wird die Anzahl gleichzeitig in-flight Mistral-Calls
  * begrenzt. Eingehende Calls warten auf einen freien Slot statt sofort
@@ -21,11 +29,11 @@
  * Implementierung: einfache FIFO-Queue mit max-concurrent-Limit.
  */
 
-/* 6 ist konservativ und matched Mistrals 6 RPS Default-Limit auf Scale-Tier.
-   Pro Analyse machen wir 3 Mistral-Calls (1 Describe + 2 Profile parallel) —
-   damit kann eine einzelne Instanz alle 2-3 Sekunden eine vollständige
-   Analyse durchschieben. Bei Cold-Start oder Workshop-Burst greift dann
-   einfach mistral.js's Retry-Backoff. */
+/* 6 gleichzeitige Calls je Instanz — historisch am alten 6-RPS-Dashboard-Wert
+   ausgerichtet (überholt, s. Datei-Kopf), heute schlicht eine konservative
+   Parallelitäts-Decke: Die echte Raten-Grenze setzen Tier-Stufe und
+   Cloud-Tasks-Nebenläufigkeit. Bei Cold-Start oder Workshop-Burst greift
+   zusätzlich mistral.js' Retry-Backoff. */
 const DEFAULT_MAX_CONCURRENT = 6;
 
 /* v1.10.6: Queue-Timeout von 90s auf 360s (6 Minuten) hochgesetzt.
@@ -109,18 +117,15 @@ const mistralSemaphore = createSemaphore();
  * entzerrt das: jeder Caller wartet, bis seit dem letzten Start des gleichen
  * Modell-Typs genug Zeit verstrichen ist.
  *
- * v1.10.8 — getrennte Buckets pro Modell-Typ: Das Mistral-Account-Dashboard
- * zeigt SEHR unterschiedliche Limits je Modell:
- *   - mistral-large-2512 (Describe + Profile-Fallback): 6 RPS, 2M TPM
- *   - mistral-small-2603 (Profile normal/boost):        1.67 RPS, 100K TPM
- * Ein gemeinsamer Bucket muss sich am LANGSAMSTEN Modell orientieren — wir
- * haetten also auch die Large-Describe-Calls auf 1.6 RPS gedrosselt, obwohl
- * Large 6 RPS koennte. Mit getrennten Buckets laeuft Describe ~3x schneller,
- * was den Wartezeit-Tail unter Workshop-Last spuerbar kuerzt.
- *
- * Intervalle (bei maxInstances=4, siehe index.js):
- *   - Large: 800ms/Instanz → 4 × 1.25 = 5 RPS gesamt, unter dem 6-RPS-Limit
- *   - Small: 2500ms/Instanz → 4 × 0.4 = 1.6 RPS gesamt, unter dem 1.67-Limit
+ * v1.10.8 — getrennte Buckets pro Modell-Typ: Das damalige Account-Dashboard
+ * (Mai 2026) zeigte sehr unterschiedliche Limits je Modell; ein gemeinsamer
+ * Bucket haette sich am LANGSAMSTEN orientieren muessen. Die getrennten
+ * Buckets bleiben sinnvoll (Describe soll nicht hinter Profile-Calls warten),
+ * aber die Intervalle unten stammen aus der Mai-Rechnung — KA-07: Heute gilt
+ * das TIER-System (T1 = 0,25 req/s org-weit, s. config.js). Die Intervalle
+ * sind damit KEINE Garantie mehr, unter dem Limit zu bleiben; das
+ * uebernimmt real die Cloud-Tasks-Nebenlaeufigkeit (7). Wer hier schneller
+ * drehen will, prueft ZUERST die Tier-Stufe im Mistral-Dashboard.
  */
 const LARGE_TOKEN_INTERVAL_MS = 800;
 const SMALL_TOKEN_INTERVAL_MS = 2500;

--- a/public/__tests__/live-anzeige.test.js
+++ b/public/__tests__/live-anzeige.test.js
@@ -850,6 +850,41 @@ describe("Live-Anzeige (v3.0)", () => {
     }
   });
 
+  it("KA-05 Lauf-Kennung: startet binnen eines Takts ein NEUER Analyse-Lauf, stirbt die alte Nachwache-Kette sofort", async () => {
+    const spy = vi.fn();
+    elements.scanAnim.scrollIntoView = spy;
+    elements.scanAnim.classList.add("active");
+    /* Lauf 1: Auge sichtbar — die Kette tickt, scrollt aber nicht. */
+    elements.scanAnim.getBoundingClientRect = imFenster;
+    try {
+      liveAnzeige.fuehrungStarten();
+      liveAnzeige.augeInsBild();
+      await vi.advanceTimersByTimeAsync(850);
+      expect(spy).not.toHaveBeenCalled();
+
+      /* Neues Foto mitten im Takt: zuruecksetzen() beendet Lauf 1, der
+         nächste Lauf startet seine Führung — aber (bewusst) OHNE eigenes
+         augeInsBild. Rutscht das Auge jetzt aus dem Bild, darf die ALTE
+         Kette nicht mehr scrollen. (RUECKBAUPROBE: Ohne die Lauf-Kennung
+         sieht der alte Tick die neue Führung als „aktiv" und zieht — der
+         Spy feuert, dieser Test wird rot.) */
+      liveAnzeige.zuruecksetzen();
+      liveAnzeige.fuehrungStarten();
+      elements.scanAnim.getBoundingClientRect = unterDerSichtkante;
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(spy).not.toHaveBeenCalled();
+
+      /* Gegenprobe: Ein augeInsBild DES NEUEN Laufs scrollt sehr wohl —
+         die Kennung sperrt nur fremde Ketten, nicht die Funktion. */
+      liveAnzeige.augeInsBild();
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      delete elements.scanAnim.scrollIntoView;
+      delete elements.scanAnim.getBoundingClientRect;
+      elements.scanAnim.classList.remove("active");
+    }
+  });
+
   it("v3.0.5 Übernahme: bloßes Antippen (touchstart) beendet die Führung NICHT — erst echtes Wischen (touchmove)", () => {
     const spy = vi.fn();
     elements.scanAnim.scrollIntoView = spy;

--- a/public/__tests__/rc-ticket.test.js
+++ b/public/__tests__/rc-ticket.test.js
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { setupDOM } from "./setup.js";
+
+/* KA-02 (Kurzaudit 2026-08-12): das Einmal-Ticket des Realitäts-Checks im
+   Frontend — Speicher-Modul, Mitsenden im Telemetrie-Logger und die
+   Verdrahtung in api.js (merken bei done, räumen bei neuem Auftrag). */
+
+vi.mock("../js/i18n.js", () => ({
+  t: (key) => key,
+  getLanguage: () => "de",
+  initI18n: () => Promise.resolve(),
+  applyTranslations: () => {},
+}));
+
+vi.mock("../js/exif.js", () => ({
+  prepareImage: vi.fn().mockResolvedValue({
+    imageBase64: "QUFB",
+    exif: { make: "Apple", model: "iPhone" },
+    gps: null,
+    dateTimeOriginal: null,
+  }),
+}));
+
+vi.mock("../js/geocoding.js", () => ({
+  startGeocoding: vi.fn(),
+}));
+
+vi.mock("../js/render.js", () => ({
+  renderCurrentMode: vi.fn(),
+}));
+
+const RC_TICKET_KEY = "malzime.queueRcTicket";
+
+const DONE_RESULT = {
+  profiles: { normal: { categories: { a: {} }, ad_targeting: [], manipulation_triggers: [], profileText: "T" } },
+  privacyRisks: [],
+  exif: {},
+  meta: { mode: "multimodal", subject: "HUMAN" },
+};
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    clone() {
+      return this;
+    },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  };
+}
+
+/* ── 1. Das Speicher-Modul selbst ──────────────────────────────────────── */
+
+describe("rc-ticket.js — Speichern, Lesen, Löschen", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("speichert und liest ein Ticket", async () => {
+    const mod = await import("../js/rc-ticket.js");
+    mod.speichereRcTicket("ticket-123");
+    expect(mod.leseRcTicket()).toBe("ticket-123");
+    expect(sessionStorage.getItem(RC_TICKET_KEY)).toBe("ticket-123");
+  });
+
+  it("löscht das Ticket wieder", async () => {
+    const mod = await import("../js/rc-ticket.js");
+    mod.speichereRcTicket("ticket-123");
+    mod.loescheRcTicket();
+    expect(mod.leseRcTicket()).toBeNull();
+  });
+
+  it("ignoriert Nicht-Strings und Leerstrings beim Speichern", async () => {
+    const mod = await import("../js/rc-ticket.js");
+    mod.speichereRcTicket("");
+    mod.speichereRcTicket(null);
+    mod.speichereRcTicket(42);
+    expect(mod.leseRcTicket()).toBeNull();
+  });
+});
+
+/* ── 2. telemetry-logger: Ticket geht mit — und NUR das ────────────────── */
+
+describe("logRealitaetsCheck — Ticket im Ereignis", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("mit gemerktem Ticket: Body trägt eventType, stufen und ticket — sonst nichts", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true });
+    const { speichereRcTicket } = await import("../js/rc-ticket.js");
+    const { logRealitaetsCheck } = await import("../js/telemetry-logger.js");
+    speichereRcTicket("ticket-abc");
+    logRealitaetsCheck({ alter: 1, interessen: 0.5 });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body).toEqual({
+      eventType: "realitaets-check",
+      stufen: { alter: 1, interessen: 0.5 },
+      ticket: "ticket-abc",
+    });
+  });
+
+  it("ohne Ticket: Body exakt wie vor KA-02 (kein ticket-Feld)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true });
+    const { logRealitaetsCheck } = await import("../js/telemetry-logger.js");
+    logRealitaetsCheck({ alter: 1 });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body).toEqual({ eventType: "realitaets-check", stufen: { alter: 1 } });
+    expect("ticket" in body).toBe(false);
+  });
+});
+
+/* ── 3. api.js-Verdrahtung: merken bei done, räumen bei neuem Auftrag ──── */
+
+describe("api.js — rcTicket-Verdrahtung", () => {
+  let analyzeImage, clearStoredJobId, state;
+
+  beforeEach(async () => {
+    setupDOM();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(Date.now() + 10000);
+    sessionStorage.clear();
+
+    const apiMod = await import("../js/api.js");
+    const stateMod = await import("../js/state.js");
+    analyzeImage = apiMod.analyzeImage;
+    clearStoredJobId = apiMod.clearStoredJobId;
+    state = stateMod.state;
+
+    state.isAnalyzing = false;
+    state.requestId = 0;
+    state.lastPrepared = null;
+    state.lastData = null;
+    state.lastFile = new File(["test"], "test.jpg", { type: "image/jpeg" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it("done-Antwort MIT rcTicket → das Ticket liegt im sessionStorage", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (String(url).includes("/api/enqueue")) return jsonResponse({ jobId: "job-1" });
+      if (String(url).includes("job-status")) {
+        return jsonResponse({ status: "done", result: DONE_RESULT, rcTicket: "server-ticket-1" });
+      }
+      return jsonResponse({ ok: true });
+    });
+    const p = analyzeImage();
+    await vi.advanceTimersByTimeAsync(8000);
+    await p;
+    expect(sessionStorage.getItem(RC_TICKET_KEY)).toBe("server-ticket-1");
+  });
+
+  it("done-Antwort OHNE rcTicket (Wiederholungs-Abruf): nichts wird gespeichert", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (String(url).includes("/api/enqueue")) return jsonResponse({ jobId: "job-1" });
+      if (String(url).includes("job-status")) return jsonResponse({ status: "done", result: DONE_RESULT });
+      return jsonResponse({ ok: true });
+    });
+    const p = analyzeImage();
+    await vi.advanceTimersByTimeAsync(8000);
+    await p;
+    expect(sessionStorage.getItem(RC_TICKET_KEY)).toBeNull();
+  });
+
+  it("neuer Analyse-Auftrag räumt das alte Ticket weg (storeJobId-Pfad)", async () => {
+    sessionStorage.setItem(RC_TICKET_KEY, "altes-ticket");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (String(url).includes("/api/enqueue")) return jsonResponse({ jobId: "job-2" });
+      if (String(url).includes("job-status")) return jsonResponse({ status: "done", result: DONE_RESULT });
+      return jsonResponse({ ok: true });
+    });
+    const p = analyzeImage();
+    await vi.advanceTimersByTimeAsync(8000);
+    await p;
+    /* Das alte Ticket ist weg; ein neues kam in dieser Antwort nicht. */
+    expect(sessionStorage.getItem(RC_TICKET_KEY)).toBeNull();
+  });
+
+  it("clearStoredJobId räumt auch das Ticket", async () => {
+    sessionStorage.setItem(RC_TICKET_KEY, "ticket-xyz");
+    clearStoredJobId();
+    expect(sessionStorage.getItem(RC_TICKET_KEY)).toBeNull();
+  });
+});

--- a/public/index.html
+++ b/public/index.html
@@ -176,6 +176,15 @@
         <a href="/stats" target="_blank" rel="noopener" class="limit-banner__stats" tabindex="0" data-i18n="limit.statsLink">Aktuelle Auslastung ansehen</a>
       </div>
 
+      <!-- KA-08 (Kurzaudit 2026-08-12): Die Einordnung „nichts davon ist wahr"
+           stand am Bildschirm bisher erst UNTER dem Upload (der Block oben ist
+           nur für den Druck). Der wichtigste pädagogische Satz gehört VOR die
+           Foto-Wahl. Gleicher i18n-Schlüssel wie unten; die .disclaimer-Klasse
+           hält ihn aus dem Druck heraus (dort übernimmt .print-disclaimer). -->
+      <div class="disclaimer disclaimer--einordnung">
+        <p data-i18n-html="disclaimer.main"><strong>malziME</strong> ist ein Lern-Tool f&uuml;r Medienkompetenz und Datenschutz-Sensibilisierung. Die KI-Profile sind erfunden und zeigen nur, was Algorithmen behaupten k&ouml;nnten &ndash; nichts davon ist wahr oder bewiesen.</p>
+      </div>
+
       <section class="upload-section">
         <label class="file-drop" for="fileInput">
           <input id="fileInput" type="file" accept="image/*" tabindex="0" />
@@ -288,8 +297,10 @@
         </div>
       </section>
 
+      <!-- KA-08: disclaimer.main steht jetzt sichtbar VOR dem Upload — hier
+           bleibt der Workshop-Hinweis, der inhaltlich zu den Demo-Fotos
+           darunter gehört. -->
       <div class="disclaimer disclaimer--flush">
-        <p data-i18n-html="disclaimer.main"><strong>malziME</strong> ist ein Lern-Tool f&uuml;r Medienkompetenz und Datenschutz-Sensibilisierung. Die KI-Profile sind erfunden und zeigen nur, was Algorithmen behaupten k&ouml;nnten &ndash; nichts davon ist wahr oder bewiesen.</p>
         <p class="disclaimer__workshop" data-i18n="disclaimer.workshop">F&uuml;r Workshops k&ouml;nnen auch die bereitgestellten KI-generierten Demo-Fotos oder &auml;ltere Bilder verwendet werden. Kein hochgeladenes Bild wird dauerhaft gespeichert oder ist nach der Analyse abrufbar.</p>
       </div>
 

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -13,6 +13,7 @@ import {
 } from "./ui.js";
 import { renderCurrentMode } from "./render.js";
 import * as liveAnzeige from "./live-anzeige.js";
+import { speichereRcTicket, loescheRcTicket } from "./rc-ticket.js";
 import * as realitaetsCheck from "./realitaets-check.js";
 import { t, getLanguage } from "./i18n.js";
 import { logClientError } from "./error-logger.js";
@@ -186,6 +187,9 @@ function storeJobId(jobId, resultToken) {
   } catch (_) {
     /* sessionStorage kann im privaten Modus werfen — kein harter Fehler. */
   }
+  /* KA-02: Neuer Auftrag → das Realitäts-Check-Ticket des vorigen Ergebnisses
+     ist verbraucht oder hinfällig. */
+  loescheRcTicket();
 }
 
 /* PRIV-107: Zeitpunkt der ERSTEN Zustellung festhalten. Bewusst nur setzen,
@@ -224,6 +228,8 @@ export function clearStoredJobId() {
   } catch (_) {
     /* dito */
   }
+  /* KA-02: Zum Tab-Stand gehört auch das Realitäts-Check-Ticket. */
+  loescheRcTicket();
 }
 
 /** Gibt eine offene jobId aus einem früheren Seitenbesuch zurück (oder null). */
@@ -355,6 +361,10 @@ async function pollJob(jobId, myId, resultToken, pollImmediately = false, liveEr
         }
         break;
       case "done":
+        /* KA-02: Das Einmal-Ticket für den Realitäts-Check kommt genau mit
+           der ersten Auslieferung (danach nie wieder) — sofort merken, damit
+           es Reload und Tab-Wiederaufnahme im 15-Minuten-Fenster überlebt. */
+        if (typeof data.rcTicket === "string") speichereRcTicket(data.rcTicket);
         return { result: data.result };
       case "failed":
         return { error: t("error.queueFailed"), reason: data.errorReason };
@@ -592,12 +602,6 @@ async function analyzeImageQueued() {
   resetQueueWaiting();
   startScanAnim(false);
   elements.scanText.textContent = t("scan.upload");
-  /* v3.0.3 Blick-Führung: Ab jetzt gehört der Blick diesem Lauf — die
-     Übernahme-Wache startet EINMAL pro Analyse (ein eigener Scroll des
-     Nutzers stoppt alle automatischen Bewegungen dauerhaft), und das Auge
-     wird ins Bild geholt, falls es unter der Sichtkante liegt (am Handy
-     sieht man sonst nur das Foto, aber nicht, dass etwas passiert). Die
-     Wiederaufnahme nach einem Neuladen bleibt bewusst ohne Führung. */
   /* v3.0.3 Blick-Führung: Ab jetzt gehört der Blick diesem Lauf — die
      Übernahme-Wache startet EINMAL pro Analyse (ein eigener Scroll des
      Nutzers stoppt alle automatischen Bewegungen dauerhaft), und das Auge

--- a/public/js/live-anzeige.js
+++ b/public/js/live-anzeige.js
@@ -228,6 +228,14 @@ const UEBERNAHME_TASTEN = new Set([
    keine Führung unterwegs (und damit auch kein automatisches Scrollen). */
 let fuehrung = null;
 
+/* KA-05 (Kurzaudit 2026-08-12): Laufende Nummer der Führung. Die
+   Auge-Nachwache ist eine setTimeout-Kette — endet ein Lauf und beginnt
+   binnen eines Takts (400 ms) der nächste, sähe der alte Tick wieder eine
+   aktive Führung und liefe als ZWEITE Kette neben der neuen weiter (im
+   Extremfall zwei Scrolls auf dasselbe Ziel). Jede Kette merkt sich deshalb
+   die Nummer ihres Laufs und stirbt beim ersten Tick mit fremder Nummer. */
+let fuehrungsLauf = 0;
+
 function fuehrungListenerEntfernen(mein) {
   if (!mein.listener) return;
   window.removeEventListener("wheel", mein.listener);
@@ -246,6 +254,7 @@ function fuehrungListenerEntfernen(mein) {
  */
 export function fuehrungStarten() {
   if (fuehrung) return;
+  fuehrungsLauf += 1; /* KA-05: neuer Lauf — alte Nachwache-Ketten verfallen */
   const mein = { aktiv: true, listener: null };
   const uebernahme = (ereignis) => {
     if (ereignis.type === "keydown" && !UEBERNAHME_TASTEN.has(ereignis.key)) return;
@@ -324,7 +333,10 @@ const AUGE_WACHE_VERSUCHE_MAX = 110;
  * die Live-Karte (Tippen), ist die Wache fertig. Desktop, Auge dauerhaft im
  * Bild: es bewegt sich weiterhin NICHTS.
  */
-export function augeInsBild(versuch = 0, zustand = { gescrollt: false }) {
+export function augeInsBild(versuch = 0, zustand = { gescrollt: false }, kennung = fuehrungsLauf) {
+  /* KA-05: Tick einer Kette aus einem FRÜHEREN Lauf — sofort sterben, sonst
+     wachen nach einem schnellen Neustart zwei Ketten nebeneinander. */
+  if (kennung !== fuehrungsLauf) return;
   if (!fuehrungAktiv()) return;
   /* Tipp-Phase erreicht: Ab hier führen Karte und Tipp-Nachscrollen. */
   if (elements.liveKarte && elements.liveKarte.classList.contains("active")) return;
@@ -345,7 +357,7 @@ export function augeInsBild(versuch = 0, zustand = { gescrollt: false }) {
     }
   }
   if (versuch < AUGE_WACHE_VERSUCHE_MAX) {
-    setTimeout(() => augeInsBild(versuch + 1, zustand), AUGE_WACHE_TAKT_MS);
+    setTimeout(() => augeInsBild(versuch + 1, zustand, kennung), AUGE_WACHE_TAKT_MS);
   }
 }
 

--- a/public/js/rc-ticket.js
+++ b/public/js/rc-ticket.js
@@ -1,0 +1,51 @@
+/**
+ * rc-ticket.js — Einmal-Ticket des Realitäts-Checks (KA-02, Kurzaudit
+ * 2026-08-12).
+ *
+ * Der Server gibt bei der ERSTEN Auslieferung eines fertigen Ergebnisses
+ * genau ein Ticket aus (job-status-Antwort, Feld `rcTicket`); der Zähler der
+ * anonymen Selbsteinschätzung nimmt eine Stimme nur noch gegen dieses Ticket
+ * an und entwertet es dabei — eine echte Analyse, höchstens eine Stimme.
+ *
+ * Eigenes Modul statt api.js: telemetry-logger.js braucht das Ticket beim
+ * Absenden, api.js beim Empfangen/Aufräumen — ein Import von api.js aus dem
+ * Logger (oder umgekehrt) ergäbe einen Kreis. sessionStorage wie bei
+ * jobId/resultToken: überlebt Reload im selben Tab, nie tab-übergreifend,
+ * und der private Modus darf werfen, ohne dass etwas kaputtgeht.
+ *
+ * Privacy: Das Ticket ist ein reiner Zufallswert ohne jede Bedeutung. Es
+ * beweist dem Server nur „gehört zu irgendeiner echten Analyse" — im
+ * Log-Ereignis und im Aggregat landet es nie, und in der Datenbank liegt
+ * ohnehin nur sein Hash (bis zur Entwertung).
+ */
+
+const RC_TICKET_KEY = "malzime.queueRcTicket";
+
+/** Merkt das vom Server ausgegebene Ticket (api.js, bei `done`). */
+export function speichereRcTicket(ticket) {
+  try {
+    if (typeof ticket === "string" && ticket.length > 0) {
+      sessionStorage.setItem(RC_TICKET_KEY, ticket);
+    }
+  } catch (_) {
+    /* ohne Speicher keine Stimme — der Check funktioniert am Bildschirm trotzdem */
+  }
+}
+
+/** Liest das gemerkte Ticket (telemetry-logger.js, beim Absenden) — oder null. */
+export function leseRcTicket() {
+  try {
+    return sessionStorage.getItem(RC_TICKET_KEY);
+  } catch (_) {
+    return null;
+  }
+}
+
+/** Räumt das Ticket weg (api.js: neuer Auftrag / Aufräumen des Tab-Stands). */
+export function loescheRcTicket() {
+  try {
+    sessionStorage.removeItem(RC_TICKET_KEY);
+  } catch (_) {
+    /* dito */
+  }
+}

--- a/public/js/telemetry-logger.js
+++ b/public/js/telemetry-logger.js
@@ -9,6 +9,7 @@
  */
 
 import { collectClientContext, coarseUserAgent } from "./client-context.js";
+import { leseRcTicket } from "./rc-ticket.js";
 
 const TELEMETRY_ENDPOINT = "/api/telemetry";
 
@@ -43,17 +44,28 @@ export function logTelemetry(eventType, context = {}) {
 /**
  * Realitäts-Check (v3.1): meldet die Selbsteinschätzung als anonymes
  * Ereignis. BEWUSST ein eigener, minimaler Pfad statt logTelemetry():
- * Es gehen AUSSCHLIESSLICH die Kategorie-Stufen über die Leitung — keine
- * traceId, keine jobId, kein UserAgent, keine Geräteklassen, nichts, was
- * die Eingabe mit einer Analyse oder einem Gerät verknüpfen könnte
- * (Privacy-Zusage der Spezifikation). Den Score rechnet der Server selbst.
+ * Es gehen AUSSCHLIESSLICH die Kategorie-Stufen und das Einmal-Ticket über
+ * die Leitung — keine traceId, keine jobId, kein UserAgent, keine
+ * Geräteklassen, nichts, was die Eingabe mit einer Analyse oder einem Gerät
+ * verknüpfen könnte (Privacy-Zusage der Spezifikation). Den Score rechnet
+ * der Server selbst.
+ *
+ * KA-02: Das Ticket (ein bedeutungsloser Zufallswert aus der
+ * job-status-Antwort) beweist dem Server nur „echte Analyse" und wird dort
+ * sofort entwertet — er loggt und speichert es nicht. Ohne Ticket zählt die
+ * Stimme nicht; gesendet wird trotzdem NICHT anders (der Bildschirm-Check
+ * funktioniert unabhängig davon).
  */
 export function logRealitaetsCheck(stufen) {
   try {
+    const ticket = leseRcTicket();
+    const nutzlast = ticket
+      ? { eventType: "realitaets-check", stufen, ticket }
+      : { eventType: "realitaets-check", stufen };
     fetch(TELEMETRY_ENDPOINT, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ eventType: "realitaets-check", stufen }),
+      body: JSON.stringify(nutzlast),
       keepalive: true,
     }).catch(() => {});
   } catch (_) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -2564,6 +2564,12 @@ ol.legal-list > li::before {
   margin-top: 0;
   margin-bottom: 28px;
 }
+/* KA-08: Einordnung VOR dem Upload — kompakt, ohne den grossen Abstand der
+   Basis-Klasse (die 32px oben gehoeren zur Position nach dem Ergebnis). */
+.disclaimer--einordnung {
+  margin-top: 0;
+  margin-bottom: 24px;
+}
 .disclaimer__workshop {
   margin-top: 8px;
   color: var(--muted) !important;

--- a/scripts/log-sink-analyse-zeilen.sh
+++ b/scripts/log-sink-analyse-zeilen.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# KA-04 (Kurzaudit 2026-08-12): Analyse-Logzeilen 30 Tage aufheben.
+#
+# Problem: Der Standard-Log-Speicher (_Default) hebt nur 1 Tag auf. Die
+# Zeilen `step:"mistral-single-large"` (Dauer, Token-Zahlen, cachedTokens)
+# sind damit am Folgetag weg — die geplanten September-Messungen
+# (Prompt-Caching-Trefferquote unter Last, HEIC-Formatanteile) waeren
+# unmoeglich.
+#
+# Loesung: Der bestehende 30-Tage-Speicher `client-diagnostics`
+# (europe-west1, beschrieben als "Anonyme Client-Diagnose ... keine PII,
+# keine IPs") bekommt diese Zeilen dazu. Sie enthalten Schritt-Name, Dauer
+# und Token-Zahlen — keine IP, kein Bild, nichts Personenbezogenes. Die
+# 30-Tage-Zusage der Datenschutzerklaerung ("vollstaendig anonyme
+# Diagnose-Daten ohne Personenbezug ... bis zu 30 Tage") deckt sie ab.
+#
+# Ausfuehren: einmalig nach Freigabe (kein Deploy noetig, wirkt sofort).
+# Ruecknahme: denselben Befehl mit dem alten Filter (nur die zwei
+# client-*-Typen) erneut ausfuehren.
+set -euo pipefail
+
+PROJECT="malzime"
+SINK="client-diagnostics-sink"
+FILTER='jsonPayload.type="client-error" OR jsonPayload.type="client-telemetry" OR jsonPayload.step="mistral-single-large"'
+
+echo "Erweitere Filter von ${SINK} (Projekt ${PROJECT}) ..."
+gcloud logging sinks update "${SINK}" \
+  --project="${PROJECT}" \
+  --log-filter="${FILTER}"
+
+echo
+echo "Kontrolle — aktiver Filter:"
+gcloud logging sinks describe "${SINK}" --project="${PROJECT}" --format='value(filter)'
+echo
+echo "Fertig. Nachweis nach der naechsten echten Analyse:"
+echo "  gcloud logging read 'jsonPayload.step=\"mistral-single-large\"' \\"
+echo "    --project=${PROJECT} --bucket=client-diagnostics --location=europe-west1 \\"
+echo "    --view=_AllLogs --limit=3 --freshness=1d"


### PR DESCRIPTION
Sanierung nach dem Kurzaudit des v3-Tags (Prüfstand 79ec393). Details im CHANGELOG-Eintrag [3.0.2].

- **KA-02:** Realitäts-Check-Zählung an ein Einmal-Ticket aus der echten Analyse gebunden (Ausgabe bei Erstauslieferung, Hash am Job-Dokument, transaktionale Entwertung; Ticket wird nie geloggt).
- **KA-11:** Live-Text-Extraktion am Modus-Schlüssel verankert statt an der Reihenfolge der Vorkommen.
- **KA-03:** release.yml abbruchfest — Zeiger-Protokoll, Löschreihenfolge erst Tag → dann Release, Wache gegen Release auf fremden Tag, concurrency-Sperre.
- **KA-05:** Auge-Nachwache an ihren Analyse-Lauf gebunden (Lauf-Kennung).
- **KA-08:** Einordnung „nichts davon ist wahr" sichtbar VOR dem Upload.
- **KA-09:** 429-Antwortrumpf wird aktiv verworfen.
- **KA-07:** Rate-Limit-Kommentare auf das heutige Tier-System korrigiert.
- **KA-04:** Skript für die 30-Tage-Aufbewahrung der Analyse-Logzeilen (Infra, Ausführung beim Deploy).

Suiten: Backend 726 / Frontend 315 / E2E 18 — grün. Lint sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)