### PR TITLE
chore: Release v3.0.4 stempeln (Deploy-Freigabe erteilt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [3.0.4] — 2026-08-12
 
 **Wartungszug aus der externen Code-Review (Codex, 2026-08-12; drei Punkte im
 Konsens beider Prüfungen):**


### PR DESCRIPTION
CHANGELOG-Stempel für den Wartungszug aus der Codex-Review (#107/#108/#109). Deploy der Functions erfolgt unmittelbar nach dem Merge; `release.yml` legt Tag+Release automatisch an.

🤖 Generated with [Claude Code](https://claude.com/claude-code)