### PR TITLE
docs: Doku-Drift bereinigt (Testzahlen, Prüfstand-Rahmung, Queue-Absatz, GPS-Wording)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Workshop-Tool fuer Medienkompetenz und Datenschutz-Sensibilisierung. Zeigt Teiln
 - **Datenwert-Rechner**: Zeigt was ein Profil fuer Datenbroker wert ist
 - **Privacy-Check**: Erkennt ungewollt preisgegebene Informationen (Telefonnummern, Adressen, Kennzeichen)
 - **EXIF-Analyse**: Zeigt versteckte Kamera-Metadaten (client-seitig extrahiert)
-- **GPS-Karte**: Zeigt den Aufnahmeort auf einer Karte (GPS verlässt nie den Browser)
+- **GPS-Karte**: Zeigt den Aufnahmeort auf einer Karte (GPS-Daten erreichen nie unsere Server; die Karte lädt der Browser direkt bei OpenStreetMap)
 - **Easter Egg**: Tierfotos bekommen ein lustiges Spass-Profil
 - **PDF-Export**: Ergebnisse als PDF speichern (fuer Workshop-Diskussionen)
 - **Demo-Fotos**: 3 anklickbare KI-generierte Demo-Fotos (keine realen Personen, siehe `public/img/demo/LICENSE.md`) mit Fake-EXIF fuer Workshops (echte KI-Analyse, kein vorgefertigtes Ergebnis)
@@ -219,14 +219,19 @@ zurueckkehrt, und ein Neuladen funktioniert ebenfalls.
 
 ## Tests
 
