### PR TITLE
feat: Infrastruktur-Prüfskript verify-infrastructure.sh + Deploy-Riegel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+**Wartungszug aus der externen Code-Review (Codex, 2026-08-12; drei Punkte im
+Konsens beider Prüfungen):**
+
+- **Sicherheit — Nonce-Verbrauch fail-closed:** Ließ sich der Verbrauch einer
+  Admin-Nonce nicht in Firestore festhalten, galt sie bisher trotzdem als
+  gültig (fail-open) — der Replay-Schutz war genau dann wirkungslos. Jetzt
+  gilt sie als nicht einlösbar: 403, keine Mutation. Kostet nichts: Der
+  Bearer-Notweg nutzt keine Nonce, und Boost/Reset schreiben selbst in
+  Firestore, wären bei einem Ausfall also ohnehin gescheitert.
+- **Betrieb — Infrastruktur-Prüfskript:** Neues, ausschließlich lesendes
+  `scripts/verify-infrastructure.sh` gleicht vor jedem Deploy den Ist-Zustand
+  der Cloud gegen den RUNBOOK-Soll-Zustand ab (Queue-Region+Concurrency,
+  Bucket-Region+Lifecycle+Soft-Delete, Firestore nur `malzime-eu`,
+  Worker nicht öffentlich, Functions-Regionen, Log-Ausschlüsse). In
+  `deploy.sh` verankert (Notschalter `SKIP_INFRA=1`); ein CI-Test erzwingt,
+  dass das Skript nie etwas verändern kann (nur Lese-Kommandos erlaubt).
+  Erstlauf gegen die echte Infrastruktur: alle Prüfungen grün.
+- **Doku — Drift bereinigt:** Feste Testzahlen aus dem README entfernt (der
+  verbindliche Stand ist der letzte CI-Lauf), `VERIFICATION.md` ausdrücklich
+  als datierter Prüfstand gerahmt und einmalig aktualisiert, der sich selbst
+  widersprechende Queue-Absatz in `ARCHITECTURE.md` neu geschrieben
+  (Stundenlimit + Tiefen-Bremse + 35-min-Höchstalter), Reaper-Absatz auf die
+  fünf realen Aufräum-Zweige gebracht, GPS-Formulierung im README
+  regelkonform präzisiert.
+
 ## [3.0.3] — 2026-08-11
 
 **Wording-Korrektur:** „Privat finanziert" heißt jetzt überall

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -40,6 +40,40 @@ läuft der Ablauf vollständig durch (dokumentiert in ADR-0001).
 5. `release.yml` legt automatisch einen GitHub-Release an, sobald die neue
    CHANGELOG-Version auf `main` landet (idempotent).
 
+## Infrastruktur-Prüfung (`scripts/verify-infrastructure.sh`)
+
+Ein Teil der Sicherheits- und Datenschutz-Zusagen lebt **außerhalb des Repos**
+in der Cloud-Konfiguration — `firebase deploy` verwaltet sie nicht. Das
+Prüfskript gleicht den Ist-Zustand **nur lesend** gegen den Soll-Zustand ab
+und läuft automatisch in `deploy.sh` vor jedem Deploy (Notschalter
+`SKIP_INFRA=1`, z. B. wenn die gcloud-Anmeldung abgelaufen ist und ein
+dringender Rollback nicht warten darf). Es kann jederzeit auch direkt
+gestartet werden.
+
+**Was es prüft (= der Soll-Zustand):**
+
+| Bereich | Soll |
+|---|---|
+| Cloud-Tasks-Queue `analyze-queue` | existiert in `europe-west1`, Concurrency 7, RUNNING |
+| Bucket `malzime-queue-uploads` | Region `EUROPE-WEST1`, Lifecycle-Löschregel nach 1 Tag aktiv, Soft-Delete 0 |
+| Firestore | genau **eine** Datenbank: `malzime-eu` in `europe-west1` |
+| Worker-IAM | `processjob` und `reapjobs` ohne `allUsers`/`allAuthenticatedUsers` (nicht öffentlich; die `/api/*`-Functions sind bewusst öffentlich, Hosting reicht durch) |
+| Functions-Regionen | alle in `europe-west1` |
+| Logging | `_Default`-Ausschluss `exclude_run_request_routine` aktiv, Sink `client-diagnostics-sink` vorhanden |
+
+Exit-Codes: 0 = grün, 1 = Abweichung (Deploy stoppt), 2 = Voraussetzung fehlt
+(gcloud nicht da/nicht angemeldet). Der Test
+`functions/src/__tests__/verify-infrastructure-script.test.js` erzwingt in der
+CI, dass das Skript ausschließlich Lese-Kommandos enthält.
+
+**Grenze des Skripts — ZDR ist Vertrag, nicht Konfiguration:** Die
+Zero-Data-Retention-Zusage von Mistral lässt sich technisch nicht abfragen.
+Ihr Nachweis ist organisatorisch: privater Nachweisordner beim Inhaber
+(ZDR-/Trainings-Opt-out-Screenshots vom 2026-08-11, Vertrags-/DPA-Unterlagen —
+bewusst NICHT im öffentlichen Repo) plus Wiedervorlage: **vor jeder
+Presse-Welle und mindestens halbjährlich** im Mistral-Dashboard nachprüfen
+und den Screenshot-Stand erneuern.
+
 ## Rollback-Hebel
 
 Vom schnellsten zum gründlichsten. Alle Flag-Hebel wirken **ohne Deploy** binnen

