### PR TITLE
feat: ZDR-Frist — Wochen-Erinnerung per Push + CI-Wächter (und die Ursache des fehlenden iOS-Pushs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [3.0.6] — 2026-08-12
+
+**Erinnerung an die ZDR-Nachprüfung — und die Ursache für ausbleibende
+Handy-Mitteilungen:**
+
+- **Wochen-Erinnerung (neu):** Eine geplante Funktion schaut montags auf die
+  Live-Seite und meldet sich eine Woche bevor die halbjährliche Nachprüfung
+  der EU-/Zero-Data-Retention-Zusage fällig wird — per Push aufs Handy, mit
+  den nötigen Schritten im Text und einem Knopf direkt ins Mistral-Dashboard.
+  Ist die Frist überschritten, meldet sie sich dringlicher. Fällt etwas aus
+  (Seite nicht erreichbar, Push-Dienst weg), passiert nichts Schlimmes: Die
+  Erinnerung ist so gebaut, dass sie den Betrieb nie stören kann.
+- **Zweites Netz:** Bleibt die Erinnerung unbeachtet, schlägt zusätzlich die
+  automatische Prüfung beim nächsten Bau an. Beide rechnen mit derselben
+  Fristdefinition — die Frist steht nur an einer Stelle im Code.
+- **Behoben: iOS-Mitteilungen kamen nie an.** Ein selbst betriebener
+  Push-Server kann iPhones nur über den Dienst ntfy.sh erreichen. Diese
+  Weiterleitung passiert erst *nach* der Antwort an den Absender — und genau
+  dann entzog die Cloud-Plattform dem Programm standardmäßig die Rechenzeit.
+  Die Weiterleitung lief still in eine Zeitüberschreitung: Die Meldung lag auf
+  dem Server, aber das Handy erfuhr nichts davon. Mit dauerhaft zugeteilter
+  Rechenzeit ist das behoben und die Zustellung bestätigt. Die frühere
+  Vermutung, das liege an der App oder an iOS, war damit widerlegt.
+- **Sicherheits-Aktualisierung des Push-Servers** auf ntfy 2.27.0 (drei
+  übersprungene Versionen mit Sicherheitskorrekturen); der Zugangsschutz —
+  senden erlaubt, anonymes Mitlesen gesperrt — ist unverändert und geprüft.
+
 ## [3.0.5] — 2026-08-12
 
 **Qualitäts-Zug „Richtung 100" (Konzept vom 2026-08-12; ohne Änderung am

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ functions/src/              Firebase Cloud Functions (2nd Gen, Node 24, europe-w
   handle-process-job.js     Queue: Worker — claimt Job, ruft Mistral, schreibt Ergebnis
   handle-job-status.js      Queue: Status-Polling + Liveness-Herzschlag
   handle-reap.js            Queue: Reaper fuer verlassene / haengende / abgelaufene Jobs
+  handle-erinnerung.js      Wochenlauf: ntfy-Push vor Ablauf der halbjaehrlichen ZDR-Nachpruefung (mit Anleitung)
+  zusagen.js                Gemeinsame Fristlogik fuer datierte Zusagen (Erinnerung + CI-Waechter)
   jobs.js                   Queue: Job-Lebenszyklus (Firestore-Collection `jobs`)
   cloud-tasks.js            Queue: Cloud-Tasks-Anbindung (+ Lokal-Shim fuer Emulator)
   queue-storage.js          Queue: temporaere Bild-Ablage im GCS-Bucket

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,6 +160,8 @@ Für Google Cloud Tasks gibt es keinen Emulator. Im Lokal-Modus (`QUEUE_LOCAL=1`
 | `handle-process-job.js` | Queue-Worker: claimt den Job, ruft die Mistral-Pipeline, schreibt das Ergebnis |
 | `handle-job-status.js` | Queue: Status-Polling für den Client + Liveness-Herzschlag |
 | `handle-reap.js` | Queue: Reaper (Minutentakt) für verlassene / hängende / abgelaufene Jobs |
+| `handle-erinnerung.js` | Wochenlauf (montags): erinnert per ntfy-Push, bevor die halbjährliche ZDR-Nachprüfung fällig wird — inkl. Handlungsanleitung im Text |
+| `zusagen.js` | Gemeinsame Fristlogik für datierte öffentliche Zusagen (Erinnerung + CI-Wächter rechnen mit derselben Definition) |
 | `jobs.js` | Queue: Job-Lebenszyklus + Firestore-Zugriff auf die `jobs`-Collection |
 | `cloud-tasks.js` | Queue: Cloud-Tasks-Anbindung (+ Lokal-Shim) |
 | `queue-storage.js` | Queue: temporäre Bild-Ablage im GCS-Bucket |

--- a/docs/ERROR-ALERTING.md
+++ b/docs/ERROR-ALERTING.md
@@ -103,10 +103,29 @@ Client-Fehler erreichen den Betreiber stattdessen über den Log-Bucket
 
 Die Richtlinie schickt an **zwei** Kanäle. Grund: Am 2026-08-10 war nicht
 belegbar, dass der ntfy-Push auf dem Sperrbildschirm ankommt — die Meldung war
-in der App sichtbar, aber nur nach aktivem Öffnen. Priorität hochsetzen,
-`upstream-base-url` und Kanalzuordnung wurden geprüft und schieden als Ursache
-aus; die verbleibende Ursache liegt in der App bzw. den iOS-Einstellungen und
-damit ausserhalb dessen, was am Server reparierbar ist.
+in der App sichtbar, aber nur nach aktivem Öffnen.
+
+> **Ursache gefunden am 2026-08-12 — sie lag doch am Server.** Die frühere
+> Vermutung („liegt an der App bzw. den iOS-Einstellungen, am Server nicht
+> reparierbar") war falsch. Im ntfy-Protokoll stand:
+> `WARN Unable to publish poll request (… context deadline exceeded)`.
+>
+> Hintergrund: Ein selbst betriebener ntfy-Server kann iPhones nicht direkt
+> erreichen — nur ntfy.sh besitzt den Apple-Push-Schlüssel. Deshalb reicht der
+> eigene Server nach jeder Nachricht eine **Anstoß-Meldung** an ntfy.sh weiter
+> (`upstream-base-url`), und erst die löst den Push aus. Diese Weiterleitung
+> passiert **nach** der HTTP-Antwort an den Absender — und genau dann entzieht
+> Cloud Run dem Container standardmäßig die CPU („CPU nur während der
+> Anfrage"). Die Weiterleitung verhungerte und lief nach 10 s in die
+> Zeitüberschreitung. Ergebnis: Nachricht liegt auf dem Server, aber kein Push
+> aufs iPhone — exakt das beobachtete Verhalten.
+>
+> **Behebung:** `gcloud run services update ntfy --no-cpu-throttling
+> --memory=512Mi` (CPU dauerhaft zugeteilt; Cloud Run verlangt dafür
+> mindestens 512 MiB). Danach verschwand die Warnung. **Lehre: Hintergrund-
+> Arbeit nach der Antwort braucht auf Cloud Run dauerhaft zugeteilte CPU —
+> sonst scheitert sie lautlos, und die Fehlersuche landet fälschlich beim
+> Endgerät.**
 
 Statt weiter daran zu schrauben, kam ein davon unabhängiger Weg dazu:
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -79,10 +79,22 @@ Subprozessoren-Liste — bewusst NICHT im öffentlichen Repo) plus Wiedervorlage
 **vor jeder Presse-Welle und mindestens halbjährlich** im Mistral-Dashboard
 nachprüfen und den Screenshot-Stand erneuern.
 
-**Damit die Frist nicht vergessen wird, wacht die CI darüber**
-(`functions/src/__tests__/zusagen-frische.test.js`): Ist das in
-`public/datenschutz.html` genannte Prüfdatum älter als 183 Tage, wird der Bau
-rot und nennt die nötigen Schritte. Ablauf beim roten Bau — **in dieser
+**Damit die Frist nicht vergessen wird, wachen zwei Schichten darüber** — beide
+rechnen mit derselben Frist aus `functions/src/zusagen.js`:
+
+1. **Freundliche Vorwarnung:** Die geplante Function `erinnerung`
+   (`handle-erinnerung.js`, montags 9 Uhr Wien) liest das Prüfdatum von der
+   **Live-Seite** und schickt eine Woche vor Fristablauf einen ntfy-Push aufs
+   Handy — mit der Handlungsanleitung im Text und einem Knopf direkt ins
+   Mistral-Dashboard. Überfällig meldet sie mit höherer Priorität. Sie ist
+   fail-soft: Seite nicht erreichbar, Datum unlesbar oder ntfy weg werden nur
+   als Warnung geloggt (nie `severity ERROR`, sonst löst die Erinnerung den
+   Fehleralarm aus).
+2. **Harte Bremse:** `functions/src/__tests__/zusagen-frische.test.js` macht
+   die CI rot, sobald das Prüfdatum älter als 183 Tage ist — falls die
+   Vorwarnung untergeht.
+
+Ablauf, wenn die Erinnerung kommt (oder der Bau rot wird) — **in dieser
 Reihenfolge**:
 
 1. Im Mistral-Dashboard nachsehen, ob „Null-Datenspeicherung" noch aktiv ist.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -74,10 +74,25 @@ CI, dass das Skript ausschließlich Lese-Kommandos enthält.
 **Grenze des Skripts — ZDR ist Vertrag, nicht Konfiguration:** Die
 Zero-Data-Retention-Zusage von Mistral lässt sich technisch nicht abfragen.
 Ihr Nachweis ist organisatorisch: privater Nachweisordner beim Inhaber
-(ZDR-/Trainings-Opt-out-Screenshots vom 2026-08-11, Vertrags-/DPA-Unterlagen —
-bewusst NICHT im öffentlichen Repo) plus Wiedervorlage: **vor jeder
-Presse-Welle und mindestens halbjährlich** im Mistral-Dashboard nachprüfen
-und den Screenshot-Stand erneuern.
+(ZDR-/Trainings-Opt-out-Screenshots, schriftliche Support-Bestätigung, DPA und
+Subprozessoren-Liste — bewusst NICHT im öffentlichen Repo) plus Wiedervorlage:
+**vor jeder Presse-Welle und mindestens halbjährlich** im Mistral-Dashboard
+nachprüfen und den Screenshot-Stand erneuern.
+
+**Damit die Frist nicht vergessen wird, wacht die CI darüber**
+(`functions/src/__tests__/zusagen-frische.test.js`): Ist das in
+`public/datenschutz.html` genannte Prüfdatum älter als 183 Tage, wird der Bau
+rot und nennt die nötigen Schritte. Ablauf beim roten Bau — **in dieser
+Reihenfolge**:
+
+1. Im Mistral-Dashboard nachsehen, ob „Null-Datenspeicherung" noch aktiv ist.
+2. Screenshot mit Datum in den privaten Nachweisordner legen.
+3. **Erst dann** das Datum in `public/datenschutz.html` an beiden Stellen
+   hochsetzen (Prüfdatum im Mistral-Absatz + `Stand:`-Zeile im Kopf) und
+   deployen.
+
+Das Datum **niemals** ohne echte Prüfung hochsetzen — dann behauptet die
+Webseite etwas Unbelegtes, und genau davor schützt der Wächter.
 
 ## Rollback-Hebel
 

--- a/functions/src/__tests__/handle-erinnerung.test.js
+++ b/functions/src/__tests__/handle-erinnerung.test.js
@@ -1,0 +1,181 @@
+const { pruefeZusagen, baueMeldung } = require("../handle-erinnerung");
+const { leseZdrPruefdatum, bewerteFrist, formatiereDatum, FRIST_TAGE, VORWARNUNG_TAGE } = require("../zusagen");
+
+/**
+ * Tests für die woechentliche Zusagen-Erinnerung.
+ *
+ * Kein Netz, keine echte Uhr: `abruf` und `jetzt` werden injiziert. Geprueft
+ * wird vor allem das, was im Ernstfall zaehlt — dass der Push GENAU DANN
+ * kommt, wenn er soll, und dass ein Fehler den Betrieb nie stoert.
+ */
+
+const SEITE = (datum) => `<p>… Zero Data Retention … zuletzt am ${datum} überprüft und dokumentiert; …</p>`;
+
+/* 2026-08-12 als feste „Jetzt"-Zeit — Tests duerfen nicht von der Uhr abhaengen. */
+const JETZT = new Date(2026, 7, 12).getTime();
+const TAG = 86400000;
+
+function abrufAttrappe({ html, seiteOk = true, ntfyOk = true, protokoll }) {
+  return async (url, optionen) => {
+    if (String(url).includes("datenschutz")) {
+      if (!seiteOk) return { ok: false, status: 503, text: async () => "" };
+      return { ok: true, status: 200, text: async () => html };
+    }
+    /* ntfy-Aufruf */
+    if (protokoll) protokoll.push(JSON.parse(optionen.body));
+    return { ok: ntfyOk, status: ntfyOk ? 200 : 500, text: async () => "" };
+  };
+}
+
+describe("zusagen.js — Fristlogik", () => {
+  test("liest das Prüfdatum aus der Seite (mit geschütztem Leerzeichen)", () => {
+    const datum = leseZdrPruefdatum(SEITE("11.&nbsp;August&nbsp;2026"));
+    expect(formatiereDatum(datum)).toBe("11. August 2026");
+  });
+
+  test("liest das Prüfdatum auch mit normalen Leerzeichen", () => {
+    expect(leseZdrPruefdatum(SEITE("1. März 2026"))).not.toBeNull();
+  });
+
+  test("gibt null zurück, wenn die Formulierung geändert wurde", () => {
+    expect(leseZdrPruefdatum("<p>zuletzt kontrolliert am 11. August 2026</p>")).toBeNull();
+  });
+
+  test("gibt null zurück bei unbekanntem Monatsnamen", () => {
+    expect(leseZdrPruefdatum(SEITE("11. Auguscht 2026"))).toBeNull();
+  });
+
+  test("frisches Datum ist nicht fällig", () => {
+    const stand = bewerteFrist(new Date(JETZT - 10 * TAG), JETZT);
+    expect(stand.faellig).toBe(false);
+    expect(stand.ueberfaellig).toBe(false);
+  });
+
+  test("genau in der Vorwarnzeit ist fällig, aber nicht überfällig", () => {
+    const stand = bewerteFrist(new Date(JETZT - (FRIST_TAGE - VORWARNUNG_TAGE) * TAG), JETZT);
+    expect(stand.faellig).toBe(true);
+    expect(stand.ueberfaellig).toBe(false);
+  });
+
+  test("nach Ablauf der Frist ist überfällig", () => {
+    const stand = bewerteFrist(new Date(JETZT - (FRIST_TAGE + 5) * TAG), JETZT);
+    expect(stand.ueberfaellig).toBe(true);
+    expect(stand.tageBisFrist).toBe(-5);
+  });
+});
+
+describe("pruefeZusagen — Push nur wenn nötig", () => {
+  test("schickt NICHTS, solange die Frist weit weg ist", async () => {
+    const protokoll = [];
+    const html = SEITE(formatiereDatum(new Date(JETZT - 10 * TAG)));
+    const ergebnis = await pruefeZusagen({
+      ntfyUrl: "https://ntfy.example/x",
+      ntfyTopic: "t",
+      abruf: abrufAttrappe({ html, protokoll }),
+      jetzt: JETZT,
+    });
+    expect(ergebnis.gesendet).toBe(false);
+    expect(ergebnis.grund).toBe("nichts-faellig");
+    expect(protokoll).toEqual([]);
+  });
+
+  test("schickt eine Woche vorher den Push mit Anleitung", async () => {
+    const protokoll = [];
+    const html = SEITE(formatiereDatum(new Date(JETZT - (FRIST_TAGE - VORWARNUNG_TAGE) * TAG)));
+    const ergebnis = await pruefeZusagen({
+      ntfyUrl: "https://ntfy.example/x",
+      ntfyTopic: "t",
+      abruf: abrufAttrappe({ html, protokoll }),
+      jetzt: JETZT,
+    });
+    expect(ergebnis.gesendet).toBe(true);
+    expect(protokoll).toHaveLength(1);
+    const push = protokoll[0];
+    expect(push.title).toMatch(/steht an/);
+    /* Die Anleitung ist der Kern — ohne sie waere die Erinnerung wertlos. */
+    expect(push.message).toMatch(/Mistral-Dashboard|Null-Datenspeicherung/);
+    expect(push.message).toMatch(/Screenshot/);
+    expect(push.message).toMatch(/NIE ohne echte Prüfung/);
+    expect(push.actions[0].url).toMatch(/admin\.mistral\.ai/);
+  });
+
+  test("meldet Überfälligkeit deutlicher (höhere Priorität, anderer Titel)", async () => {
+    const protokoll = [];
+    const html = SEITE(formatiereDatum(new Date(JETZT - (FRIST_TAGE + 20) * TAG)));
+    await pruefeZusagen({
+      ntfyUrl: "https://ntfy.example/x",
+      ntfyTopic: "t",
+      abruf: abrufAttrappe({ html, protokoll }),
+      jetzt: JETZT,
+    });
+    expect(protokoll[0].title).toMatch(/überfällig/i);
+    expect(protokoll[0].priority).toBe(5);
+    expect(protokoll[0].message).toMatch(/ÜBERFÄLLIG seit 20 Tagen/);
+  });
+});
+
+describe("pruefeZusagen — fail-soft", () => {
+  test("Seite nicht erreichbar: kein Absturz, kein Push", async () => {
+    const ergebnis = await pruefeZusagen({
+      ntfyUrl: "https://ntfy.example/x",
+      ntfyTopic: "t",
+      abruf: abrufAttrappe({ html: "", seiteOk: false }),
+      jetzt: JETZT,
+    });
+    expect(ergebnis).toEqual({ gesendet: false, grund: "seite-nicht-lesbar" });
+  });
+
+  test("Prüfdatum unlesbar (Formulierung geändert): kein Absturz, kein Push", async () => {
+    const ergebnis = await pruefeZusagen({
+      ntfyUrl: "https://ntfy.example/x",
+      ntfyTopic: "t",
+      abruf: abrufAttrappe({ html: "<p>ohne Datum</p>" }),
+      jetzt: JETZT,
+    });
+    expect(ergebnis).toEqual({ gesendet: false, grund: "pruefdatum-unlesbar" });
+  });
+
+  test("ntfy antwortet mit Fehler: kein Absturz", async () => {
+    const html = SEITE(formatiereDatum(new Date(JETZT - (FRIST_TAGE + 1) * TAG)));
+    const ergebnis = await pruefeZusagen({
+      ntfyUrl: "https://ntfy.example/x",
+      ntfyTopic: "t",
+      abruf: abrufAttrappe({ html, ntfyOk: false }),
+      jetzt: JETZT,
+    });
+    expect(ergebnis).toEqual({ gesendet: false, grund: "ntfy-fehlgeschlagen" });
+  });
+
+  test("Netzfehler beim Abruf: kein Absturz", async () => {
+    const ergebnis = await pruefeZusagen({
+      ntfyUrl: "https://ntfy.example/x",
+      ntfyTopic: "t",
+      abruf: async () => {
+        throw new Error("Netz weg");
+      },
+      jetzt: JETZT,
+    });
+    expect(ergebnis).toEqual({ gesendet: false, grund: "fehler" });
+  });
+
+  test("fehlende ntfy-Konfiguration: kein Absturz", async () => {
+    const html = SEITE(formatiereDatum(new Date(JETZT - (FRIST_TAGE + 1) * TAG)));
+    const ergebnis = await pruefeZusagen({
+      abruf: abrufAttrappe({ html }),
+      jetzt: JETZT,
+    });
+    expect(ergebnis).toEqual({ gesendet: false, grund: "keine-ntfy-konfiguration" });
+  });
+});
+
+describe("baueMeldung", () => {
+  test("nennt die drei Schritte in der richtigen Reihenfolge", () => {
+    const meldung = baueMeldung({ tageAlt: 180, tageBisFrist: 3, ueberfaellig: false, datumText: "11. August 2026" });
+    const pos1 = meldung.text.indexOf("1.");
+    const pos2 = meldung.text.indexOf("2.");
+    const pos3 = meldung.text.indexOf("3.");
+    expect(pos1).toBeGreaterThan(-1);
+    expect(pos2).toBeGreaterThan(pos1);
+    expect(pos3).toBeGreaterThan(pos2);
+  });
+});

--- a/functions/src/__tests__/i18n-guardian.test.js
+++ b/functions/src/__tests__/i18n-guardian.test.js
@@ -125,8 +125,12 @@ describe("i18n Guardian (Backend)", () => {
 
     /* Infrastructure files — no user-facing text, permanently excluded.
        mistral-mock.js is a test fixture: its bilingual canned profile data
-       simulates Mistral API output and is not localised content. */
-    const EXCLUDED = ["i18n.js", "config.js", "middleware.js", "mistral-mock.js"];
+       simulates Mistral API output and is not localised content.
+       zusagen.js parses German month names off the German privacy page, and
+       handle-erinnerung.js writes an operator-only push to the maintainer's
+       phone — neither text ever reaches a workshop participant, so neither
+       is localisation material. */
+    const EXCLUDED = ["i18n.js", "config.js", "middleware.js", "mistral-mock.js", "zusagen.js", "handle-erinnerung.js"];
 
     it("non-allowlisted backend JS files have no hardcoded German", () => {
       const violations = [];

--- a/functions/src/__tests__/zusagen-frische.test.js
+++ b/functions/src/__tests__/zusagen-frische.test.js
@@ -1,0 +1,99 @@
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Frische-Wächter für datierte Zusagen (Konzept „Richtung 100", 2026-08-12).
+ *
+ * Seit v3.0.5 nennt die Datenschutzerklärung ein Prüfdatum für die
+ * EU-/Zero-Data-Retention-Zusage und verspricht öffentlich, „spätestens
+ * halbjährlich" nachzuprüfen. Ein solches Versprechen ist nur so viel wert
+ * wie seine Einhaltung — und niemand erinnert sich in sechs Monaten von
+ * selbst daran.
+ *
+ * Darum wacht die CI darüber: Wird das Prüfdatum zu alt, färbt sich der Bau
+ * rot und nennt im Klartext, was zu tun ist. Das ist derselbe Gedanke wie
+ * beim Infrastruktur-Prüfskript — eine Zusage bekommt einen Wächter, keine
+ * Erinnerungsnotiz.
+ *
+ * Auflösen des roten Baus (5 Minuten):
+ *   1. Im Mistral-Dashboard nachsehen, ob „Null-Datenspeicherung" noch aktiv
+ *      ist (admin.mistral.ai → Datenschutz).
+ *   2. Screenshot mit Datum in den privaten Nachweisordner legen.
+ *   3. Das Datum in public/datenschutz.html an BEIDEN Stellen hochsetzen
+ *      (Prüfdatum im Mistral-Absatz + „Stand:"-Zeile im Kopf), Deploy.
+ *
+ * NIEMALS das Datum ohne echte Prüfung hochsetzen — dann behauptet die
+ * Webseite etwas Unbelegtes, und genau das soll dieser Test verhindern.
+ */
+
+const WURZEL = path.join(__dirname, "../../..");
+const SEITE = path.join(WURZEL, "public/datenschutz.html");
+
+/* Öffentliches Versprechen: „spätestens halbjährlich". */
+const FRIST_TAGE = 183;
+
+const MONATE = {
+  Januar: 0,
+  Februar: 1,
+  März: 2,
+  April: 3,
+  Mai: 4,
+  Juni: 5,
+  Juli: 6,
+  August: 7,
+  September: 8,
+  Oktober: 9,
+  November: 10,
+  Dezember: 11,
+};
+
+/** Liest „11.&nbsp;August&nbsp;2026" (auch mit normalen Leerzeichen) als Datum. */
+function leseDeutschesDatum(text, muster) {
+  const treffer = text.match(muster);
+  if (!treffer) return null;
+  const [, tag, monat, jahr] = treffer;
+  const monatIndex = MONATE[monat];
+  if (monatIndex === undefined) return null;
+  return new Date(Number(jahr), monatIndex, Number(tag));
+}
+
+function tageSeit(datum) {
+  return Math.floor((Date.now() - datum.getTime()) / 86400000);
+}
+
+describe("Frische datierter Zusagen (Datenschutzerklärung)", () => {
+  const inhalt = fs.readFileSync(SEITE, "utf8");
+
+  test("das ZDR-Prüfdatum steht in der Seite und ist lesbar", () => {
+    const datum = leseDeutschesDatum(
+      inhalt,
+      /zuletzt am (\d{1,2})\.(?:&nbsp;|\s)([A-Za-zÄÖÜäöü]+)(?:&nbsp;|\s)(\d{4})/
+    );
+    expect(datum).not.toBeNull();
+  });
+
+  test("das ZDR-Prüfdatum ist nicht älter als das öffentliche Versprechen (halbjährlich)", () => {
+    const datum = leseDeutschesDatum(
+      inhalt,
+      /zuletzt am (\d{1,2})\.(?:&nbsp;|\s)([A-Za-zÄÖÜäöü]+)(?:&nbsp;|\s)(\d{4})/
+    );
+    const alter = tageSeit(datum);
+    if (alter > FRIST_TAGE) {
+      throw new Error(
+        `Das in der Datenschutzerklärung genannte Prüfdatum ist ${alter} Tage alt ` +
+          `(erlaubt: ${FRIST_TAGE}). Die Seite verspricht öffentlich eine Prüfung ` +
+          `mindestens halbjährlich.\n` +
+          `→ Im Mistral-Dashboard nachsehen, ob Zero Data Retention noch aktiv ist, ` +
+          `Screenshot in den Nachweisordner legen, DANN das Datum in ` +
+          `public/datenschutz.html an beiden Stellen hochsetzen (Prüfdatum + „Stand:").\n` +
+          `Das Datum niemals ohne echte Prüfung ändern.`
+      );
+    }
+    expect(alter).toBeLessThanOrEqual(FRIST_TAGE);
+  });
+
+  test("die Stand-Zeile im Kopf ist vorhanden und lesbar", () => {
+    const datum = leseDeutschesDatum(inhalt, /Stand: (\d{1,2})\.(?:&nbsp;|\s)([A-Za-zÄÖÜäöü]+)(?:&nbsp;|\s)(\d{4})/);
+    expect(datum).not.toBeNull();
+  });
+});

--- a/functions/src/__tests__/zusagen-frische.test.js
+++ b/functions/src/__tests__/zusagen-frische.test.js
@@ -1,26 +1,26 @@
 const fs = require("fs");
 const path = require("path");
+const { leseZdrPruefdatum, bewerteFrist, FRIST_TAGE } = require("../zusagen");
 
 /**
  * Frische-Wächter für datierte Zusagen (Konzept „Richtung 100", 2026-08-12).
  *
  * Seit v3.0.5 nennt die Datenschutzerklärung ein Prüfdatum für die
- * EU-/Zero-Data-Retention-Zusage und verspricht öffentlich, „spätestens
- * halbjährlich" nachzuprüfen. Ein solches Versprechen ist nur so viel wert
+ * EU-/Zero-Data-Retention-Zusage und verspricht öffentlich, spätestens
+ * halbjährlich nachzuprüfen. Ein solches Versprechen ist nur so viel wert
  * wie seine Einhaltung — und niemand erinnert sich in sechs Monaten von
  * selbst daran.
  *
- * Darum wacht die CI darüber: Wird das Prüfdatum zu alt, färbt sich der Bau
- * rot und nennt im Klartext, was zu tun ist. Das ist derselbe Gedanke wie
- * beim Infrastruktur-Prüfskript — eine Zusage bekommt einen Wächter, keine
- * Erinnerungsnotiz.
+ * Zwei Schichten wachen darüber, beide über `../zusagen.js` (eine Frist,
+ * eine Definition):
+ *   - `handle-erinnerung.js` warnt eine Woche vorher per ntfy-Push aufs Handy.
+ *   - DIESER Test ist die harte Bremse, falls die Vorwarnung untergeht.
  *
  * Auflösen des roten Baus (5 Minuten):
- *   1. Im Mistral-Dashboard nachsehen, ob „Null-Datenspeicherung" noch aktiv
- *      ist (admin.mistral.ai → Datenschutz).
+ *   1. Im Mistral-Dashboard nachsehen, ob Null-Datenspeicherung noch aktiv ist.
  *   2. Screenshot mit Datum in den privaten Nachweisordner legen.
  *   3. Das Datum in public/datenschutz.html an BEIDEN Stellen hochsetzen
- *      (Prüfdatum im Mistral-Absatz + „Stand:"-Zeile im Kopf), Deploy.
+ *      (Prüfdatum im Mistral-Absatz + Stand-Zeile im Kopf), Deploy.
  *
  * NIEMALS das Datum ohne echte Prüfung hochsetzen — dann behauptet die
  * Webseite etwas Unbelegtes, und genau das soll dieser Test verhindern.
@@ -29,71 +29,30 @@ const path = require("path");
 const WURZEL = path.join(__dirname, "../../..");
 const SEITE = path.join(WURZEL, "public/datenschutz.html");
 
-/* Öffentliches Versprechen: „spätestens halbjährlich". */
-const FRIST_TAGE = 183;
-
-const MONATE = {
-  Januar: 0,
-  Februar: 1,
-  März: 2,
-  April: 3,
-  Mai: 4,
-  Juni: 5,
-  Juli: 6,
-  August: 7,
-  September: 8,
-  Oktober: 9,
-  November: 10,
-  Dezember: 11,
-};
-
-/** Liest „11.&nbsp;August&nbsp;2026" (auch mit normalen Leerzeichen) als Datum. */
-function leseDeutschesDatum(text, muster) {
-  const treffer = text.match(muster);
-  if (!treffer) return null;
-  const [, tag, monat, jahr] = treffer;
-  const monatIndex = MONATE[monat];
-  if (monatIndex === undefined) return null;
-  return new Date(Number(jahr), monatIndex, Number(tag));
-}
-
-function tageSeit(datum) {
-  return Math.floor((Date.now() - datum.getTime()) / 86400000);
-}
-
 describe("Frische datierter Zusagen (Datenschutzerklärung)", () => {
   const inhalt = fs.readFileSync(SEITE, "utf8");
 
   test("das ZDR-Prüfdatum steht in der Seite und ist lesbar", () => {
-    const datum = leseDeutschesDatum(
-      inhalt,
-      /zuletzt am (\d{1,2})\.(?:&nbsp;|\s)([A-Za-zÄÖÜäöü]+)(?:&nbsp;|\s)(\d{4})/
-    );
-    expect(datum).not.toBeNull();
+    expect(leseZdrPruefdatum(inhalt)).not.toBeNull();
   });
 
   test("das ZDR-Prüfdatum ist nicht älter als das öffentliche Versprechen (halbjährlich)", () => {
-    const datum = leseDeutschesDatum(
-      inhalt,
-      /zuletzt am (\d{1,2})\.(?:&nbsp;|\s)([A-Za-zÄÖÜäöü]+)(?:&nbsp;|\s)(\d{4})/
-    );
-    const alter = tageSeit(datum);
-    if (alter > FRIST_TAGE) {
+    const stand = bewerteFrist(leseZdrPruefdatum(inhalt));
+    if (stand.tageAlt > FRIST_TAGE) {
       throw new Error(
-        `Das in der Datenschutzerklärung genannte Prüfdatum ist ${alter} Tage alt ` +
+        `Das in der Datenschutzerklärung genannte Prüfdatum ist ${stand.tageAlt} Tage alt ` +
           `(erlaubt: ${FRIST_TAGE}). Die Seite verspricht öffentlich eine Prüfung ` +
           `mindestens halbjährlich.\n` +
           `→ Im Mistral-Dashboard nachsehen, ob Zero Data Retention noch aktiv ist, ` +
           `Screenshot in den Nachweisordner legen, DANN das Datum in ` +
-          `public/datenschutz.html an beiden Stellen hochsetzen (Prüfdatum + „Stand:").\n` +
+          `public/datenschutz.html an beiden Stellen hochsetzen (Prüfdatum + Stand-Zeile).\n` +
           `Das Datum niemals ohne echte Prüfung ändern.`
       );
     }
-    expect(alter).toBeLessThanOrEqual(FRIST_TAGE);
+    expect(stand.tageAlt).toBeLessThanOrEqual(FRIST_TAGE);
   });
 
   test("die Stand-Zeile im Kopf ist vorhanden und lesbar", () => {
-    const datum = leseDeutschesDatum(inhalt, /Stand: (\d{1,2})\.(?:&nbsp;|\s)([A-Za-zÄÖÜäöü]+)(?:&nbsp;|\s)(\d{4})/);
-    expect(datum).not.toBeNull();
+    expect(inhalt).toMatch(/Stand: \d{1,2}\.(?:&nbsp;|\s)[A-Za-zÄÖÜäöü]+(?:&nbsp;|\s)\d{4}/);
   });
 });

--- a/functions/src/handle-erinnerung.js
+++ b/functions/src/handle-erinnerung.js
@@ -1,0 +1,128 @@
+"use strict";
+
+/**
+ * handle-erinnerung.js — woechentlicher Blick auf datierte Zusagen.
+ *
+ * Laeuft montags und schickt einen ntfy-Push, sobald die ZDR-Nachpruefung
+ * innerhalb der naechsten Woche faellig wird (oder schon ueberfaellig ist).
+ * Der Push nennt nicht nur DASS etwas ansteht, sondern auch WAS zu tun ist —
+ * eine Erinnerung ohne Anleitung waere nur ein schlechtes Gewissen.
+ *
+ * Zwei Schichten, bewusst getrennt:
+ *   - hier die freundliche Vorwarnung (eine Woche vorher, aufs Handy)
+ *   - in der CI die harte Bremse (`__tests__/zusagen-frische.test.js`),
+ *     falls die Vorwarnung untergeht
+ *
+ * Das Pruefdatum wird aus der LIVE-Seite gelesen, nicht aus einer Kopie:
+ * Erinnert wird an das, was die Oeffentlichkeit tatsaechlich liest.
+ *
+ * Fail-soft: Jeder Fehler (Seite nicht erreichbar, Datum unlesbar, ntfy weg)
+ * wird nur als Warnung geloggt — eine Erinnerung darf nie den Betrieb stoeren
+ * und nie den Fehleralarm ausloesen (kein severity ERROR).
+ */
+
+const { SITE_URL } = require("./domains");
+const { leseZdrPruefdatum, bewerteFrist, formatiereDatum, FRIST_TAGE } = require("./zusagen");
+
+const MISTRAL_DATENSCHUTZ_URL = "https://admin.mistral.ai/plateforme/privacy";
+const ABRUF_TIMEOUT_MS = 8000;
+
+/** Baut den Meldungstext — inklusive der drei Schritte in der richtigen Reihenfolge. */
+function baueMeldung(stand) {
+  const wann = stand.ueberfaellig
+    ? `ÜBERFÄLLIG seit ${Math.abs(stand.tageBisFrist)} Tagen`
+    : `fällig in ${stand.tageBisFrist} Tagen`;
+
+  return {
+    titel: stand.ueberfaellig ? "malziME: ZDR-Prüfung überfällig" : "malziME: ZDR-Prüfung steht an",
+    text:
+      `Die Datenschutzerklärung verspricht eine Nachprüfung spätestens halbjährlich — ${wann}.\n` +
+      `Zuletzt geprüft: ${stand.datumText} (${stand.tageAlt} Tage her, Frist ${FRIST_TAGE}).\n\n` +
+      `1. Im Mistral-Dashboard nachsehen: ist „Null-Datenspeicherung" noch aktiv?\n` +
+      `2. Screenshot mit Datum in den Nachweisordner am Desktop legen.\n` +
+      `3. Claude sagen: „ZDR geprüft, alles aktiv" — Datum auf der Seite und Deploy macht Claude.\n\n` +
+      `Das Datum NIE ohne echte Prüfung ändern.`,
+  };
+}
+
+/**
+ * Prüft die Frist und schickt bei Bedarf den Push.
+ * `abruf` und `jetzt` sind injizierbar, damit Tests ohne Netz und ohne
+ * echte Uhr laufen.
+ */
+async function pruefeZusagen({ ntfyUrl, ntfyTopic, abruf = fetch, jetzt = Date.now() } = {}) {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ABRUF_TIMEOUT_MS);
+    let html;
+    try {
+      const res = await abruf(`${SITE_URL}/datenschutz.html`, { signal: controller.signal });
+      if (!res.ok) {
+        console.log(JSON.stringify({ warning: "erinnerung-seite-nicht-lesbar", status: res.status }));
+        return { gesendet: false, grund: "seite-nicht-lesbar" };
+      }
+      html = await res.text();
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const datum = leseZdrPruefdatum(html);
+    if (!datum) {
+      /* Formulierung geaendert oder Datum entfernt — das ist ein echter
+         Fund, aber kein Grund den Betrieb zu stoeren. Die CI-Bremse faellt
+         darueber ohnehin um. */
+      console.log(JSON.stringify({ warning: "erinnerung-pruefdatum-unlesbar" }));
+      return { gesendet: false, grund: "pruefdatum-unlesbar" };
+    }
+
+    const stand = { ...bewerteFrist(datum, jetzt), datumText: formatiereDatum(datum) };
+    if (!stand.faellig) {
+      console.log(JSON.stringify({ info: "erinnerung-nichts-faellig", tageBisFrist: stand.tageBisFrist }));
+      return { gesendet: false, grund: "nichts-faellig", tageBisFrist: stand.tageBisFrist };
+    }
+
+    if (!ntfyUrl || !ntfyTopic) {
+      console.log(JSON.stringify({ warning: "erinnerung-ohne-ntfy-konfiguration" }));
+      return { gesendet: false, grund: "keine-ntfy-konfiguration" };
+    }
+
+    const meldung = baueMeldung(stand);
+    const pushController = new AbortController();
+    const pushTimeout = setTimeout(() => pushController.abort(), 5000);
+    try {
+      const res = await abruf(ntfyUrl, {
+        signal: pushController.signal,
+        method: "POST",
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+        body: JSON.stringify({
+          topic: ntfyTopic,
+          title: meldung.titel,
+          message: meldung.text,
+          priority: stand.ueberfaellig ? 5 : 4,
+          tags: ["calendar", "shield"],
+          actions: [{ action: "view", label: "Mistral-Dashboard", url: MISTRAL_DATENSCHUTZ_URL }],
+        }),
+      });
+      if (!res.ok) {
+        console.log(JSON.stringify({ warning: "erinnerung-ntfy-fehlgeschlagen", status: res.status }));
+        return { gesendet: false, grund: "ntfy-fehlgeschlagen" };
+      }
+    } finally {
+      clearTimeout(pushTimeout);
+    }
+
+    console.log(
+      JSON.stringify({
+        info: "erinnerung-gesendet",
+        tageBisFrist: stand.tageBisFrist,
+        ueberfaellig: stand.ueberfaellig,
+      })
+    );
+    return { gesendet: true, tageBisFrist: stand.tageBisFrist, ueberfaellig: stand.ueberfaellig };
+  } catch (err) {
+    console.log(JSON.stringify({ warning: "erinnerung-fehler", error: err.message }));
+    return { gesendet: false, grund: "fehler" };
+  }
+}
+
+module.exports = { pruefeZusagen, baueMeldung };

--- a/functions/src/index.js
+++ b/functions/src/index.js
@@ -11,6 +11,7 @@ const { handleEnqueue } = require("./handle-enqueue");
 const { handleProcessJob } = require("./handle-process-job");
 const { handleJobStatus } = require("./handle-job-status");
 const { reapJobs } = require("./handle-reap");
+const { pruefeZusagen } = require("./handle-erinnerung");
 const { ALLOWED_ORIGINS } = require("./domains");
 
 const adminSecret = defineSecret("ADMIN_SECRET");
@@ -139,4 +140,20 @@ exports.reapJobs = onSchedule(
     timeoutSeconds: 120,
   },
   () => reapJobs()
+);
+
+/* erinnerung — geplanter Lauf (montags 9 Uhr Wien): schickt einen ntfy-Push,
+   wenn die halbjaehrliche ZDR-Nachpruefung binnen einer Woche faellig wird.
+   Freundliche Vorwarnung VOR der harten CI-Bremse (zusagen-frische.test.js).
+   Siehe handle-erinnerung.js. */
+exports.erinnerung = onSchedule(
+  {
+    region: "europe-west1",
+    schedule: "every monday 09:00",
+    timeZone: "Europe/Vienna",
+    memory: "256MiB",
+    timeoutSeconds: 60,
+    secrets: [ntfyUrl, ntfyTopic],
+  },
+  () => pruefeZusagen({ ntfyUrl: ntfyUrl.value(), ntfyTopic: ntfyTopic.value() })
 );

--- a/functions/src/zusagen.js
+++ b/functions/src/zusagen.js
@@ -1,0 +1,88 @@
+"use strict";
+
+/**
+ * zusagen.js — gemeinsame Logik für datierte oeffentliche Zusagen.
+ *
+ * Die Datenschutzerklaerung nennt ein Pruefdatum fuer die EU-/Zero-Data-
+ * Retention-Zusage und verspricht oeffentlich eine Nachpruefung „spaetestens
+ * halbjaehrlich". Zwei Stellen wachen darueber — und beide benutzen bewusst
+ * DIESE Datei, damit die Frist nur an einer Stelle definiert ist:
+ *
+ *  1. `__tests__/zusagen-frische.test.js` — harte Bremse: die CI wird rot,
+ *     sobald das Datum im Quelltext der Seite zu alt ist.
+ *  2. `handle-erinnerung.js` — freundliche Vorwarnung: eine Woche vorher
+ *     kommt ein ntfy-Push mit der Handlungsanleitung.
+ *
+ * Die Seite selbst ist die einzige Quelle des Datums (das ist es, was die
+ * Oeffentlichkeit liest) — es wird nirgends zusaetzlich gespeichert.
+ */
+
+/* Oeffentliches Versprechen: „spaetestens halbjaehrlich". */
+const FRIST_TAGE = 183;
+
+/* Wie lange vorher der Push kommt. */
+const VORWARNUNG_TAGE = 7;
+
+const MONATE = {
+  Januar: 0,
+  Februar: 1,
+  März: 2,
+  April: 3,
+  Mai: 4,
+  Juni: 5,
+  Juli: 6,
+  August: 7,
+  September: 8,
+  Oktober: 9,
+  November: 10,
+  Dezember: 11,
+};
+
+/* „11.&nbsp;August&nbsp;2026" oder „11. August 2026" nach „zuletzt am". */
+const PRUEFDATUM_MUSTER = /zuletzt am (\d{1,2})\.(?:&nbsp;|\s)([A-Za-zÄÖÜäöü]+)(?:&nbsp;|\s)(\d{4})/;
+
+/**
+ * Liest das ZDR-Pruefdatum aus dem HTML der Datenschutzerklaerung.
+ * Gibt `null` zurueck, wenn es fehlt oder die Formulierung geaendert wurde —
+ * beide Waechter behandeln das als Fehlerfall, nicht als „alles in Ordnung".
+ */
+function leseZdrPruefdatum(html) {
+  const treffer = String(html || "").match(PRUEFDATUM_MUSTER);
+  if (!treffer) return null;
+  const [, tag, monat, jahr] = treffer;
+  const monatIndex = MONATE[monat];
+  if (monatIndex === undefined) return null;
+  const datum = new Date(Number(jahr), monatIndex, Number(tag));
+  return Number.isNaN(datum.getTime()) ? null : datum;
+}
+
+/**
+ * Bewertet ein Pruefdatum gegen die Frist.
+ * `jetzt` ist injizierbar, damit Tests nicht von der echten Uhr abhaengen.
+ */
+function bewerteFrist(datum, jetzt = Date.now()) {
+  const tageAlt = Math.floor((jetzt - datum.getTime()) / 86400000);
+  const tageBisFrist = FRIST_TAGE - tageAlt;
+  return {
+    tageAlt,
+    tageBisFrist,
+    /* faellig = Vorwarnzeit erreicht ODER schon ueberschritten */
+    faellig: tageBisFrist <= VORWARNUNG_TAGE,
+    ueberfaellig: tageBisFrist < 0,
+  };
+}
+
+/** Formatiert ein Datum als „11. August 2026" fuer Meldungstexte. */
+function formatiereDatum(datum) {
+  const monat = Object.keys(MONATE).find((m) => MONATE[m] === datum.getMonth());
+  return `${datum.getDate()}. ${monat} ${datum.getFullYear()}`;
+}
+
+module.exports = {
+  FRIST_TAGE,
+  VORWARNUNG_TAGE,
+  PRUEFDATUM_MUSTER,
+  leseZdrPruefdatum,
+  bewerteFrist,
+  formatiereDatum,
+};


### PR DESCRIPTION
## Warum

Die Datenschutzerklärung nennt seit v3.0.5 ein Prüfdatum für die EU-/Zero-Data-Retention-Zusage und verspricht öffentlich eine Nachprüfung „spätestens halbjährlich". Bisher hing die Einhaltung an einer Zeile im RUNBOOK — also an nichts.

## Was

**Zwei Schichten, eine gemeinsame Fristdefinition (`functions/src/zusagen.js`):**

1. **Freundliche Vorwarnung** — `handle-erinnerung.js`, geplante Function montags 9 Uhr Wien: liest das Prüfdatum von der **Live-Seite** (kein zweiter Speicherort, keine Drift) und schickt eine Woche vor Ablauf einen ntfy-Push. Der Text nennt die drei Schritte in der richtigen Reihenfolge, mit Knopf direkt ins Mistral-Dashboard; überfällig meldet er mit höherer Priorität. Fail-soft: Seite weg, Datum unlesbar oder ntfy weg werden nur als Warnung geloggt — nie `severity ERROR`, sonst löst die Erinnerung selbst den Fehleralarm aus.
2. **Harte Bremse** — `zusagen-frische.test.js`: CI wird rot, sobald das Prüfdatum älter als 183 Tage ist, mit Klartext-Anleitung.

Ausdrücklich dokumentiert: Das Datum nie ohne echte Prüfung hochsetzen — sonst behauptet die Webseite etwas Unbelegtes.

## Der eigentliche Fund: warum iOS-Pushes nie ankamen

Beim Live-Test fiel im ntfy-Protokoll auf:

```
WARN Unable to publish poll request (… context deadline exceeded)
```

Ein selbst betriebener ntfy-Server kann iPhones nicht direkt erreichen — nur ntfy.sh hat den Apple-Push-Schlüssel. Der eigene Server reicht deshalb nach jeder Nachricht eine Anstoß-Meldung an ntfy.sh weiter, **nach** der HTTP-Antwort an den Absender. Genau dann entzieht Cloud Run dem Container standardmäßig die CPU — die Weiterleitung verhungerte und lief nach 10 s in die Zeitüberschreitung. Ergebnis: Nachricht liegt auf dem Server, kein Push aufs iPhone.

**Behoben** per `gcloud run services update ntfy --no-cpu-throttling --memory=512Mi`. Danach: keine Warnung mehr, und der Betreiber hat die Zustellung als echte Handy-Mitteilung bestätigt. Die bisherige Doku-Aussage („liegt an der App bzw. iOS, am Server nicht reparierbar") ist in `ERROR-ALERTING.md` als widerlegt korrigiert — samt Lehre: Hintergrundarbeit nach der Antwort braucht auf Cloud Run dauerhaft zugeteilte CPU, sonst scheitert sie lautlos.

## Belege

- **Echte Funktion gegen die echte Live-Seite:** heute → „nichts fällig, 182 Tage Luft"; mit vorgestellter Uhr (176 Tage) → Push ausgelöst und auf dem Handy angekommen.
- **Negativprobe des CI-Wächters:** künstlich altes Datum → rot mit „578 Tage alt (erlaubt: 183)"; Originaldatei danach unverändert.
- 19 neue Tests (Fristlogik, Push-nur-wenn-nötig, Überfälligkeit, fünf Fail-soft-Pfade, Reihenfolge der Anleitung); Backend-Suite **753/753 grün**, ESLint + Prettier sauber.
- `zusagen.js` + `handle-erinnerung.js` im i18n-Wächter als Infrastruktur ausgenommen (Betreiber-Texte, nie für Teilnehmende).

🤖 Generated with [Claude Code](https://claude.com/claude-code)