+Alle Suiten laufen automatisiert in der CI bei jedem Push und Pull Request
+([GitHub Actions](https://github.com/malziland/malzime/actions)) — der
+verbindliche Stand ist immer der letzte CI-Lauf, deshalb stehen hier bewusst
+keine festen Testzahlen.
+
 ```bash
-# Backend (Jest, 611 Tests)
+# Backend (Jest)
 cd functions && npm test
 
-# Frontend (Vitest + jsdom, 193 Tests)
+# Frontend (Vitest + jsdom)
 npm run test:frontend
 
-# E2E (Playwright, 5 Tests)
+# E2E (Playwright)
 npm run test:e2e
 
 # Coverage
@@ -240,11 +245,11 @@ cd functions && npm run format:check   # Backend Prettier
 npm run format:frontend:check          # Frontend Prettier
 ```
 
-**Backend (611 Tests):** HTTP-Handler, Admin-Endpunkte, Stats-Handler, HMAC-Auth, Nonce-Flow, Tier-Erkennung (SUBJECT-basiert), Config, Counter, Middleware (Rate Limiting), Privacy-Risiken (aus Mistrals "Sichtbarer Text"), Upload-Parsing, Magic-Byte-Validierung, XML-Escaping, ntfy-Benachrichtigungen, i18n-Guardian, Mistral-Integration (Mock-Tests), JSON-Repair (4-stufig), Throttle-Semaphore, Queue (Job-Lebenszyklus, Reaper, Feature-Flag, Cloud-Tasks-Anbindung, Abhol-Ticket).
+**Backend:** HTTP-Handler, Admin-Endpunkte, Stats-Handler, HMAC-Auth, Nonce-Flow, Tier-Erkennung (SUBJECT-basiert), Config, Counter, Middleware (Rate Limiting), Privacy-Risiken (aus Mistrals "Sichtbarer Text"), Upload-Parsing, Magic-Byte-Validierung, XML-Escaping, ntfy-Benachrichtigungen, i18n-Guardian, Mistral-Integration (Mock-Tests), JSON-Repair (4-stufig), Throttle-Semaphore, Queue (Job-Lebenszyklus, Reaper, Feature-Flag, Cloud-Tasks-Anbindung, Abhol-Ticket).
 
-**Frontend (193 Tests):** DOM-Helpers, State, Scan-Animation, Limit-Banner, Maintenance-Modal, Geocoding, Render-Pipeline, API-Integration, Warteschlange samt Wiederaufnahme, Stats-Seite, i18n-Modul, i18n-Guardian.
+**Frontend:** DOM-Helpers, State, Scan-Animation, Limit-Banner, Maintenance-Modal, Geocoding, Render-Pipeline, API-Integration, Warteschlange samt Wiederaufnahme, Stats-Seite, i18n-Modul, i18n-Guardian.
 
-**E2E (5 Tests):** Playwright — Smoke-Tests (Demo-Flow, fehlerfreies Laden), axe-A11y-Gate (Startseite + Profil-Ansicht) und Tastatur-Durchlauf.
+**E2E:** Playwright — Smoke-Tests (Demo-Flow, fehlerfreies Laden), axe-A11y-Gate (Startseite + Profil-Ansicht) und Tastatur-Durchlauf.
 
 ## CI/CD
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,11 +114,13 @@ Der Client hält keine lange Verbindung mehr, sondern pollt. Jeder `job-status`-
 
 ### Reaper
 
-`reapJobs` läuft im Minutentakt und räumt drei Sorten auf: verlassene wartende Jobs (`queued` ohne Herzschlag → `abandoned`), hängende Jobs (`processing` über dem Timeout → `failed`) und abgelaufene Job-Dokumente (älter als `JOB_RETENTION_MS` = 2 h → gelöscht).
+`reapJobs` läuft im Minutentakt und räumt auf: verlassene wartende Jobs (`queued` ohne Herzschlag → `abandoned`), hängende Jobs (`processing` über dem Timeout → `failed`), überfällige wartende Jobs (älter als `MAX_QUEUED_AGE_MS` = 35 min → `abandoned`, auch wenn noch gepollt wird), zugestellte Ergebnisse nach dem Browser-Wiederholungs-Fenster (15 min ab Erstzustellung → gelöscht, PRIV-107b) und abgelaufene Job-Dokumente (älter als `JOB_RETENTION_MS` = 2 h → gelöscht). Bei `abandoned` wird der Stunden-Slot zurückgegeben und das zwischengespeicherte Bild mitgelöscht.
 
 ### Einlass-Politik
 
-Der Enqueue prüft bewusst **keine Queue-Tiefe** — der Einlass ist allein durch das Stundenlimit begrenzt (500/h). Das liegt sogar knapp **unter** dem Verarbeitungs-Durchsatz (~387 Analysen/h bei Concurrency 7 × ~65 s/Job), der Durchsatz liegt damit UNTER dem Einlass. Deshalb bremst der Einlass seit dem Audit 2026-08-10 ab einer Warteschlangen-Tiefe von 155 (`MAX_QUEUE_DEPTH`) ehrlich ab, statt Auftraege anzunehmen, die den 30-Minuten-Deckel des Browsers ueberschreiten — das Stundenlimit deckelt den Einlass, bevor die Queue-Tiefe je zum Problem wird. Zusätzlich: Nutzer sehen Position + ETA sofort nach dem Upload und können selbst entscheiden, ob sie warten; Abbrecher werden nach der 8-Minuten-Karenz gereapt und geben ihren Stunden-Slot zurück (Selbstregulation). Der Client deckelt das Polling bei 30 min. Bewusste Entscheidung, bestätigt im LANGAUDIT 2026-07 (ARCH-001).
+Der Einlass ist doppelt begrenzt: durch das **globale Stundenlimit** (500/h, rollendes 60-Minuten-Fenster in Firestore) und durch die **Queue-Tiefen-Bremse** — ab 155 wartenden Jobs (`MAX_QUEUE_DEPTH`) lehnt der Enqueue neue Aufträge ehrlich ab, statt Wartezeiten anzunehmen, die den 30-Minuten-Polling-Deckel des Browsers überschreiten würden. In der Praxis greift fast immer das Stundenlimit zuerst: 500/h Einlass steht einem Verarbeitungs-Durchsatz von ~387 Analysen/h gegenüber (Concurrency 7 × ~65 s/Job).
+
+Dazu kommt die Selbstregulation: Nutzer sehen Position + ETA sofort nach dem Upload und können selbst entscheiden, ob sie warten. Abbrecher werden nach der 8-Minuten-Karenz gereapt und geben ihren Stunden-Slot zurück. Wartende Jobs haben zusätzlich ein absolutes Höchstalter von 35 Minuten (`MAX_QUEUED_AGE_MS`) — fortlaufendes Pollen hält einen Job also nicht unbegrenzt am Leben.
 
 ### Lokaler Betrieb
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1,18 +1,21 @@
 # Verifikationsmatrix
 
+**Datierter Prüfstand — keine Aussage über den heutigen Zustand.**
 Welche Qualitäts- und Sicherheitsanforderung ist wodurch **belegt** — nicht behauptet.
 Jede Zeile nennt den Nachweisweg (Befehl bzw. CI-Job) und das letzte belastbare
-Ergebnis mit Referenz (Commit, CI-Run, Datum). Audits nutzen diese Tabelle als
-Einstieg; ein Datum allein ist keine Evidenz. Einträge mit Status **offen** sind
-bewusst als offen ausgewiesen.
+Ergebnis mit Referenz (Commit, CI-Run, Datum). Die Zahlen und Häkchen beschreiben
+den Stand **zum jeweils genannten Datum**; der aktuelle Stand ergibt sich immer
+aus einem frischen Lauf des genannten Nachweiswegs (bzw. dem letzten CI-Lauf).
+Audits nutzen diese Tabelle als Einstieg; ein Datum allein ist keine Evidenz.
+Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 ## Kernnachweise
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 611/611 grün — lokal auf dem Sanierungsstand, 2026-08-10 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 193/193 grün — lokal auf dem Sanierungsstand, 2026-08-10 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 10/10 grün (Smoke 2, A11y 4 inkl. Beast Mode, Tastatur 1, Sticky 3) — 2026-08-10 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 726/726 grün — lokal auf `main` (v3.0.3), 2026-08-12 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 315/315 grün — lokal auf `main` (v3.0.3), 2026-08-12 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 18/18 grün (Smoke, A11y inkl. Beast Mode, Tastatur, Sticky-Toggle, Modus-Merken, Live-Anzeige, Realitäts-Check, Start-ohne-Hinweis) — lokal auf `main` (v3.0.3), 2026-08-12 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node scripts/audit-gate.mjs functions` (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |


### PR DESCRIPTION
## Was

Punkt 3 des Codex-Konsens (Review 2026-08-12) — Doku-Bereinigung nach dem differenzierten Plan:

- **README.md:** Feste Testzahlen (611/193/5) entfernt — der verbindliche Stand ist der letzte CI-Lauf, darauf wird jetzt verwiesen. Zusätzlich die Formulierung „GPS verlässt nie den Browser" durch die regelkonforme Fassung ersetzt (Nominatim/OSM-Kacheln gehen nachweisbar vom Browser ins Netz; korrekt ist: GPS-Daten erreichen nie unsere Server).
- **docs/VERIFICATION.md:** Kopf rahmt die Datei jetzt ausdrücklich als **datierten Prüfstand** (keine Aussage über heute). Die drei Suiten-Zeilen einmalig auf den echten Stand gehoben: 726 Backend / 315 Frontend / 18 E2E, alle lokal auf `main` (v3.0.3) am 2026-08-12 grün gelaufen. E2E-Zeile nennt jetzt Testdateien statt Unterzahlen (keine neue Drift-Falle).
- **docs/ARCHITECTURE.md:** Der sich selbst widersprechende Absatz „Einlass-Politik" („prüft bewusst keine Queue-Tiefe" vs. „bremst ab 155") ist neu geschrieben — nur noch der Ist-Zustand: Stundenlimit 500/h + Queue-Tiefen-Bremse 155 + 35-min-Höchstalter. Der Reaper-Absatz daneben hatte dieselbe Drift („drei Sorten", real fünf Zweige) und ist mitgezogen.

## Beleg

Baseline vor dem Umbau, lokal auf `main`: Backend 726/726, Frontend 315/315, E2E 18/18 — alle grün.

Kein Code geändert, kein Deploy nötig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)