--- a/functions/src/__tests__/verify-infrastructure-script.test.js
+++ b/functions/src/__tests__/verify-infrastructure-script.test.js
@@ -1,0 +1,78 @@
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+/**
+ * Wächter für scripts/verify-infrastructure.sh (Codex-Review 2026-08-12).
+ *
+ * Das Skript verspricht in seinem Kopf: AUSSCHLIESSLICH LESEND. Dieses
+ * Versprechen ist sicherheitskritisch — es läuft vor jedem Deploy und mit
+ * den vollen Rechten des angemeldeten gcloud-Kontos. Würde jemand später
+ * ein `update`/`delete`/`set-iam-policy` hineinbauen, wäre aus dem Prüf-
+ * ein Eingriffs-Skript geworden, ohne dass es jemandem auffällt.
+ *
+ * Darum erzwingt dieser Test statisch: Jede Zeile, die gcloud oder gsutil
+ * aufruft, muss ein bekanntes Lese-Kommando sein. Kein Netzwerk, keine
+ * Cloud-Aufrufe — reine Textanalyse plus Bash-Syntaxprüfung.
+ */
+
+const SCRIPT = path.join(__dirname, "../../../scripts/verify-infrastructure.sh");
+const DEPLOY = path.join(__dirname, "../../../scripts/deploy.sh");
+
+/* Lese-Kommandos, die das Prüfskript benutzen darf. Bewusst eng gefasst:
+   Wer ein neues braucht, erweitert die Liste hier im selben Commit —
+   dann sieht der Review die Erweiterung. */
+const ERLAUBTE_LESE_MUSTER = [
+  /gcloud (tasks queues|storage buckets|firestore databases|functions|run services|logging sinks) (describe|list|get-iam-policy)\b/,
+  /gcloud auth list\b/,
+  /command -v gcloud/,
+];
+
+function gcloudZeilen(inhalt) {
+  /* Nur echte AUFRUFE zählen (Zeilenanfang, `$(...)` oder `command -v`) —
+     nicht jede Erwähnung des Wortes in echo-Meldungen oder Strings. */
+  const aufruf = /(^\s*|\$\(\s*|command -v )(gcloud|gsutil)\b/;
+  return inhalt
+    .split("\n")
+    .map((zeile, i) => ({ zeile, nr: i + 1 }))
+    .filter(({ zeile }) => {
+      const ohneKommentar = zeile.replace(/^\s*#.*/, "");
+      return aufruf.test(ohneKommentar);
+    });
+}
+
+describe("verify-infrastructure.sh", () => {
+  const inhalt = fs.readFileSync(SCRIPT, "utf8");
+
+  test("existiert und ist ausführbar", () => {
+    const stat = fs.statSync(SCRIPT);
+    expect(stat.mode & 0o100).toBeTruthy();
+  });
+
+  test("Bash-Syntax ist gültig (bash -n)", () => {
+    expect(() => execSync(`bash -n "${SCRIPT}"`, { stdio: "pipe", timeout: 15000 })).not.toThrow();
+  });
+
+  test("jede gcloud-/gsutil-Zeile ist ein bekanntes LESE-Kommando", () => {
+    const verstoesse = gcloudZeilen(inhalt).filter(
+      ({ zeile }) => !ERLAUBTE_LESE_MUSTER.some((muster) => muster.test(zeile))
+    );
+    expect(verstoesse).toEqual([]);
+  });
+
+  test("enthält kein einziges bekanntes Schreib-Verb für gcloud/gsutil", () => {
+    /* Doppelter Boden zur Allowlist oben: selbst wenn jemand die Allowlist
+       aufweicht, schlagen bekannte Schreib-Verben hier separat an. */
+    const schreibVerben =
+      /\b(update|create|delete|deploy|patch|import|set-iam-policy|add-iam-policy-binding|remove-iam-policy-binding|lifecycle set|iam ch|rm|cp|mv|rsync)\b/;
+    for (const { zeile, nr } of gcloudZeilen(inhalt)) {
+      expect({ nr, schreibt: schreibVerben.test(zeile) }).toEqual({ nr, schreibt: false });
+    }
+  });
+
+  test("deploy.sh ruft die Infrastruktur-Prüfung mit SKIP_INFRA-Notschalter auf", () => {
+    const deploy = fs.readFileSync(DEPLOY, "utf8");
+    expect(deploy).toMatch(/SKIP_INFRA/);
+    expect(deploy).toMatch(/verify-infrastructure\.sh/);
+  });
+});

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,6 +30,16 @@ else
   npm run test:frontend
 fi
 
+# ── Infra-Riegel: Ist-Zustand der Cloud gegen den RUNBOOK-Soll-Zustand ──
+# Nur lesend (Queue, Bucket, Firestore, Worker-IAM, Regionen, Logging).
+# Notschalter fuer den Ernstfall (z. B. gcloud-Anmeldung abgelaufen und ein
+# dringender Rollback darf nicht warten): SKIP_INFRA=1
+if [ "${SKIP_INFRA:-0}" = "1" ]; then
+  echo "WARNUNG: SKIP_INFRA=1 gesetzt — Infrastruktur-Pruefung wird UEBERSPRUNGEN."
+else
+  ./scripts/verify-infrastructure.sh
+fi
+
 # ── Cache-Busting-Version generieren (Konvention: ?v=YYYYMMDDNN) ──
 # Aktuellen Buster aus index.html lesen; am selben Tag laufende Nummer +1,
 # sonst neuer Tag mit laufender Nummer 01.

--- a/scripts/verify-infrastructure.sh
+++ b/scripts/verify-infrastructure.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# malziME Infrastruktur-Prüfskript — AUSSCHLIESSLICH LESEND.
+#
+# Prüft den Ist-Zustand der Cloud-Infrastruktur gegen den Soll-Zustand aus
+# docs/RUNBOOK.md („Normalbetrieb"). Hintergrund (Codex-Review 2026-08-12):
+# Ein Teil der Sicherheits- und Datenschutz-Zusagen lebt NICHT im Repo,
+# sondern in der Cloud-Konfiguration — `firebase deploy` verwaltet sie nicht.
+# Dieses Skript macht die Regel „Zusagen über Infrastruktur werden an der
+# Infrastruktur belegt" automatisch statt händisch.
+#
+# Es verändert NICHTS: nur describe/list/get-iam-policy. Der Test
+# functions/src/__tests__/verify-infrastructure-script.test.js erzwingt das
+# (jede gcloud-/gsutil-Zeile muss ein Lese-Kommando sein).
+#
+# Nutzung:
+#   ./scripts/verify-infrastructure.sh      # direkt
+#   (läuft automatisch in scripts/deploy.sh; Notschalter: SKIP_INFRA=1)
+#
+# Exit-Codes: 0 = alles grün · 1 = Abweichung gefunden · 2 = Voraussetzung fehlt
+
+set -u
+cd "$(dirname "$0")/.."
+
+PROJECT="malzime"
+REGION="europe-west1"
+BUCKET="gs://malzime-queue-uploads"
+QUEUE="analyze-queue"
+
+FEHLER=0
+
+gruen() { printf "  \033[32m✓\033[0m %s\n" "$1"; }
+rot()   { printf "  \033[31m✗\033[0m %s\n" "$1"; FEHLER=1; }
+
+pruef() { # $1 Beschreibung, $2 Soll, $3 Ist
+  if [ "$2" = "$3" ]; then
+    gruen "$1: $3"
+  else
+    rot "$1: SOLL »${2}«, IST »${3:-<leer>}«"
+  fi
+}
+
+# ── Voraussetzungen ──
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "FEHLER: gcloud nicht gefunden — Prüfung nicht möglich." >&2
+  exit 2
+fi
+KONTO=$(gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null | head -1)
+if [ -z "$KONTO" ]; then
+  echo "FEHLER: Keine aktive gcloud-Anmeldung. Bitte im Terminal 'gcloud auth login' ausführen." >&2
+  exit 2
+fi
+
+echo "Infrastruktur-Prüfung malziME (Projekt $PROJECT, angemeldet: $KONTO)"
+
+# ── 1. Cloud-Tasks-Queue: Region + Concurrency + Status ──
+echo "— Cloud-Tasks-Queue"
+QUEUE_INFO=$(gcloud tasks queues describe "$QUEUE" --location="$REGION" --project="$PROJECT" \
+  --format="value(rateLimits.maxConcurrentDispatches,state)" 2>/dev/null || true)
+QUEUE_CONC=$(printf "%s" "$QUEUE_INFO" | cut -f1)
+QUEUE_STATE=$(printf "%s" "$QUEUE_INFO" | cut -f2)
+# Dass describe mit --location=$REGION antwortet, IST der Regions-Beleg.
+if [ -z "$QUEUE_INFO" ]; then
+  rot "Queue »${QUEUE}« in $REGION nicht gefunden (falsche Region oder gelöscht?)"
+else
+  gruen "Queue »${QUEUE}« existiert in $REGION"
+  pruef "Concurrency (RUNBOOK: 7 seit v2.8)" "7" "$QUEUE_CONC"
+  pruef "Queue-Status" "RUNNING" "$QUEUE_STATE"
+fi
+
+# ── 2. Upload-Bucket: EU-Region, Lifecycle-Sicherheitsnetz, Soft-Delete aus ──
+echo "— Upload-Bucket ($BUCKET)"
+BUCKET_JSON=$(gcloud storage buckets describe "$BUCKET" --format=json 2>/dev/null || true)
+if [ -z "$BUCKET_JSON" ]; then
+  rot "Bucket nicht lesbar/nicht gefunden"
+else
+  printf "%s" "$BUCKET_JSON" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+ok = True
+loc = d.get("location", "")
+if loc == "EUROPE-WEST1":
+    print("  OK Region: " + loc)
+else:
+    print("  FEHLT Region: SOLL EUROPE-WEST1, IST " + (loc or "<leer>")); ok = False
+# Soft-Delete 0: geloescht heisst geloescht (PRIV-Zusage, Stand 2026-08).
+# gcloud liefert die Bucket-Schluessel in snake_case (soft_delete_policy),
+# die Unterschluessel aber in camelCase — beide Varianten abfangen.
+sd_policy = d.get("soft_delete_policy") or d.get("softDeletePolicy") or {}
+sd = str(sd_policy.get("retentionDurationSeconds", sd_policy.get("retention_duration_seconds", "<leer>")))
+if sd in ("0", "0s"):
+    print("  OK Soft-Delete: aus (0)")
+else:
+    print("  FEHLT Soft-Delete: SOLL 0, IST " + sd); ok = False
+# Lifecycle: Delete nach 1 Tag als Sicherheitsnetz hinter der aktiven Loeschung
+rules = (d.get("lifecycle_config") or d.get("lifecycle") or {}).get("rule") or []
+netz = [r for r in rules
+        if (r.get("action") or {}).get("type") == "Delete"
+        and (r.get("condition") or {}).get("age") == 1]
+if netz:
+    print("  OK Lifecycle: Delete nach 1 Tag aktiv")
+else:
+    print("  FEHLT Lifecycle: keine Delete-Regel mit age=1 gefunden"); ok = False
+sys.exit(0 if ok else 1)
+' | sed -e "s/^  OK /  \x1b[32m✓\x1b[0m /" -e "s/^  FEHLT /  \x1b[31m✗\x1b[0m /"
+  # Python-Exitcode steckt wegen der sed-Pipe in PIPESTATUS[0]
+  if [ "${PIPESTATUS[0]}" != "0" ]; then FEHLER=1; fi
+fi
+
+# ── 3. Firestore: genau EINE Datenbank, malzime-eu in europe-west1 ──
+echo "— Firestore"
+DBS=$(gcloud firestore databases list --project="$PROJECT" --format="value(name,locationId)" 2>/dev/null || true)
+DB_ANZAHL=$(printf "%s\n" "$DBS" | grep -c "databases/" || true)
+if [ "$DB_ANZAHL" != "1" ]; then
+  rot "Datenbank-Anzahl: SOLL 1, IST $DB_ANZAHL ($(printf "%s" "$DBS" | tr '\n' ' '))"
+else
+  DB_NAME=$(printf "%s" "$DBS" | cut -f1)
+  DB_LOC=$(printf "%s" "$DBS" | cut -f2)
+  pruef "Datenbank" "projects/$PROJECT/databases/malzime-eu" "$DB_NAME"
+  pruef "Firestore-Region" "$REGION" "$DB_LOC"
+fi
+
+# ── 4. Worker-IAM: processJob + reapJobs dürfen NICHT öffentlich sein ──
+# (enqueue/jobStatus/... sind bewusst öffentlich: Firebase Hosting reicht
+#  die /api/*-Aufrufe an sie durch.)
+echo "— Worker-Zugriffsschutz"
+for DIENST in processjob reapjobs; do
+  IAM=$(gcloud run services get-iam-policy "$DIENST" --region="$REGION" --project="$PROJECT" --format=json 2>/dev/null || true)
+  if [ -z "$IAM" ]; then
+    rot "$DIENST: IAM-Policy nicht lesbar"
+  elif printf "%s" "$IAM" | grep -qE '"(allUsers|allAuthenticatedUsers)"'; then
+    rot "$DIENST: ÖFFENTLICH erreichbar (allUsers/allAuthenticatedUsers gefunden!)"
+  else
+    gruen "$DIENST: nicht öffentlich (kein allUsers/allAuthenticatedUsers)"
+  fi
+done
+
+# ── 5. Alle Functions in der EU-Region ──
+echo "— Functions-Regionen"
+AUSSERHALB=$(gcloud functions list --project="$PROJECT" --format=json 2>/dev/null \
+  | python3 -c '
+import json, sys
+for f in json.load(sys.stdin):
+    teile = f["name"].split("/")           # projects/P/locations/REGION/functions/NAME
+    if teile[3] != "europe-west1":
+        print(teile[3] + ":" + teile[5])
+' || true)
+if [ -z "$AUSSERHALB" ]; then
+  gruen "alle Functions in $REGION"
+else
+  rot "Functions außerhalb $REGION: $AUSSERHALB"
+fi
+
+# ── 6. Logging: Routine-Ausschlüsse + Diagnose-Sink ──
+echo "— Logging"
+EXCL=$(gcloud logging sinks describe _Default --project="$PROJECT" --format=json 2>/dev/null \
+  | python3 -c 'import json,sys; print(" ".join(e["name"] for e in json.load(sys.stdin).get("exclusions",[])))' || true)
+case " $EXCL " in
+  *" exclude_run_request_routine "*) gruen "_Default: Routine-Request-Ausschluss aktiv" ;;
+  *) rot "_Default: Ausschluss »exclude_run_request_routine« fehlt (IST: ${EXCL:-<keine>})" ;;
+esac
+SINKS=$(gcloud logging sinks list --project="$PROJECT" --format="value(name)" 2>/dev/null || true)
+case " $(printf "%s" "$SINKS" | tr '\n' ' ') " in
+  *" client-diagnostics-sink "*) gruen "Diagnose-Sink »client-diagnostics-sink« vorhanden" ;;
+  *) rot "Diagnose-Sink »client-diagnostics-sink« fehlt" ;;
+esac
+
+# ── Ergebnis ──
+echo ""
+echo "Hinweis: Die Zero-Data-Retention-Zusage von Mistral ist VERTRAGLICH und"
+echo "hier nicht technisch prüfbar — Nachweisordner + Wiedervorlage, siehe RUNBOOK."
+echo "(Der EU-Endpunkt api.eu.mistral.ai ist codeseitig durch config.test.js abgesichert.)"
+echo ""
+if [ "$FEHLER" = "0" ]; then
+  echo "ERGEBNIS: Alle Infrastruktur-Prüfungen grün."
+  exit 0
+else
+  echo "ERGEBNIS: ABWEICHUNG(EN) gefunden — Soll-Zustand siehe docs/RUNBOOK.md." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Was

