### PR TITLE
feat: QS-Werkzeuge — Prüfstand-Stempler, Auto-Live-Smoke, Doku-Drift-Wächter

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -39,6 +39,10 @@ läuft der Ablauf vollständig durch (dokumentiert in ADR-0001).
    relevant, reine Functions-Deploys brauchen keinen).
 5. `release.yml` legt automatisch einen GitHub-Release an, sobald die neue
    CHANGELOG-Version auf `main` landet (idempotent).
+6. Nach dem Deploy läuft automatisch `scripts/live-smoke.sh`: vier
+   kostenfreie Proben gegen die Live-API (Upload-Ablehnung 400 mit echter
+   Validierungs-Meldung, Honeypot 403, Admin-Zugriffsschutz 403, Stats 200) —
+   alle enden vor KI-Aufruf und Stundenzähler. Notschalter `SKIP_SMOKE=1`.
 
 ## Infrastruktur-Prüfung (`scripts/verify-infrastructure.sh`)
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 726/726 grün — lokal auf `main` (v3.0.3), 2026-08-12 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 315/315 grün — lokal auf `main` (v3.0.3), 2026-08-12 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 18/18 grün (Smoke, A11y inkl. Beast Mode, Tastatur, Sticky-Toggle, Modus-Merken, Live-Anzeige, Realitäts-Check, Start-ohne-Hinweis) — lokal auf `main` (v3.0.3), 2026-08-12 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 734/734 grün — `scripts/pruefstand.sh`, Commit 626cb70, 2026-08-12 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 315/315 grün — `scripts/pruefstand.sh`, Commit 626cb70, 2026-08-12 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 18/18 grün — `scripts/pruefstand.sh`, Commit 626cb70, 2026-08-12 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node scripts/audit-gate.mjs functions` (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |
@@ -57,3 +57,10 @@ Ein Eintrag wird aktualisiert, wenn sein Nachweis durch eine Änderung ungültig
 oder ein neuer Pflicht-Nachweis entsteht (z. B. neue Profilpflicht, behobenes
 Audit-Finding). Die Rollback-Probe wird bei größeren Toolchain-Wechseln (Node-Major,
 Test-Runner) wiederholt, nicht bei jedem Release.
+
+**Die drei Suiten-Zeilen oben stempelt `scripts/pruefstand.sh` automatisch** —
+das Skript lässt alle drei Suiten laufen und trägt Anzahl, Commit und Datum
+selbst ein; bei einer roten Suite wird nichts gestempelt. Von Hand gepflegte
+Zahlen sind in diesen drei Zeilen nicht mehr vorgesehen. Der CI-Test
+`doku-drift.test.js` wacht darüber, dass das README zahlenfrei bleibt, interne
+Doku-Links existieren und die Suiten-Zeilen datiert sind.

--- a/functions/src/__tests__/doku-drift.test.js
+++ b/functions/src/__tests__/doku-drift.test.js
@@ -1,0 +1,67 @@
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Drift-Wächter für die Dokumentation (Konzept „Richtung 100", 2026-08-12).
+ *
+ * Die Doku-Bereinigung vom 2026-08-12 (Codex-Konsens, PR #107) hat feste
+ * Testzahlen aus dem README entfernt und die Verifikationsmatrix als
+ * datierten Prüfstand gerahmt. Dieser Test sorgt dafür, dass diese Ordnung
+ * nicht schleichend zurückdriftet:
+ *
+ *  1. Das README darf keine festen Testzahlen mehr behaupten — der
+ *     verbindliche Stand ist der letzte CI-Lauf.
+ *  2. Interne Markdown-Links (README + docs/) müssen auf existierende
+ *     Dateien zeigen — tote Verweise sind genau die Drift, die ein
+ *     öffentliches Repo unglaubwürdig macht.
+ *  3. Die drei Suiten-Zeilen der Verifikationsmatrix müssen datiert sein
+ *     (Format des Stemplers scripts/pruefstand.sh).
+ *
+ * Reine Textanalyse — kein Netzwerk, keine Cloud.
+ */
+
+const WURZEL = path.join(__dirname, "../../..");
+
+function lies(datei) {
+  return fs.readFileSync(path.join(WURZEL, datei), "utf8");
+}
+
+describe("Doku-Drift-Wächter", () => {
+  test("README behauptet keine festen Testzahlen", () => {
+    const treffer = lies("README.md").match(/\b\d+\s+Tests?\b/g) || [];
+    expect(treffer).toEqual([]);
+  });
+
+  test("interne Markdown-Links in README und docs/ zeigen auf existierende Dateien", () => {
+    const dateien = ["README.md"].concat(
+      fs
+        .readdirSync(path.join(WURZEL, "docs"))
+        .filter((name) => name.endsWith(".md"))
+        .map((name) => path.join("docs", name))
+    );
+
+    const tote = [];
+    for (const datei of dateien) {
+      const inhalt = lies(datei);
+      /* [Text](ziel) — nur relative Datei-Links; http(s), mailto und
+         reine Anker (#…) sind nicht unsere Baustelle. */
+      for (const treffer of inhalt.matchAll(/\[[^\]]*\]\(([^)\s]+)\)/g)) {
+        const ziel = treffer[1];
+        if (/^(https?:|mailto:|#)/.test(ziel)) continue;
+        const ohneAnker = ziel.split("#")[0];
+        if (!ohneAnker) continue;
+        const aufgeloest = path.resolve(WURZEL, path.dirname(datei), ohneAnker);
+        if (!fs.existsSync(aufgeloest)) tote.push(`${datei} → ${ziel}`);
+      }
+    }
+    expect(tote).toEqual([]);
+  });
+
+  test("die drei Suiten-Zeilen der Verifikationsmatrix sind datiert (Stempler-Format)", () => {
+    const matrix = lies("docs/VERIFICATION.md");
+    for (const zeile of ["Backend-Unit-Tests", "Frontend-Unit-Tests", "E2E kritischster Nutzerfluss"]) {
+      const muster = new RegExp(`\\| ${zeile}[^\\n]*\\d{4}-\\d{2}-\\d{2}[^\\n]*\\|`);
+      expect(matrix).toMatch(muster);
+    }
+  });
+});

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -94,5 +94,13 @@ else
   npx firebase deploy --only "$TARGET"
 fi
 
+# ── Live-Beweis: vier kostenfreie Proben gegen die frisch deployte Produktion ──
+# (endet vor KI-Aufruf und Stundenzähler; Notschalter SKIP_SMOKE=1)
+if [ "${SKIP_SMOKE:-0}" = "1" ]; then
+  echo "WARNUNG: SKIP_SMOKE=1 gesetzt — Live-Smoke wird UEBERSPRUNGEN."
+else
+  ./scripts/live-smoke.sh
+fi
+
 echo ""
 echo "Deploy abgeschlossen. Version: ?v=$VERSION"

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# malziME Live-Smoke — vier kostenfreie Proben gegen die echte Produktion.
+#
+# Läuft automatisch am Ende von scripts/deploy.sh (Notschalter SKIP_SMOKE=1)
+# und kann jederzeit direkt gestartet werden. Jeder Deploy endet damit mit
+# einem Live-Beweis statt mit Hoffnung.
+#
+# Alle vier Proben enden VOR dem KI-Aufruf und VOR dem Stundenzähler:
+# sie kosten nichts, verändern nichts und verfälschen keine Statistik
+# (Rezept dokumentiert seit 2026-07-29, Live-Smoke-Regel: immer den Pfad
+# messen, den der echte Client nimmt — JSON+Base64 über malzi.me/api/…).
+#
+# Exit-Codes: 0 = alle Proben wie erwartet · 1 = Abweichung
+
+set -u
+BASIS="https://malzi.me"
+FEHLER=0
+
+probe() { # $1 Beschreibung, $2 erwarteter HTTP-Code, $3 Methode, $4 Pfad, $5 Body (leer = GET ohne Body)
+  local IST
+  if [ -n "$5" ]; then
+    IST=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -X "$3" "$BASIS$4" -H "Content-Type: application/json" -d "$5")
+  else
+    IST=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$BASIS$4")
+  fi
+  if [ "$IST" = "$2" ]; then
+    printf "  \033[32m✓\033[0m %s: HTTP %s\n" "$1" "$IST"
+  else
+    printf "  \033[31m✗\033[0m %s: SOLL HTTP %s, IST HTTP %s\n" "$1" "$2" "$IST"
+    FEHLER=1
+  fi
+}
+
+echo "Live-Smoke gegen $BASIS (kostenfrei, ohne Zustandsänderung)"
+
+# 1) Kompletter Request-Weg: Body ankommen, Base64 dekodieren, Validierung
+#    erreichen — BMP steht nicht auf der Erlaubt-Liste und MUSS 400 geben.
+probe "Upload-Weg (BMP → Ablehnung)" 400 POST "/api/enqueue" '{"imageBase64":"aGFsbG8gbWFsemlNRQ==","mimeType":"image/bmp","lang":"de"}'
+
+#    Zusatz-Schärfe: die Ablehnung muss die ECHTE Validierungs-Meldung sein
+#    (nicht irgendein anderer 400er).
+ANTWORT=$(curl -s --max-time 20 -X POST "$BASIS/api/enqueue" -H "Content-Type: application/json" -d '{"imageBase64":"aGFsbG8gbWFsemlNRQ==","mimeType":"image/bmp","lang":"de"}')
+case "$ANTWORT" in
+  *"Invalid file type"*) printf "  \033[32m✓\033[0m Ablehnungs-Text: echte Dateityp-Validierung\n" ;;
+  *) printf "  \033[31m✗\033[0m Ablehnungs-Text unerwartet: %.80s\n" "$ANTWORT"; FEHLER=1 ;;
+esac
+
+# 2) Bot-Schutz: gefülltes Honeypot-Feld MUSS 403 geben.
+probe "Honeypot" 403 POST "/api/enqueue" '{"imageBase64":"aGFsbG8=","mimeType":"image/jpeg","lang":"de","website":"bot"}'
+
+# 3) Admin-Schutz: ungültige Nonce MUSS 403 geben (keine Mutation möglich).
+probe "Admin-Zugriffsschutz" 403 POST "/api/admin/boost" '{"nonce":"ungueltig"}'
+
+# 4) Lebenszeichen: öffentliche Stats MUSS 200 geben.
+probe "Stats-Endpunkt" 200 GET "/api/stats" ""
+
+if [ "$FEHLER" = "0" ]; then
+  echo "ERGEBNIS: Live-Smoke grün — alle vier Proben wie erwartet."
+  exit 0
+else
+  echo "ERGEBNIS: Live-Smoke ROT — Abweichung an der Produktion! Störungs-Rezepte: docs/RUNBOOK.md." >&2
+  exit 1
+fi

--- a/scripts/pruefstand.sh
+++ b/scripts/pruefstand.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# malziME Prüfstand-Stempler.
+#
+# Lässt alle drei Test-Suiten laufen und stempelt die Ergebnisse (Anzahl,
+# Commit, Datum) automatisch in die drei Suiten-Zeilen von
+# docs/VERIFICATION.md. Hintergrund (Konzept „Richtung 100" 2026-08-12):
+# Die Verifikationsmatrix ist ein datierter Prüfstand — solange ein Mensch
+# die Zahlen tippt, können sie veralten. Dieses Skript nimmt dem Menschen
+# den Handgriff ab: Gestempelt wird NUR, was gerade wirklich grün gelaufen
+# ist. Schlägt eine Suite fehl, wird NICHTS gestempelt.
+#
+# Nutzung: ./scripts/pruefstand.sh   (Dauer ~5 min, E2E inklusive)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+DATUM=$(date +%Y-%m-%d)
+COMMIT=$(git rev-parse --short HEAD)
+MATRIX="docs/VERIFICATION.md"
+
+echo "Prüfstand-Lauf auf Commit $COMMIT ($DATUM) — alle drei Suiten, danach Stempel."
+
+# ── 1. Backend (Jest) ──
+echo "— Backend-Suite läuft…"
+BACKEND_LOG=$(npm test --prefix functions 2>&1) || { echo "$BACKEND_LOG" | tail -20; echo "ABBRUCH: Backend-Suite rot — es wird nichts gestempelt."; exit 1; }
+BACKEND=$(printf "%s" "$BACKEND_LOG" | grep -Eo "Tests:\s+[0-9]+ passed, [0-9]+ total" | grep -Eo "[0-9]+" | head -1)
+
+# ── 2. Frontend (Vitest) ──
+echo "— Frontend-Suite läuft…"
+FRONTEND_LOG=$(npm run test:frontend 2>&1) || { echo "$FRONTEND_LOG" | tail -20; echo "ABBRUCH: Frontend-Suite rot — es wird nichts gestempelt."; exit 1; }
+FRONTEND=$(printf "%s" "$FRONTEND_LOG" | grep -Eo "Tests\s+[0-9]+ passed" | grep -Eo "[0-9]+" | head -1)
+
+# ── 3. E2E (Playwright) ──
+echo "— E2E-Suite läuft (dauert am längsten)…"
+E2E_LOG=$(npm run test:e2e 2>&1) || { echo "$E2E_LOG" | tail -20; echo "ABBRUCH: E2E-Suite rot — es wird nichts gestempelt."; exit 1; }
+E2E=$(printf "%s" "$E2E_LOG" | grep -Eo "[0-9]+ passed" | grep -Eo "[0-9]+" | tail -1)
+
+# ── Plausibilität: alle drei Zahlen müssen da sein ──
+for WERT in "$BACKEND" "$FRONTEND" "$E2E"; do
+  if ! [[ "$WERT" =~ ^[0-9]+$ ]] || [ "$WERT" -eq 0 ]; then
+    echo "ABBRUCH: Testanzahl nicht lesbar (Backend=$BACKEND, Frontend=$FRONTEND, E2E=$E2E) — Ausgabeformat geändert?"
+    exit 1
+  fi
+done
+
+echo "Alle Suiten grün: Backend $BACKEND · Frontend $FRONTEND · E2E $E2E — Stempel wird gesetzt."
+
+# ── Stempeln: nur die Ergebnis-Zelle der drei Suiten-Zeilen ersetzen ──
+BACKEND="$BACKEND" FRONTEND="$FRONTEND" E2E="$E2E" COMMIT="$COMMIT" DATUM="$DATUM" python3 - "$MATRIX" <<'EOF'
+import os, re, sys
+
+pfad = sys.argv[1]
+text = open(pfad, encoding="utf-8").read()
+b, f, e = os.environ["BACKEND"], os.environ["FRONTEND"], os.environ["E2E"]
+stempel_ende = f"— `scripts/pruefstand.sh`, Commit {os.environ['COMMIT']}, {os.environ['DATUM']} |"
+
+ersetzungen = [
+    (r"(\| Backend-Unit-Tests \|[^|]+\|) [^|]+\|",  rf"\1 ✅ {b}/{b} grün {stempel_ende}"),
+    (r"(\| Frontend-Unit-Tests \|[^|]+\|) [^|]+\|", rf"\1 ✅ {f}/{f} grün {stempel_ende}"),
+    (r"(\| E2E kritischster Nutzerfluss[^|]*\|[^|]+\|) [^|]+\|", rf"\1 ✅ {e}/{e} grün {stempel_ende}"),
+]
+for muster, ersatz in ersetzungen:
+    text, anzahl = re.subn(muster, ersatz, text, count=1)
+    if anzahl != 1:
+        print(f"ABBRUCH: Zeile zu Muster {muster!r} nicht gefunden — Tabellenaufbau geändert?")
+        sys.exit(1)
+
+open(pfad, "w", encoding="utf-8").write(text)
+EOF
+
+echo "Gestempelt in $MATRIX:"
+grep -E "Backend-Unit-Tests|Frontend-Unit-Tests|E2E kritischster" "$MATRIX" | sed 's/^/  /'
+echo "Fertig. Die Änderung wie üblich per Branch + PR auf main bringen."


### PR DESCRIPTION
## Was (Konzept „Richtung 100", Phase 1, Punkte 1–3)

- **`scripts/pruefstand.sh`:** lässt alle drei Suiten laufen und stempelt Anzahl + Commit + Datum selbst in die drei Suiten-Zeilen von VERIFICATION.md. Rote Suite ⇒ kein Stempel. Die Zahlen kann ab jetzt niemand mehr veralten lassen, weil niemand sie mehr tippt. **Beweis: Erstlauf in diesem PR — 734/734, 315/315, 18/18, selbst gestempelt.**
- **`scripts/live-smoke.sh` + deploy.sh-Anschluss:** vier kostenfreie Proben gegen die Produktion (Upload-Ablehnung 400 inkl. Prüfung der echten Validierungs-Meldung, Honeypot 403, Admin-403, Stats 200), laufen künftig automatisch nach jedem Deploy (Notschalter `SKIP_SMOKE=1`). **Beweis: Erstlauf gegen live — 5/5 grün, Exit 0.**
- **`doku-drift.test.js` (CI):** README bleibt zahlenfrei, interne Markdown-Links in README + docs/ müssen existieren (Erstlauf: null tote Links), die Suiten-Zeilen bleiben datiert. Sichert die Doku-Bereinigung aus #107 dauerhaft ab.

Backend-Suite mit den neuen Tests: **734/734 grün**; RUNBOOK (Deploy-Schritt 6) und VERIFICATION (Pflege-Abschnitt) beschreiben die neuen Abläufe.

Kein Laufzeit-Code verändert — Functions-Quellcode unberührt, nur Skripte, Tests, Doku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)