Punkt 1 des Codex-Konsens (Review 2026-08-12), der wertvollste: Ein Teil der Sicherheits- und Datenschutz-Zusagen lebt außerhalb des Repos in der Cloud-Konfiguration. `scripts/verify-infrastructure.sh` gleicht den Ist-Zustand **ausschließlich lesend** gegen den RUNBOOK-Soll-Zustand ab:

- Cloud-Tasks-Queue `analyze-queue`: existiert in `europe-west1`, Concurrency 7, RUNNING
- Bucket `malzime-queue-uploads`: EU-Region, Lifecycle-Löschregel (Delete nach 1 Tag), Soft-Delete 0
- Firestore: genau eine Datenbank `malzime-eu` in `europe-west1`
- Worker-IAM: `processjob` + `reapjobs` nicht öffentlich (kein `allUsers`/`allAuthenticatedUsers`)
- Alle Functions in `europe-west1`
- Logging: Routine-Request-Ausschluss aktiv, Diagnose-Sink vorhanden

Verankert in `deploy.sh` direkt neben dem Test-Riegel (Notschalter `SKIP_INFRA=1` nach dem Muster von `SKIP_TESTS=1`, für den Fall abgelaufener gcloud-Anmeldung bei dringendem Rollback).

## Nur-Lese-Garantie, erzwungen durch CI

Neuer Test `verify-infrastructure-script.test.js` (Muster: `cloudtasks-scripts.test.js`): Bash-Syntaxprüfung, jede gcloud-/gsutil-Aufrufzeile muss auf einer engen Allowlist von Lese-Kommandos stehen, plus separater Schreib-Verben-Scan als doppelter Boden. Simulierte Schreib-Kommandos (`update`, `add-iam-policy-binding`, `lifecycle set`) werden nachweislich erkannt.

## Belege

- **Erstlauf gegen die echte Infrastruktur: alle 13 Prüfungen grün, Exit 0.**
- **Negativprobe:** Kopie mit verfälschten Soll-Werten (Concurrency 6, falscher DB-Name) meldet beide Abweichungen rot, Exit 1.
- Backend-Suite: **731/731 grün** (726 + 5 neue Wächter-Tests); ESLint + Prettier sauber.

## Außerdem

- `docs/RUNBOOK.md`: neuer Abschnitt „Infrastruktur-Prüfung" mit Soll-Tabelle und der ausdrücklichen **Grenze des Skripts**: Die ZDR-Zusage von Mistral ist vertraglich, nicht technisch prüfbar — Nachweisordner + Wiedervorlage (vor jeder Presse-Welle, mindestens halbjährlich).
- `CHANGELOG.md`: `[Unveröffentlicht]`-Abschnitt für den gesamten Wartungszug (Nonce fail-closed #108, Doku-Bereinigung #107, dieses Skript) — Versionsstempel folgt beim Deploy, damit `release.yml` den Release erst dann anlegt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)