### PR TITLE
Formulierungs-Sperrliste als Pflicht-Check — und fünf Verstöße, die sie sofort gefunden hat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,17 +145,23 @@ jobs:
 
       - run: python3 scripts/pruefungen/checks/aussentext.py .
 
-  # ── Die uebrigen drei Pruefungen: melden, noch nicht blockieren ────────
-  # Stand 2026-08-12 haben sie im Repo echte Kandidaten gefunden (4 blinde Tests
-  # von 924, 8 stille Fehlschlaege in scripts/, 2 driftende Fakten). Sie sofort
-  # blockierend zu schalten haette jeden PR rot gemacht; ein dauerrot Job wird
-  # ignoriert wie ein dauergruener. Deshalb erst aufraeumen, dann
-  # continue-on-error entfernen — dann sind es Kontrollen statt Berichte.
+  # ── Zwei weitere Pruefungen: melden, noch nicht blockieren ─────────────
+  # Stand 2026-08-12 finden sie im Repo echte Kandidaten: 8 stille Fehlschlaege
+  # in scripts/ und 4 Tests von 924, die rechnerisch nicht rot werden koennen.
+  # Sie sofort blockierend zu schalten haette jeden PR rot gemacht; ein dauerhaft
+  # roter Job wird genauso ignoriert wie ein dauerhaft gruener. Deshalb erst
+  # aufraeumen, dann continue-on-error entfernen — dann sind es Kontrollen.
+  #
+  # fakten-drift.py laeuft hier bewusst NICHT mit: Es meldete "Testanzahl mit 27
+  # verschiedenen Werten" und meinte damit die Zahlen alter CHANGELOG-Eintraege.
+  # Die Heuristik kann eine dokumentierte Historie nicht von einem Widerspruch
+  # unterscheiden, und ein Befund, der sich nicht beheben laesst, ohne die
+  # Historie zu faelschen, gehoert nicht in eine Pipeline. Von Hand bleibt es
+  # nuetzlich: python3 scripts/pruefungen/checks/fakten-drift.py .
   pruefungen-bericht:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - run: python3 scripts/pruefungen/checks/fakten-drift.py .
       - run: python3 scripts/pruefungen/checks/stiller-fehlschlag.py .
       - run: python3 scripts/pruefungen/checks/test-blind.py .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,37 @@ jobs:
             https://malzi.me/impressum
           budgetPath: .github/lighthouse-budget.json
           uploadArtifacts: true
+
+  # ── Formulierungs-Sperrliste: blockierend ──────────────────────────────
+  # Warum als Pflicht-Check und nicht als Erinnerung: Die Regel "nicht
+  # behaupten, GPS verlasse das Geraet nie" stand seit Monaten in CONTRIBUTING
+  # und wurde trotzdem an fuenf Stellen verletzt (README 2x, CONTRIBUTING,
+  # CHANGELOG, public/llms.txt) — gefunden erst durch diesen Job am 2026-08-12.
+  # Eine Wording-Regel ohne Test ist eine Bitte, kein Schutz.
+  # Sperrliste: .pruefungen/aussentext.txt
+  aussentext:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Zuerst die Pruefungen selbst pruefen: zwoelf Proben, je Pruefung eine
+      # gegen kaputtes und eine gegen sauberes Material. Ohne diesen Schritt
+      # koennte ein defekter Pruefer gruen melden, ohne etwas zu pruefen.
+      - run: sh scripts/pruefungen/selbstpruefung.sh
+
+      - run: python3 scripts/pruefungen/checks/aussentext.py .
+
+  # ── Die uebrigen drei Pruefungen: melden, noch nicht blockieren ────────
+  # Stand 2026-08-12 haben sie im Repo echte Kandidaten gefunden (4 blinde Tests
+  # von 924, 8 stille Fehlschlaege in scripts/, 2 driftende Fakten). Sie sofort
+  # blockierend zu schalten haette jeden PR rot gemacht; ein dauerrot Job wird
+  # ignoriert wie ein dauergruener. Deshalb erst aufraeumen, dann
+  # continue-on-error entfernen — dann sind es Kontrollen statt Berichte.
+  pruefungen-bericht:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: python3 scripts/pruefungen/checks/fakten-drift.py .
+      - run: python3 scripts/pruefungen/checks/stiller-fehlschlag.py .
+      - run: python3 scripts/pruefungen/checks/test-blind.py .

--- a/.pruefungen/aussentext.txt
+++ b/.pruefungen/aussentext.txt
@@ -1,0 +1,26 @@
+# Verbotene Formulierungen in Texten, die nach aussen gehen (malziME).
+#
+# Format:  regulaerer Ausdruck|Begruendung
+# Getrennt wird am LETZTEN |, der Ausdruck darf also selbst | als Oder enthalten.
+# Zeilen mit # sind Kommentare. Grosz-/Kleinschreibung wird ignoriert.
+# Eine Zeile, die sich nicht laden laesst, bricht den Lauf mit Exit 2 ab.
+#
+# Geprueft wird alles unter .md .html .htm .txt .json .yml .yaml — also README,
+# CONTRIBUTING, CHANGELOG, die Seiten unter public/ und llms.txt.
+#
+# Stand 2026-08-12: Beim Anlegen dieser Liste waren fuenf Stellen im Repo verletzt
+# (README 2x, CONTRIBUTING, CHANGELOG, public/llms.txt) — alle im selben Zug korrigiert.
+
+verl(ae|ä)sst nie den (Browser|Client)|Absolute Zusage, technisch nicht haltbar. Richtig ist: GPS erreicht nie unsere Server.
+
+verlassen nie den (Browser|Client)|Absolute Zusage, technisch nicht haltbar. Richtig ist: GPS erreicht nie unsere Server.
+
+malziland e\.U\.|Diese Kurzform der Firmierung existiert nicht. Die vollstaendige Firmierung steht im Impressum und wird unveraendert uebernommen; die reine Marke "malziland" ohne Rechtsform ist erlaubt. Der volle Name steht hier bewusst nicht, weil er selbst das Trennzeichen enthaelt.
+
+zertifiziert\w* (Saferinternet|Trainer)|Es gibt keine Zertifizierung. Korrekt ist Saferinternet-Trainer ohne Zusatz.
+
+\b(der|dem|den|des) Betreibers?\b(?!-)|Keine Zuschreibung in dritter Person, sachlich formulieren. Ausgenommen Rechtstexte und strukturierte Daten.
+
+zu ?100 ?% (sicher|anonym)|Absolute Sicherheitszusage ohne Nachweis. Abschwaechen oder Nachweis verlinken.
+
+garantiert (sicher|anonym|fehlerfrei)|Garantie ohne Nachweis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+**Formulierungs-Sperrliste als Pflicht-Check — und fünf Verstöße, die sie sofort
+gefunden hat:**
+
+- **Neuer CI-Job `aussentext` (blockierend):** Prüft alle Texte, die nach außen
+  gehen (README, CONTRIBUTING, CHANGELOG, die Seiten unter `public/`, `llms.txt`)
+  gegen eine Sperrliste in `.pruefungen/aussentext.txt`. Der Job prüft zuerst die
+  Prüfung selbst (`scripts/pruefungen/selbstpruefung.sh`, zwölf Proben), damit ein
+  defekter Prüfer nicht grün meldet, ohne etwas zu prüfen.
+- **Fünf Verstöße korrigiert.** Die Regel „nicht behaupten, GPS verlasse das Gerät
+  nie" steht seit Monaten in CONTRIBUTING — und war trotzdem an fünf Stellen
+  verletzt: README (2x), CONTRIBUTING, CHANGELOG (Eintrag v1.0.0) und
+  `public/llms.txt`. Letzteres wiegt am schwersten: Diese Datei lesen KI-Crawler,
+  die Falschaussage wurde also aktiv weitergetragen. Überall steht jetzt „GPS
+  erreicht nie unsere Server" — sachlich richtig, weil der Browser für Karte und
+  Ortsname OpenStreetMap und Nominatim sehr wohl direkt aufruft.
+- **Firmierung korrigiert:** Ein CHANGELOG-Eintrag führte die Kurzform der Firma,
+  die es nicht gibt. Jetzt vollständig.
+- **Zuschreibung in dritter Person entfernt** (`docs/ERROR-ALERTING.md`, 2 Stellen):
+  Die Meldung wird jetzt sachlich beschrieben, statt sie einer Person zuzuschreiben.
+- **Neuer Job `pruefungen-bericht` (nicht blockierend):** Drei weitere Prüfungen
+  (driftende Fakten, stille Fehlschläge in Skripten, Tests ohne Zusicherung) laufen
+  mit und melden. Sie sind bewusst noch nicht blockierend: Sie finden derzeit echte
+  Kandidaten (4 blinde Tests von 924, 8 Stellen in `scripts/`), und ein dauerhaft
+  roter Job wird genauso ignoriert wie ein dauerhaft grüner. Erst aufräumen, dann
+  `continue-on-error` entfernen.
+
 ## [3.0.6] — 2026-08-12
 
 **Erinnerung an die ZDR-Nachprüfung — und die Ursache für ausbleibende
@@ -92,9 +120,9 @@ Konsens beider Prüfungen):**
 **Wording-Korrektur:** „Privat finanziert" heißt jetzt überall
 **„eigenfinanziert"** (Statistik-Seite, Stundenlimit-Banner, Deutsch und
 Englisch). Grund: Die Kosten trägt laut Impressum das Unternehmen
-malziland e.U. — „privat" war als Wort angreifbar, „eigenfinanziert" ist es
-nicht. An Kostenlosigkeit, Werbefreiheit und Tracking-Freiheit ändert sich
-selbstverständlich nichts.
+malziland - learning | training | consulting e.U. — „privat" war als Wort
+angreifbar, „eigenfinanziert" ist es nicht. An Kostenlosigkeit,
+Werbefreiheit und Tracking-Freiheit ändert sich selbstverständlich nichts.
 
 ## [3.0.2] — 2026-08-11
 
@@ -2392,7 +2420,7 @@ Erster oeffentlicher Release.
 - **Zwei Modi**: Serioese Analyse (sachlich) und Beast Mode (uebertrieben-provokant)
 - **Datenwert-Rechner**: Zeigt was ein Profil fuer Datenbroker wert ist
 - **Privacy-Check**: Erkennt ungewollt preisgegebene Informationen (Telefonnummern, Adressen, Kennzeichen)
-- **EXIF-Analyse**: Versteckte Kamera-Metadaten (client-seitig extrahiert, GPS verlässt nie den Browser)
+- **EXIF-Analyse**: Versteckte Kamera-Metadaten (client-seitig extrahiert, GPS erreicht nie unsere Server)
 - **GPS-Karte**: Aufnahmeort auf Leaflet-Karte (nur lokal im Browser)
 - **Tier-Easter-Egg**: Tierfotos bekommen ein lustiges Spass-Profil
 - **PDF-Export**: Ergebnisse als PDF speichern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,17 @@ gefunden hat:**
   die es nicht gibt. Jetzt vollständig.
 - **Zuschreibung in dritter Person entfernt** (`docs/ERROR-ALERTING.md`, 2 Stellen):
   Die Meldung wird jetzt sachlich beschrieben, statt sie einer Person zuzuschreiben.
-- **Neuer Job `pruefungen-bericht` (nicht blockierend):** Drei weitere Prüfungen
-  (driftende Fakten, stille Fehlschläge in Skripten, Tests ohne Zusicherung) laufen
-  mit und melden. Sie sind bewusst noch nicht blockierend: Sie finden derzeit echte
-  Kandidaten (4 blinde Tests von 924, 8 Stellen in `scripts/`), und ein dauerhaft
-  roter Job wird genauso ignoriert wie ein dauerhaft grüner. Erst aufräumen, dann
+- **Neuer Job `pruefungen-bericht` (nicht blockierend):** Zwei weitere Prüfungen
+  (stille Fehlschläge in Skripten, Tests ohne Zusicherung) laufen mit und melden.
+  Sie sind bewusst noch nicht blockierend: Sie finden derzeit echte Kandidaten
+  (8 Stellen in `scripts/`, 4 blinde Tests von 924), und ein dauerhaft roter Job
+  wird genauso ignoriert wie ein dauerhaft grüner. Erst aufräumen, dann
   `continue-on-error` entfernen.
+- **`fakten-drift` läuft bewusst nicht in der Pipeline mit.** Es meldete „Testanzahl
+  mit 27 verschiedenen Werten" und meinte damit die Zahlen alter CHANGELOG-Einträge.
+  Die Heuristik kann eine dokumentierte Historie nicht von einem Widerspruch
+  unterscheiden — ein Befund, der sich nicht beheben lässt, ohne die Historie zu
+  fälschen, gehört nicht in eine Pipeline. Von Hand bleibt die Prüfung nützlich.
 
 ## [3.0.6] — 2026-08-12
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Detaillierte Anleitung: [`docs/SETUP.md`](docs/SETUP.md)
 
 Diese Regeln sind nicht verhandelbar:
 
-- **GPS verlässt nie den Browser.** Keine Ausnahmen.
+- **GPS erreicht nie unsere Server.** Keine Ausnahmen. Genau so formulieren, nicht als Zusage über das Gerät: Für Karte und Ortsname ruft der Browser OpenStreetMap und Nominatim direkt auf. Die Koordinaten verlassen das Gerät also sehr wohl — nur eben nie in Richtung malziME. Jede Formulierung, die etwas anderes behauptet, ist im Netzwerk-Tab in zehn Sekunden widerlegt und steht auf der Sperrliste in `.pruefungen/aussentext.txt`.
 - **Keine externen Scripts.** Alles muss self-hosted sein.
 - **Keine Tracking-Cookies, Analytics oder Werbung.**
 - **Keine dauerhafte Speicherung von Bildern oder Profilen.** (Im Queue-Betrieb liegt das Bild kurz im Storage — es muss unmittelbar nach der Verarbeitung gelöscht werden.)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Datenschutz ist kein Feature — es ist das Fundament:
 
 - **EU-Hosting fuer KI-Analysen**: Alle Bild-Analysen laufen ueber Mistral AI (Paris, EU-DSGVO). Mistral als Auftragsverarbeiter nach Art. 28 DSGVO. Auf dem genutzten kostenpflichtigen API-Tier ist Training auf Eingaben/Ausgaben laut Anbieter-Zusage deaktiviert.
 - **Keine US-KI-Anbieter mehr**: Seit v1.6.0 wurden Google Vertex AI und Cloud Vision aus der Pipeline entfernt. Google bleibt nur fuer die Infrastruktur (Firebase Hosting + Cloud Functions + Firestore, alles in `europe-west1`).
-- **EXIF-Extraktion im Browser**: exifr parsed die Metadaten lokal, GPS verlässt nie den Client
+- **EXIF-Extraktion im Browser**: exifr parsed die Metadaten lokal, GPS erreicht nie unsere Server
 - **Server bekommt kein GPS**: Nur komprimiertes Bild + Kamera-Hersteller/Modell (ohne GPS, ohne dateTimeOriginal)
 - **Geocoding direkt vom Browser**: Nominatim wird client-seitig aufgerufen, nicht ueber den Server
 - **Keine dauerhafte Speicherung**: Im Queue-Betrieb liegt das Bild nur kurz zur Verarbeitung im EU-Storage und wird sofort danach geloescht; das Job-Dokument spaetestens nach 2 h. Kein Profil bleibt dauerhaft gespeichert
@@ -265,6 +265,8 @@ GitHub Actions Workflow `.github/workflows/ci.yml`:
 - **Secret-Scan** via gitleaks (prueft auf versehentlich committete API-Keys)
 - **Dependabot** prueft monatlich auf Updates (npm + GitHub Actions, je Bereich zu einem PR gebuendelt) und oeffnet bei gemeldeten Sicherheitsluecken sofort einen Reparatur-PR
 - **Audit-Gate** im Backend-Job (`scripts/audit-gate.mjs`): blockiert bei hohen und kritischen Schwachstellen. Laesst sich eine Luecke tief in einer fremden Abhaengigkeitskette nachweislich (noch) nicht reparieren, kann sie **begruendet und mit Ablaufdatum** in `.github/audit-allowlist.json` ausgenommen werden — danach faellt das Gate von selbst wieder auf rot
+- **Formulierungs-Sperrliste** (`aussentext`): blockiert, wenn ein Text, der nach aussen geht, eine Formulierung aus `.pruefungen/aussentext.txt` enthaelt — etwa eine Datenschutz-Zusage, die im Netzwerk-Tab widerlegbar waere. Der Job prueft zuerst die Pruefung selbst (`scripts/pruefungen/selbstpruefung.sh`)
+- **Weitere Pruefungen** (`pruefungen-bericht`): driftende Fakten, stille Fehlschlaege in Skripten, Tests ohne Zusicherung — laufen mit und melden, blockieren noch nicht
 - **Branch Protection** fuer `main`: Merges erst nach gruenen Status-Checks (`test-backend`, `test-frontend`, `test-e2e`, `secret-scan`)
 - Deploy erfolgt manuell per `npx firebase deploy`
 
@@ -299,7 +301,7 @@ GitHub Actions Workflow `.github/workflows/ci.yml`:
 - Kein Firebase SDK im Frontend, kein reCAPTCHA
 - KI-Analyse ausschliesslich ueber Mistral AI (Paris/EU). Mistral als Auftragsverarbeiter nach Art. 28 DSGVO, kein Training auf den Daten.
 - Infrastruktur (Hosting, Cloud Functions, Firestore) bei Google Ireland in europe-west1 — auch als Auftragsverarbeiter, kein Zugriff auf Bildinhalte.
-- GPS-Daten verlassen nie den Browser des Nutzers
+- GPS-Daten erreichen nie unsere Server (Karte und Ortsname holt der Browser direkt bei OpenStreetMap bzw. Nominatim)
 - Details: [malzi.me/datenschutz](https://malzi.me/datenschutz)
 
 ## Lizenz

--- a/docs/ERROR-ALERTING.md
+++ b/docs/ERROR-ALERTING.md
@@ -3,7 +3,7 @@
 ## Was ist das?
 
 Wenn eine Cloud Function einen Fehler loggt (Absturz, Speicherfehler, API-Timeout,
-ausgefallene Kostenbremse), wird der Betreiber sofort benachrichtigt — statt es
+ausgefallene Kostenbremse), geht sofort eine Benachrichtigung raus — statt es
 erst Tage später zu merken.
 
 ## Wie es funktioniert
@@ -96,8 +96,8 @@ Der Filter wurde am 2026-07-17 (LANGAUDIT OPS-001) um die Queue-Functions
 war seit der Queue-Umstellung (v2.0) ohne Alarm. Die Functions `errors` und
 `telemetry` sind **bewusst ausgespart**: `handle-errors.js` loggt jeden
 Client-Fehlerbericht mit severity ERROR — im Filter wäre das Alarm-Spam.
-Client-Fehler erreichen den Betreiber stattdessen über den Log-Bucket
-`client-diagnostics` (30 Tage Aufbewahrung), nicht über ntfy.
+Client-Fehler landen stattdessen im Log-Bucket
+`client-diagnostics` (30 Tage Aufbewahrung), nicht bei ntfy.
 
 ## Zweiter Kanal: E-Mail (seit 2026-08-10)
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -27,6 +27,8 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 | Reproduzierbarer Build | — entfällt: kein Build-Schritt (Vanilla-JS-Frontend wird direkt ausgeliefert, Functions deployen Quellcode) | n/a, Begründung links |
 | **Rollback-Probe** (Release-Stand aus sich heraus lauffähig) | Release-Tag in temporärem `git worktree` auschecken, `npm ci` Root + functions, beide Test-Suiten | ✅ Tag `v2.3.1` (Commit `8d39a10`): Setup ok, 435/435 + 165/165 Tests grün, Exit 0 — 2026-07-14, Node 24, macOS; Worktree danach entfernt |
 | Betriebs-Rollback ohne Deploy (Feature-Flags) | Firestore-Flag `useSingleLargeCall`, Verfahren in [RUNBOOK.md](RUNBOOK.md) | ✅ produktiv erprobt (Architektur-Umstellungen v2.0/v2.2 liefen über genau diese Schalter) |
+| Formulierungs-Sperrliste in Außentexten | CI-Job `aussentext`; lokal `python3 scripts/pruefungen/checks/aussentext.py .` — Regeln in `.pruefungen/aussentext.txt`. Ungültig, sobald eine Regel dazukommt oder ein neuer Außentext entsteht | ✅ 0 Verstöße bei 39 geprüften Dateien, 7 Regeln geladen — Zweig `feat/pruefungen-ci`, 2026-08-12. Gegenprobe: 7 absichtliche Verstöße lösen 7 Treffer aus; die 5 echten Fundstellen sind im selben Zug korrigiert |
+| Die Prüfungen selbst können rot werden | CI-Job `aussentext`, Schritt 1: `sh scripts/pruefungen/selbstpruefung.sh` — je Prüfung eine Probe gegen kaputtes und eine gegen sauberes Material | ✅ 12/12 Proben, Exit 0 — 2026-08-12. Rückbauprobe je Korrektur durchgeführt: jede Korrektur lässt genau ihre Probe fallen |
 
 ## Profilpflichten
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,7 +6,7 @@ Betreiber: malziland - learning | training | consulting e.U., Inhaber Christoph 
 
 Zielgruppe: Workshops mit Kindern, Jugendlichen und Erwachsenen zu Datenschutz, Algorithmen-Bias und Profiling (Safer Internet, Schule, Erwachsenenbildung).
 
-Datenschutz: Hochgeladene Fotos werden nur für die Dauer der Analyse verarbeitet und danach aktiv gelöscht. GPS-Daten (EXIF) verlassen nie den Browser. Keine Cookies, kein Tracking, keine Konten.
+Datenschutz: Hochgeladene Fotos werden nur für die Dauer der Analyse verarbeitet und danach aktiv gelöscht. GPS-Daten (EXIF) erreichen nie unsere Server. Keine Cookies, kein Tracking, keine Konten.
 
 Sprachen: Deutsch (Standard) und Englisch (umschaltbar auf der Seite).
 

--- a/scripts/pruefungen/README.md
+++ b/scripts/pruefungen/README.md
@@ -1,0 +1,92 @@
+# PRUEFUNGEN — vier Kontrollen statt vier Bitten
+
+> **Herkunft:** Dieses Verzeichnis ist eine Kopie des Werkzeugkastens aus der
+> Audit-Familie (`~/.claude/skills/audit-familie/pruefungen`, Stand 2026-08-12,
+> Paket 1.0 plus vier Korrekturen). Es liegt hier, weil die CI nur sieht, was im
+> Repository liegt. Aenderungen bitte an BEIDEN Stellen — die Familie ist die Quelle.
+>
+> Der Ordner `negativprobe/` enthaelt **absichtlich fehlerhaftes Beispielmaterial**
+> (Skripte mit Erfolgsluegen, Tests ohne Zusicherung, widerspruechliche Zahlen). Das
+> ist kein Code dieses Projekts und wird von allen Pruefungen uebersprungen.
+
+Diese vier Pruefungen setzen Regeln der Familie in Programme um, die rot werden koennen.
+Der Unterschied ist der Kern der ganzen Sache: Eine Regel im Prompt wirkt vielleicht,
+eine Pruefung in der Pipeline wirkt immer.
+
+Jede der vier deckt eine Fehlerklasse ab, die in der Praxis tatsaechlich Schaden
+angerichtet hat.
+
+## Die vier Pruefungen
+
+**fakten-drift.py** findet Fakten, die an mehreren Stellen verschieden stehen. Zahl der
+Tests, Version, Abdeckung, Fristen. Die haeufigste Befundklasse ueberhaupt. Setzt die
+Ein-Quellen-Regel (KERN 11) durch.
+
+**stiller-fehlschlag.py** findet Stellen, an denen ein Fehlschlag wie Erfolg aussieht:
+Erfolgsmeldung nach Semikolon statt nach `&&`, verschluckte Fehler, Rueckgabewert nach
+einer Pipe, fehlendes `set -e`. Setzt KERN 5c durch.
+
+**aussentext.py** prueft Texte, die nach aussen gehen, gegen eine Liste verbotener
+Formulierungen. Mit eingebauter Positivkontrolle: Schlaegt die Suche an einem bekannten
+Verstoss nicht an, meldet die Pruefung, dass sie selbst kaputt ist, statt gruen zu
+werden.
+
+**test-blind.py** findet Tests, die rechnerisch nicht rot werden koennen: ohne
+Zusicherung, uebersprungen, immer wahr. Setzt KERN 4 Frage 2 durch.
+
+## Aufruf
+
+    sh pruefe-alles.sh /pfad/zum/projekt
+
+Einzeln:
+
+    python3 checks/fakten-drift.py /pfad/zum/projekt
+
+Rueckgabewerte: 0 sauber, 1 Fundstellen, 2 keine Suchflaeche oder Aufrufproblem. Der
+Wert 2 ist ausdruecklich kein Erfolg: Eine Pruefung, die nichts zu pruefen fand, hat
+nichts bestanden.
+
+## Selbstpruefung
+
+    sh selbstpruefung.sh
+
+Fuehrt jede Pruefung zweimal aus: gegen absichtlich kaputtes Material, wo sie rot werden
+MUSS, und gegen sauberes Material, wo sie gruen bleiben muss. Acht Proben.
+
+Das ist der Teil, der beim ersten Anlauf der Familie gefehlt hat. Damals wurde ein
+Pruefskript nur gegen fehlerhaftes Material getestet, wurde korrekt rot, und liess
+trotzdem beliebigen Unsinn durch, weil die zweite Richtung nie geprueft wurde. Beim Bau
+dieser vier Pruefungen hat die zweite Richtung sofort einen Fehlalarm gefunden
+(`pytest.raises` wurde nicht als Zusicherung erkannt). Ohne sie waere er in Betrieb
+gegangen.
+
+## Einbau ins Projekt
+
+Damit aus den Pruefungen Kontrollen werden, muessen sie mitlaufen, nicht auf Zuruf
+starten. Drei Stufen, je nach Ausbaustufe des Projekts:
+
+1. **Von Hand**, vor jeder Abgabe: `sh pruefe-alles.sh .`
+2. **Vor dem Commit**, ueber den Vor-Commit-Haken des Projekts.
+3. **In der Pipeline**, als eigener Job. Ein roter Job bricht ab. Erst hier ist es
+   wirklich eine Kontrolle, weil sie sich nicht vergessen laesst.
+
+Der `/projektstart` baut Stufe 3 ab der Ausbaustufe STANDARD ein.
+
+## Anpassen
+
+`.pruefungen/aussentext.txt` im Projekt enthaelt die verbotenen Formulierungen. Beim
+ersten Lauf wird eine Vorlage angelegt, die anzupassen ist.
+
+`.pruefungen/fakten.txt` kann eigene Fakt-Muster ergaenzen, je Zeile
+`Bezeichnung|regulaerer Ausdruck mit einer Klammergruppe`.
+
+## Grenzen
+
+Was diese vier Pruefungen nicht finden koennen, und wo die Kontrolle stattdessen wohnt:
+
+- Ob eine Aussage inhaltlich stimmt. Sie pruefen Form und Widerspruch, nicht Wahrheit.
+- Ob ein Test das Richtige prueft. Sie finden nur Tests, die gar nichts pruefen koennen.
+- Ob ein Satz auf dem Bildschirm Sinn ergibt. Kein Werkzeug der Kette liest die Sprache
+  des Nutzers; das bleibt Sichtpruefung durch einen Menschen.
+- Zustandsdrift in der Aussenwelt (Regionen, Zugriffsrechte, Fristen beim Anbieter).
+  Dafuer ist das Zusagen-Pruefskript des Projekts zustaendig (KERN 6).

--- a/scripts/pruefungen/checks/aussentext.py
+++ b/scripts/pruefungen/checks/aussentext.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""aussentext.py — prueft Texte, die nach aussen gehen, gegen verbotene Formulierungen.
+
+Der belegte Vorfall dahinter: Eine Formulierung, die im Netzwerk-Tab widerlegbar war,
+stand dokumentiert auf der Verbotsliste und ueberlebte trotzdem monatelang im README.
+Eine Wording-Regel ohne Test ist eine Bitte, kein Schutz.
+
+Diese Pruefung hat eine eingebaute Positivkontrolle: Sie prueft sich selbst an einem
+bekannten Verstoss. Schlaegt die Kontrolle nicht an, ist die Suche kaputt und die
+Pruefung meldet das, statt gruen zu werden.
+
+Aufruf:  python3 aussentext.py [verzeichnis]
+Exit 0 = sauber, Exit 1 = Verstoss, Exit 2 = Aufrufproblem oder kaputte Suche.
+
+Regeln liegen in .pruefungen/aussentext.txt, je Zeile:
+    <regulaerer Ausdruck>|<Begruendung, warum die Formulierung nicht zulaessig ist>
+Zeilen mit # sind Kommentare. Ohne Regeldatei legt die Pruefung eine Vorlage an.
+
+Getrennt wird am LETZTEN |, denn der regulaere Ausdruck darf selbst | enthalten
+(Oder-Verknuepfung). Die Begruendung ist Fliesstext und darf keines enthalten.
+Eine Zeile, die sich nicht laden laesst, beendet den Lauf mit Exit 2. Sie als Hinweis
+zu ueberspringen hiesse, mit einer stillschweigend geschwaechten Pruefung
+weiterzuarbeiten - genau die Fehlerform, gegen die diese Pruefungen gebaut sind.
+"""
+import os
+import re
+import sys
+
+ENDUNGEN = (".md", ".html", ".htm", ".txt", ".json", ".yml", ".yaml", ".vue", ".jsx",
+            ".tsx", ".svelte")
+# "negativprobe" enthaelt das absichtlich kaputte Beispielmaterial dieser Pruefungen.
+# Ohne den Ausschluss meldet jeder Lauf im eigenen Verzeichnis Dauerfunde aus dem
+# eigenen Testmaterial — und ein Pruefer, der nie gruen werden kann, wird ignoriert.
+UEBERSPRINGEN = {".git", "node_modules", "vendor", "dist", "build", ".venv",
+                 "__pycache__", "target", "coverage", "test", "tests", "__tests__",
+                 "negativprobe"}
+
+VORLAGE = """# Verbotene Formulierungen in Texten, die nach aussen gehen.
+# Format:  regulaerer Ausdruck|Begruendung
+# Diese Zeilen sind Beispiele. Passe sie an dein Projekt an.
+verlaesst nie den Browser|Absolute Zusage ueber Datenfluesse ist im Netzwerk-Tab widerlegbar. Beschreiben, was das System tut, nicht was es niemals tut.
+zu ?100 ?% sicher|Sicherheit ist keine Zusage, die man geben kann.
+garantiert (?:sicher|anonym|fehlerfrei)|Garantie ohne Nachweis. Formulierung abschwaechen oder Nachweis verlinken.
+militaerisch(?:e|er)? Verschluesselung|Marketingbegriff ohne technischen Gehalt.
+"""
+
+# Ein Satz, der gegen die erste Vorlagenregel verstoesst. Dient der Selbstpruefung.
+KONTROLLSATZ = "Deine Position verlaesst nie den Browser."
+KONTROLLMUSTER = r"verlaesst nie den Browser"
+
+
+def regeln_laden(wurzel):
+    ordner = os.path.join(wurzel, ".pruefungen")
+    pfad = os.path.join(ordner, "aussentext.txt")
+    if not os.path.isfile(pfad):
+        os.makedirs(ordner, exist_ok=True)
+        with open(pfad, "w", encoding="utf-8") as f:
+            f.write(VORLAGE)
+        print(f"Vorlage angelegt: {os.path.relpath(pfad, wurzel)}")
+        print("Bitte an das Projekt anpassen. Es gelten vorerst die Beispielregeln.")
+        print("-" * 60)
+
+    regeln = []
+    maengel = []
+    with open(pfad, encoding="utf-8", errors="replace") as f:
+        for nr, zeile in enumerate(f, 1):
+            zeile = zeile.strip()
+            if not zeile or zeile.startswith("#"):
+                continue
+            if "|" not in zeile:
+                maengel.append(f"Zeile {nr}: kein Trennzeichen | vorhanden")
+                continue
+            # Von rechts trennen: Der Ausdruck darf | enthalten, die Begruendung nicht.
+            ausdruck, grund = zeile.rsplit("|", 1)
+            # Steht in der Begruendung ein |, wandert der Text davor stillschweigend in
+            # den Ausdruck und macht daraus eine viel zu weite Alternation. Der Ausdruck
+            # kompiliert dabei tadellos - es faellt also nur ueber die Trefferzahl auf.
+            # Erkennungsmerkmal: In einem Ausdruck steht | ohne Leerzeichen (a|b), in
+            # Prosa mit ("learning | training").
+            if " | " in ausdruck:
+                maengel.append(
+                    f"Zeile {nr}: Der Ausdruck enthaelt ' | ' mit Leerzeichen. "
+                    "Vermutlich steht in der Begruendung ein |, und der Text davor "
+                    "gehoert jetzt zum Suchmuster. Begruendung ohne | schreiben.")
+                continue
+            try:
+                regeln.append((re.compile(ausdruck.strip(), re.I), grund.strip(),
+                               ausdruck.strip()))
+            except re.error as fehler:
+                maengel.append(f"Zeile {nr}: ungueltiger Ausdruck: {fehler}")
+    return regeln, maengel
+
+
+def positivkontrolle(regeln):
+    """Die Suche muss an einem bekannten Verstoss anschlagen (KERN 8, Bedingung 5)."""
+    if not any(a.search(KONTROLLSATZ) for a, _, _ in regeln):
+        # Nur aussagekraeftig, wenn die Kontrollregel ueberhaupt geladen ist.
+        if any(roh == KONTROLLMUSTER for _, _, roh in regeln):
+            return False
+    return True
+
+
+def dateien(wurzel):
+    for ordner, unterordner, namen in os.walk(wurzel):
+        unterordner[:] = [u for u in unterordner
+                          if u not in UEBERSPRINGEN and not u.startswith(".")]
+        for name in namen:
+            if name.lower().endswith(ENDUNGEN):
+                yield os.path.join(ordner, name)
+
+
+def main():
+    wurzel = sys.argv[1] if len(sys.argv) > 1 else "."
+    if not os.path.isdir(wurzel):
+        print(f"FEHLER: kein Verzeichnis: {wurzel}")
+        return 2
+
+    print("AUSSENTEXT")
+    print(f"Geprueft unter: {os.path.abspath(wurzel)}")
+    print("-" * 60)
+
+    regeln, maengel = regeln_laden(wurzel)
+    if maengel:
+        print("FEHLER: Die Regeldatei ist nicht vollstaendig ladbar.")
+        for eintrag in maengel:
+            print(f"  {eintrag}")
+        print("Eine Regel, die nicht laedt, prueft nichts — und der Lauf saehe trotzdem")
+        print("aus wie ein Ergebnis. Erst die Regeldatei reparieren, dann messen.")
+        return 2
+
+    if not regeln:
+        print("Keine Regeln geladen. Ohne Regeln keine Aussage, kein bestandener Test.")
+        return 2
+
+    if not positivkontrolle(regeln):
+        print("FEHLER: Die Positivkontrolle schlaegt nicht an. Die Suche ist kaputt,")
+        print("nicht der Text sauber. Ergebnis ist wertlos, bis das behoben ist.")
+        return 2
+
+    geprueft = 0
+    funde = []
+    for pfad in dateien(wurzel):
+        geprueft += 1
+        try:
+            with open(pfad, encoding="utf-8", errors="replace") as f:
+                zeilen = f.readlines()
+        except OSError:
+            continue
+        for nr, zeile in enumerate(zeilen, 1):
+            for ausdruck, grund, _ in regeln:
+                treffer = ausdruck.search(zeile)
+                if treffer:
+                    funde.append((os.path.relpath(pfad, wurzel), nr,
+                                  treffer.group(0), grund))
+
+    print(f"Regeln: {len(regeln)} (Positivkontrolle bestanden)")
+    print(f"Dateien: {geprueft}")
+
+    for kurz, nr, text, grund in funde:
+        print(f"\n{kurz}:{nr}")
+        print(f"  Formulierung: {text}")
+        print(f"  Grund:        {grund}")
+
+    print("-" * 60)
+    if not funde:
+        print("ERGEBNIS: kein Verstoss gefunden.")
+        return 0
+    print(f"ERGEBNIS: {len(funde)} Verstoss/Verstoesse. Formulierung aendern oder die")
+    print("Regel begruendet streichen. Beides ist eine Entscheidung, kein Versehen.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pruefungen/checks/fakten-drift.py
+++ b/scripts/pruefungen/checks/fakten-drift.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""fakten-drift.py — findet Fakten, die an mehreren Stellen verschieden stehen.
+
+Deckt die haeufigste Befundklasse ab: dieselbe Zahl in README, CHANGELOG und
+Verifikationsmatrix, dreifach verschieden. Umsetzung der Ein-Quellen-Regel (KERN 11)
+als Pruefung statt als Bitte.
+
+Aufruf:  python3 fakten-drift.py [verzeichnis]
+Exit 0 = kein Drift, Exit 1 = Drift gefunden, Exit 2 = Aufrufproblem.
+
+Eigene Muster: eine Datei .pruefungen/fakten.txt anlegen, je Zeile
+    <Bezeichnung>|<regulaerer Ausdruck mit genau einer Klammergruppe>
+Beispiel:
+    Zeilenlimit|max(?:imal)?\\s+(\\d+)\\s+Zeilen
+"""
+import os
+import re
+import sys
+
+# Nur Textdateien, in denen Fakten behauptet werden. Code bleibt aussen vor:
+# dort ist eine Zahl eine Implementierung, keine Behauptung.
+ENDUNGEN = (".md", ".markdown", ".txt", ".rst", ".adoc")
+# "negativprobe": eigenes Beispielmaterial dieser Pruefungen, sonst Dauerfunde.
+UEBERSPRINGEN = {".git", "node_modules", "vendor", "dist", "build", ".venv",
+                 "__pycache__", ".next", "target", "coverage", "negativprobe"}
+
+# Eingebaute Muster. Bezeichnung -> regulaerer Ausdruck mit einer Klammergruppe.
+MUSTER = {
+    "Testanzahl": r"(\d[\d.']*)\s*(?:Tests?|Testfaelle|test cases?)\b",
+    "Testabdeckung": r"(?:Coverage|Abdeckung|Testabdeckung)[^\d\n]{0,20}(\d{1,3})\s*%",
+    "Version": r"\bVersion\s+v?(\d+\.\d+(?:\.\d+)?)",
+    "Node-Version": r"[Nn]ode(?:\.js)?\s+v?(\d+(?:\.\d+)*)",
+    "Python-Version": r"[Pp]ython\s+v?(\d+\.\d+(?:\.\d+)?)",
+    "Port": r"\b[Pp]ort\s+(\d{2,5})\b",
+    "Aufbewahrungsfrist": r"(\d+)\s*(?:Tage|Tagen)\b",
+}
+
+
+def eigene_muster(wurzel):
+    pfad = os.path.join(wurzel, ".pruefungen", "fakten.txt")
+    if not os.path.isfile(pfad):
+        return {}
+    zusatz = {}
+    with open(pfad, encoding="utf-8", errors="replace") as f:
+        for nr, zeile in enumerate(f, 1):
+            zeile = zeile.strip()
+            if not zeile or zeile.startswith("#"):
+                continue
+            if "|" not in zeile:
+                print(f"  Hinweis: {pfad}:{nr} ohne Trennzeichen |, uebersprungen")
+                continue
+            name, ausdruck = zeile.split("|", 1)
+            try:
+                if re.compile(ausdruck).groups != 1:
+                    print(f"  Hinweis: {pfad}:{nr} braucht genau eine Klammergruppe")
+                    continue
+                zusatz[name.strip()] = ausdruck
+            except re.error as fehler:
+                print(f"  Hinweis: {pfad}:{nr} ungueltiger Ausdruck: {fehler}")
+    return zusatz
+
+
+def dateien(wurzel):
+    for ordner, unterordner, namen in os.walk(wurzel):
+        unterordner[:] = [u for u in unterordner
+                          if u not in UEBERSPRINGEN and not u.startswith(".")]
+        for name in namen:
+            if name.lower().endswith(ENDUNGEN):
+                yield os.path.join(ordner, name)
+
+
+def main():
+    wurzel = sys.argv[1] if len(sys.argv) > 1 else "."
+    if not os.path.isdir(wurzel):
+        print(f"FEHLER: kein Verzeichnis: {wurzel}")
+        return 2
+
+    muster = dict(MUSTER)
+    muster.update(eigene_muster(wurzel))
+
+    # bezeichnung -> wert -> Liste von Fundstellen
+    funde = {name: {} for name in muster}
+    geprueft = 0
+
+    for pfad in dateien(wurzel):
+        geprueft += 1
+        try:
+            with open(pfad, encoding="utf-8", errors="replace") as f:
+                zeilen = f.readlines()
+        except OSError:
+            continue
+        for nr, zeile in enumerate(zeilen, 1):
+            # Ein Wert mit Datum oder Stand daneben ist nach KERN 11 zulaessig.
+            if re.search(r"Stand\s+\d{4}-\d{2}-\d{2}|Commit\s+[0-9a-f]{7}", zeile):
+                continue
+            for name, ausdruck in muster.items():
+                for treffer in re.finditer(ausdruck, zeile):
+                    wert = treffer.group(1).replace("'", "").replace(".", "")
+                    funde[name].setdefault(wert, []).append(
+                        f"{os.path.relpath(pfad, wurzel)}:{nr}")
+
+    print("FAKTEN-DRIFT")
+    print(f"Geprueft: {geprueft} Textdateien unter {os.path.abspath(wurzel)}")
+    print(f"Muster: {len(muster)} ({len(muster) - len(MUSTER)} eigene)")
+    print("-" * 60)
+
+    if geprueft == 0:
+        print("Keine Textdateien gefunden. Ohne Suchflaeche keine Aussage.")
+        return 2
+
+    treffer_gesamt = 0
+    for name, werte in sorted(funde.items()):
+        if len(werte) < 2:
+            continue
+        # Mehrere verschiedene Werte fuer denselben Fakt.
+        treffer_gesamt += 1
+        print(f"\nDRIFT: {name} steht mit {len(werte)} verschiedenen Werten da.")
+        for wert, stellen in sorted(werte.items(), key=lambda p: -len(p[1])):
+            orte = ", ".join(stellen[:4])
+            mehr = f" (+{len(stellen) - 4} weitere)" if len(stellen) > 4 else ""
+            print(f"  {wert:<12} {orte}{mehr}")
+        print("  Abhilfe: eine kanonische Quelle bestimmen, andere Stellen verweisen")
+        print("  lassen oder den Wert weglassen. Nicht alle Kopien nachziehen.")
+
+    print("-" * 60)
+    if treffer_gesamt == 0:
+        print("ERGEBNIS: kein Drift gefunden.")
+        return 0
+    print(f"ERGEBNIS: {treffer_gesamt} Fakt(en) driften. Ein-Quellen-Regel anwenden.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pruefungen/checks/stiller-fehlschlag.py
+++ b/scripts/pruefungen/checks/stiller-fehlschlag.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""stiller-fehlschlag.py — findet Stellen, an denen ein Fehlschlag wie Erfolg aussieht.
+
+Der belegte Vorfall dahinter: Ein Push wurde abgelehnt, die Meldung sagte trotzdem
+Erfolg, die Korrektur landete nie, die Auslieferung lief weiter. Umsetzung von
+KERN 5c ("jeder Kanal hat eine Fehlerform, die wie Erfolg aussieht") als Pruefung.
+
+Aufruf:  python3 stiller-fehlschlag.py [verzeichnis]
+Exit 0 = sauber, Exit 1 = Fundstellen, Exit 2 = Aufrufproblem.
+"""
+import os
+import re
+import sys
+
+ENDUNGEN = (".sh", ".bash", ".zsh", ".yml", ".yaml")
+# "negativprobe": eigenes Beispielmaterial dieser Pruefungen, sonst Dauerfunde.
+UEBERSPRINGEN = {".git", "node_modules", "vendor", "dist", "build", ".venv",
+                 "__pycache__", "target", "coverage", "negativprobe"}
+
+ERFOLGSWORT = (r"(?:erfolg|erledigt|fertig|gruen|ok\b|done|success|passed|"
+               r"deployed|veroeffentlicht|abgeschlossen|✓|✅)")
+
+REGELN = [
+    (
+        "Erfolgsmeldung nach Semikolon",
+        re.compile(r";\s*(?:echo|print|printf)\b[^\n]*" + ERFOLGSWORT, re.I),
+        "Das Semikolon fuehrt die Meldung auch aus, wenn der Befehl davor scheitert. "
+        "Mit && verketten, dann haengt die Meldung am Rueckgabewert.",
+    ),
+    (
+        "Fehler wird verschluckt",
+        re.compile(r"\|\|\s*(?:true|:)\s*$", re.M),
+        "|| true macht aus jedem Fehlschlag einen Erfolg. Nur zulaessig, wenn der "
+        "Rueckgabewert danach ausdruecklich geprueft und gemeldet wird.",
+    ),
+    (
+        "Ausgabe verworfen und Fehler mit",
+        re.compile(r">\s*/dev/null\s+2>&1\s*(?:;|$)", re.M),
+        "Ohne anschliessende Pruefung des Rueckgabewerts ist nicht unterscheidbar, "
+        "ob der Befehl lief oder scheiterte.",
+    ),
+    (
+        "Rueckgabewert nach Pipe",
+        re.compile(r"\|[^\n|]+\n[^\n]*\$\?", re.M),
+        "Nach einer Pipe liefert $? den Wert des LETZTEN Befehls, nicht des ersten. "
+        "Mit set -o pipefail arbeiten oder den Wert direkt abfragen.",
+    ),
+    (
+        "Leeres Suchergebnis als Ergebnis gelesen",
+        re.compile(r"(?:grep|rg|ag)\b[^\n|]*\|\s*(?:wc|head|tail)\b[^\n]*\n"
+                   r"(?![^\n]*(?:if|test|\[)).*?" + ERFOLGSWORT, re.I | re.S),
+        "Eine Suche, die nichts findet, und eine Suche, die scheitert, sehen gleich "
+        "aus. Positivkontrolle noetig: an bekannter Fundstelle muss sie anschlagen.",
+    ),
+]
+
+# Fuer Shell-Skripte zusaetzlich: fehlendes set -e ist die Grundform des Problems.
+SET_E = re.compile(r"^\s*set\s+-[a-z]*e", re.M)
+SHELL_ENDUNGEN = (".sh", ".bash", ".zsh")
+
+
+def dateien(wurzel):
+    for ordner, unterordner, namen in os.walk(wurzel):
+        unterordner[:] = [u for u in unterordner
+                          if u not in UEBERSPRINGEN and not u.startswith(".")]
+        for name in namen:
+            if name.lower().endswith(ENDUNGEN):
+                yield os.path.join(ordner, name)
+
+
+def main():
+    wurzel = sys.argv[1] if len(sys.argv) > 1 else "."
+    if not os.path.isdir(wurzel):
+        print(f"FEHLER: kein Verzeichnis: {wurzel}")
+        return 2
+
+    print("STILLER FEHLSCHLAG")
+    print(f"Geprueft unter: {os.path.abspath(wurzel)}")
+    print("-" * 60)
+
+    geprueft = 0
+    funde = []
+
+    for pfad in dateien(wurzel):
+        geprueft += 1
+        try:
+            with open(pfad, encoding="utf-8", errors="replace") as f:
+                inhalt = f.read()
+        except OSError:
+            continue
+        kurz = os.path.relpath(pfad, wurzel)
+
+        for name, ausdruck, rat in REGELN:
+            for treffer in ausdruck.finditer(inhalt):
+                zeile = inhalt.count("\n", 0, treffer.start()) + 1
+                text = treffer.group(0).strip().splitlines()[0][:70]
+                funde.append((kurz, zeile, name, text, rat))
+
+        if pfad.lower().endswith(SHELL_ENDUNGEN) and not SET_E.search(inhalt):
+            funde.append((kurz, 1, "Kein set -e",
+                          "Skript bricht bei Fehlern nicht ab",
+                          "Ohne set -e laeuft das Skript nach einem Fehlschlag weiter "
+                          "und kann am Ende Erfolg melden."))
+
+    if geprueft == 0:
+        print("Keine Skript- oder Pipeline-Dateien gefunden. Ohne Suchflaeche keine")
+        print("Aussage. Das ist kein bestandener Test.")
+        return 2
+
+    print(f"Dateien: {geprueft}")
+    for kurz, zeile, name, text, rat in funde:
+        print(f"\n{kurz}:{zeile}  {name}")
+        print(f"  Stelle:  {text}")
+        print(f"  Abhilfe: {rat}")
+
+    print("-" * 60)
+    if not funde:
+        print("ERGEBNIS: keine Fundstellen.")
+        return 0
+    print(f"ERGEBNIS: {len(funde)} Fundstelle(n). Jede Erfolgsmeldung gehoert an den")
+    print("Rueckgabewert des Befehls, ueber den sie etwas behauptet.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pruefungen/checks/test-blind.py
+++ b/scripts/pruefungen/checks/test-blind.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""test-blind.py — findet Tests, die rechnerisch nicht rot werden koennen.
+
+Umsetzung von KERN 4 Frage 2 ("kann sie ueberhaupt scheitern?") als Pruefung. Ein Test
+ohne Zusicherung, ein uebersprungener Test und eine immer wahre Zusicherung sind gruen,
+egal was der Code tut. Sie zaehlen als Abdeckung und decken nichts ab.
+
+Sprachneutral ueber Muster gaengiger Rahmenwerke: pytest, unittest, jest, vitest,
+mocha, go test, JUnit.
+
+Aufruf:  python3 test-blind.py [verzeichnis]
+Exit 0 = sauber, Exit 1 = Fundstellen, Exit 2 = Aufrufproblem.
+"""
+import os
+import re
+import sys
+
+TESTDATEI = re.compile(
+    r"(?:^|[/\\])(?:test_[^/\\]+|[^/\\]+_test|[^/\\]+\.(?:test|spec))\.[a-z]+$|"
+    r"(?:^|[/\\])(?:tests?|__tests__|spec)[/\\]", re.I)
+ENDUNGEN = (".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".java", ".rb", ".php", ".rs")
+# "negativprobe": eigenes Beispielmaterial dieser Pruefungen, sonst Dauerfunde.
+UEBERSPRINGEN = {".git", "node_modules", "vendor", "dist", "build", ".venv",
+                 "__pycache__", "target", "coverage", "negativprobe"}
+
+# Beginn einer Testfunktion in gaengigen Rahmenwerken.
+TESTBEGINN = re.compile(
+    r"^\s*(?:"
+    r"def\s+test\w*\s*\(|"                       # pytest / unittest
+    r"(?:it|test)\s*(?:\.\w+)?\s*\(\s*[\"'`]|"   # jest / vitest / mocha
+    r"func\s+Test\w*\s*\(|"                      # go
+    r"(?:public\s+)?void\s+test\w*\s*\("         # junit
+    r")", re.I)
+
+ZUSICHERUNG = re.compile(
+    r"\b(?:assert\w*|expect|should|require\.|assert_\w+|t\.Error|t\.Fatal|"
+    r"toBe|toEqual|toThrow|toHaveBeen|verify|checkThat|"
+    # Eine erwartete Ausnahme ist eine vollwertige Zusicherung: der Test wird rot,
+    # wenn sie ausbleibt. Ohne diese Formen meldet die Pruefung Fehlalarm.
+    r"raises|assertRaises|rejects|expectException|willThrow|ShouldPanic)\b", re.I)
+
+UEBERSPRUNGEN = re.compile(
+    r"(?:@(?:pytest\.mark\.)?skip|@Ignore|\bit\.skip|\btest\.skip|\bxit\b|\bxdescribe\b|"
+    r"\bdescribe\.skip|\.todo\b|t\.Skip\(|@unittest\.skip|pytest\.skip\()", re.I)
+
+IMMER_WAHR = re.compile(
+    r"(?:assert\s+True\b|assert\s+1\s*==\s*1|assertTrue\s*\(\s*True\s*\)|"
+    r"expect\s*\(\s*true\s*\)\s*\.\s*(?:toBe|toEqual)\s*\(\s*true\s*\)|"
+    r"expect\s*\(\s*1\s*\)\s*\.\s*(?:toBe|toEqual)\s*\(\s*1\s*\)|"
+    r"assert\s*\(\s*true\s*\)|assertEquals\s*\(\s*1\s*,\s*1\s*\))", re.I)
+
+
+def testdateien(wurzel):
+    for ordner, unterordner, namen in os.walk(wurzel):
+        unterordner[:] = [u for u in unterordner
+                          if u not in UEBERSPRINGEN and not u.startswith(".")]
+        for name in namen:
+            pfad = os.path.join(ordner, name)
+            if name.lower().endswith(ENDUNGEN) and TESTDATEI.search(pfad):
+                yield pfad
+
+
+def einruecken(zeile):
+    return len(zeile) - len(zeile.lstrip())
+
+
+def bloecke(zeilen):
+    """Grobe Blockbildung: von einem Testbeginn bis zum naechsten oder bis die
+    Einrueckung wieder auf oder unter das Ausgangsniveau faellt."""
+    treffer = [i for i, z in enumerate(zeilen) if TESTBEGINN.search(z)]
+    for pos, start in enumerate(treffer):
+        ende = treffer[pos + 1] if pos + 1 < len(treffer) else len(zeilen)
+        basis = einruecken(zeilen[start])
+        for i in range(start + 1, ende):
+            roh = zeilen[i]
+            if roh.strip() and einruecken(roh) <= basis and not roh.strip().startswith(
+                    ("}", ")", "]")):
+                ende = i
+                break
+        yield start, ende
+
+
+def main():
+    wurzel = sys.argv[1] if len(sys.argv) > 1 else "."
+    if not os.path.isdir(wurzel):
+        print(f"FEHLER: kein Verzeichnis: {wurzel}")
+        return 2
+
+    print("TESTS, DIE NICHT ROT WERDEN KOENNEN")
+    print(f"Geprueft unter: {os.path.abspath(wurzel)}")
+    print("-" * 60)
+
+    dateien = 0
+    tests = 0
+    funde = []
+
+    for pfad in testdateien(wurzel):
+        dateien += 1
+        try:
+            with open(pfad, encoding="utf-8", errors="replace") as f:
+                zeilen = f.readlines()
+        except OSError:
+            continue
+        kurz = os.path.relpath(pfad, wurzel)
+
+        for start, ende in bloecke(zeilen):
+            tests += 1
+            block = "".join(zeilen[start:ende])
+            kopf = zeilen[start].strip()[:60]
+            vorlauf = "".join(zeilen[max(0, start - 3):start])
+
+            if UEBERSPRUNGEN.search(block) or UEBERSPRUNGEN.search(vorlauf):
+                funde.append((kurz, start + 1, kopf, "uebersprungen",
+                              "Ein uebersprungener Test zaehlt als Abdeckung und "
+                              "prueft nichts. Reparieren oder loeschen."))
+                continue
+            if IMMER_WAHR.search(block):
+                funde.append((kurz, start + 1, kopf, "immer wahr",
+                              "Die Zusicherung ist unabhaengig vom Code wahr."))
+                continue
+            if not ZUSICHERUNG.search(block):
+                funde.append((kurz, start + 1, kopf, "ohne Zusicherung",
+                              "Der Test laeuft durch, ohne etwas zu behaupten. Er wird "
+                              "nur rot, wenn der Code abstuerzt."))
+
+    if dateien == 0:
+        print("Keine Testdateien gefunden. Ohne Suchflaeche keine Aussage. Das ist")
+        print("kein bestandener Test, sondern ein Befund ueber die Suche oder das")
+        print("Projekt.")
+        return 2
+
+    print(f"Testdateien: {dateien}, erkannte Tests: {tests}")
+    for kurz, nr, kopf, art, rat in funde:
+        print(f"\n{kurz}:{nr}  [{art}]")
+        print(f"  {kopf}")
+        print(f"  {rat}")
+
+    print("-" * 60)
+    if not funde:
+        print(f"ERGEBNIS: alle {tests} erkannten Tests koennen scheitern.")
+        print("Das sagt nichts darueber, ob sie das Richtige pruefen.")
+        return 0
+    print(f"ERGEBNIS: {len(funde)} von {tests} Tests koennen so nicht rot werden.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pruefungen/negativprobe/kaputt/.pruefungen/aussentext.txt
+++ b/scripts/pruefungen/negativprobe/kaputt/.pruefungen/aussentext.txt
@@ -1,0 +1,7 @@
+# Verbotene Formulierungen in Texten, die nach aussen gehen.
+# Format:  regulaerer Ausdruck|Begruendung
+# Diese Zeilen sind Beispiele. Passe sie an dein Projekt an.
+verlaesst nie den Browser|Absolute Zusage ueber Datenfluesse ist im Netzwerk-Tab widerlegbar. Beschreiben, was das System tut, nicht was es niemals tut.
+zu ?100 ?% sicher|Sicherheit ist keine Zusage, die man geben kann.
+garantiert (?:sicher|anonym|fehlerfrei)|Garantie ohne Nachweis. Formulierung abschwaechen oder Nachweis verlinken.
+militaerisch(?:e|er)? Verschluesselung|Marketingbegriff ohne technischen Gehalt.

--- a/scripts/pruefungen/negativprobe/kaputt/CHANGELOG.md
+++ b/scripts/pruefungen/negativprobe/kaputt/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Aenderungen
+Jetzt 726 Tests. Coverage 91%.

--- a/scripts/pruefungen/negativprobe/kaputt/README.md
+++ b/scripts/pruefungen/negativprobe/kaputt/README.md
@@ -1,0 +1,3 @@
+# Beispielprojekt
+Die Suite umfasst 611 Tests. Coverage 82%.
+Deine Position verlaesst nie den Browser.

--- a/scripts/pruefungen/negativprobe/kaputt/deploy.sh
+++ b/scripts/pruefungen/negativprobe/kaputt/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+git push origin main ; echo "Deploy erfolgreich"
+npm run build > /dev/null 2>&1
+grep -c "fehler" log.txt | wc -l
+echo "Alles ok"

--- a/scripts/pruefungen/negativprobe/kaputt/tests/test_beispiel.py
+++ b/scripts/pruefungen/negativprobe/kaputt/tests/test_beispiel.py
@@ -1,0 +1,12 @@
+import pytest
+
+def test_ohne_zusicherung():
+    ergebnis = berechne(2, 3)
+    print(ergebnis)
+
+@pytest.mark.skip
+def test_uebersprungen():
+    assert berechne(2, 3) == 5
+
+def test_immer_wahr():
+    assert True

--- a/scripts/pruefungen/negativprobe/nur-ausgeschlossenes/README.md
+++ b/scripts/pruefungen/negativprobe/nur-ausgeschlossenes/README.md
@@ -1,0 +1,2 @@
+# Beispielprojekt
+Alle Skripte liegen im ausgeschlossenen Ordner.

--- a/scripts/pruefungen/negativprobe/nur-ausgeschlossenes/negativprobe/deploy.sh
+++ b/scripts/pruefungen/negativprobe/nur-ausgeschlossenes/negativprobe/deploy.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+git push origin main; echo "Deploy erfolgreich"

--- a/scripts/pruefungen/negativprobe/regeln-kaputt/.pruefungen/aussentext.txt
+++ b/scripts/pruefungen/negativprobe/regeln-kaputt/.pruefungen/aussentext.txt
@@ -1,0 +1,7 @@
+# Absichtlich kaputt: eine gueltige Regel UND eine, deren Klammer nie schliesst.
+# ERWARTUNG: aussentext.py bricht mit Exit 2 ab.
+# Die gueltige Regel ist noetig, damit die Probe scharf ist: Ohne sie waere die
+# Regelliste leer und der alte Code haette schon deshalb mit 2 geendet - der
+# Rueckbau des Fixes waere unbemerkt geblieben.
+zu ?100 ?% sicher|Sicherheit ist keine Zusage, die man geben kann.
+unmatched (klammer|Diese Regel kann nicht kompilieren.

--- a/scripts/pruefungen/negativprobe/regeln-kaputt/README.md
+++ b/scripts/pruefungen/negativprobe/regeln-kaputt/README.md
@@ -1,0 +1,2 @@
+# Beispielprojekt
+Hier steht nichts Verbotenes.

--- a/scripts/pruefungen/negativprobe/regeln-mit-oder/.pruefungen/aussentext.txt
+++ b/scripts/pruefungen/negativprobe/regeln-mit-oder/.pruefungen/aussentext.txt
@@ -1,0 +1,3 @@
+# ERWARTUNG: Der Ausdruck enthaelt | als Oder. Nur beim Trennen von rechts laedt er.
+# Mit split("|", 1) bliebe "garantiert (?:sicher" uebrig - nicht kompilierbar.
+garantiert (?:sicher|anonym|fehlerfrei)|Garantie ohne Nachweis.

--- a/scripts/pruefungen/negativprobe/regeln-mit-oder/README.md
+++ b/scripts/pruefungen/negativprobe/regeln-mit-oder/README.md
@@ -1,0 +1,2 @@
+# Beispielprojekt
+Unsere Auswertung ist garantiert anonym.

--- a/scripts/pruefungen/negativprobe/regeln-prosa-pipe/.pruefungen/aussentext.txt
+++ b/scripts/pruefungen/negativprobe/regeln-prosa-pipe/.pruefungen/aussentext.txt
@@ -1,0 +1,5 @@
+# Absichtlich kaputt: Die Begruendung enthaelt ein | (hier ein Firmenname).
+# ERWARTUNG: Exit 2. Ohne die Erkennung wuerde der Ausdruck stillschweigend zu
+# "verbotenes wort|Nicht verwenden. Richtig ist: Firma - learning | training" -
+# er kompiliert tadellos und trifft ab sofort jedes Vorkommen von " training".
+verbotenes wort|Nicht verwenden. Richtig ist: Firma - learning | training | consulting e.U.

--- a/scripts/pruefungen/negativprobe/regeln-prosa-pipe/README.md
+++ b/scripts/pruefungen/negativprobe/regeln-prosa-pipe/README.md
@@ -1,0 +1,2 @@
+# Beispiel
+Hier steht training als ganz normales Wort.

--- a/scripts/pruefungen/negativprobe/sauber/.pruefungen/aussentext.txt
+++ b/scripts/pruefungen/negativprobe/sauber/.pruefungen/aussentext.txt
@@ -1,0 +1,7 @@
+# Verbotene Formulierungen in Texten, die nach aussen gehen.
+# Format:  regulaerer Ausdruck|Begruendung
+# Diese Zeilen sind Beispiele. Passe sie an dein Projekt an.
+verlaesst nie den Browser|Absolute Zusage ueber Datenfluesse ist im Netzwerk-Tab widerlegbar. Beschreiben, was das System tut, nicht was es niemals tut.
+zu ?100 ?% sicher|Sicherheit ist keine Zusage, die man geben kann.
+garantiert (?:sicher|anonym|fehlerfrei)|Garantie ohne Nachweis. Formulierung abschwaechen oder Nachweis verlinken.
+militaerisch(?:e|er)? Verschluesselung|Marketingbegriff ohne technischen Gehalt.

--- a/scripts/pruefungen/negativprobe/sauber/README.md
+++ b/scripts/pruefungen/negativprobe/sauber/README.md
@@ -1,0 +1,4 @@
+# Beispielprojekt
+Aktuelle Testzahlen stehen in docs/VERIFICATION.md.
+Die Standortdaten werden im Browser verarbeitet und nur auf ausdrueckliche
+Anforderung uebertragen.

--- a/scripts/pruefungen/negativprobe/sauber/deploy.sh
+++ b/scripts/pruefungen/negativprobe/sauber/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+git push origin main && echo "Deploy erfolgreich"
+npm run build

--- a/scripts/pruefungen/negativprobe/sauber/tests/test_beispiel.py
+++ b/scripts/pruefungen/negativprobe/sauber/tests/test_beispiel.py
@@ -1,0 +1,6 @@
+def test_addition():
+    assert berechne(2, 3) == 5
+
+def test_fehlerfall():
+    with pytest.raises(ValueError):
+        berechne(None, 3)

--- a/scripts/pruefungen/pruefe-alles.sh
+++ b/scripts/pruefungen/pruefe-alles.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# pruefe-alles.sh — fuehrt alle Pruefungen der Familie gegen ein Projekt aus.
+#
+# Aufruf:  sh pruefe-alles.sh [projektverzeichnis]
+# Exit 0 = alle sauber, Exit 1 = mindestens eine Pruefung hat Fundstellen.
+#
+# Fuer die Pipeline gedacht: Ein roter Lauf bricht ab. Das ist der Unterschied
+# zwischen einer Regel und einer Kontrolle.
+
+HIER=$(cd "$(dirname "$0")" && pwd)
+ZIEL="${1:-.}"
+FEHLER=0
+UEBERSPRUNGEN=0
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "FEHLER: python3 nicht gefunden. Die Pruefungen laufen nicht."
+  echo "Das ist ein Fehlschlag, kein Hinweis: ungeprueft gilt als nicht bestanden."
+  exit 1
+fi
+
+lauf() {
+  echo ""
+  echo "############################################################"
+  python3 "$HIER/checks/$1" "$ZIEL"
+  ERG=$?
+  case "$ERG" in
+    0) : ;;
+    1) FEHLER=$((FEHLER + 1)) ;;
+    *) UEBERSPRUNGEN=$((UEBERSPRUNGEN + 1)) ;;
+  esac
+}
+
+echo "PRUEFUNGEN DER AUDIT-FAMILIE"
+echo "Ziel: $(cd "$ZIEL" 2>/dev/null && pwd || echo "$ZIEL")"
+echo "Stand: $(date '+%Y-%m-%d %H:%M:%S %Z')"
+
+lauf fakten-drift.py
+lauf stiller-fehlschlag.py
+lauf aussentext.py
+lauf test-blind.py
+
+echo ""
+echo "############################################################"
+echo "ZUSAMMENFASSUNG"
+echo "  Pruefungen mit Fundstellen: $FEHLER"
+echo "  Pruefungen ohne Suchflaeche: $UEBERSPRUNGEN"
+if [ "$UEBERSPRUNGEN" -gt 0 ]; then
+  echo "  Achtung: Eine Pruefung ohne Suchflaeche ist kein bestandener Test."
+  echo "  Entweder gibt es die geprueften Artefakte nicht, oder die Suche greift"
+  echo "  nicht. Beides gehoert geklaert, nicht abgehakt."
+fi
+if [ "$FEHLER" -eq 0 ] && [ "$UEBERSPRUNGEN" -eq 0 ]; then
+  echo "  ERGEBNIS: alle vier Pruefungen sauber."
+  exit 0
+fi
+[ "$FEHLER" -gt 0 ] && exit 1
+exit 0

--- a/scripts/pruefungen/selbstpruefung.sh
+++ b/scripts/pruefungen/selbstpruefung.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# selbstpruefung.sh — prueft die Pruefungen selbst.
+#
+# Jede Pruefung muss zweierlei koennen: bei kaputtem Material rot werden UND bei
+# sauberem Material gruen. Nur das erste zu testen ist der Fehler, der in der
+# Familie schon einmal passiert ist: Ein Abgabe-Check wurde gegen einen
+# unvollstaendigen Bericht getestet, wurde korrekt rot, und liess trotzdem
+# Stichwortsalat durch. Getestet war nur eine Richtung.
+#
+# Aufruf: sh selbstpruefung.sh
+# Exit 0 = alle Pruefungen verhalten sich in beide Richtungen richtig.
+
+HIER=$(cd "$(dirname "$0")" && pwd)
+KAPUTT="$HIER/negativprobe/kaputt"
+SAUBER="$HIER/negativprobe/sauber"
+FEHLER=0
+
+lauf() {
+  # $1 = Skriptname, $2 = Verzeichnis, $3 = erwarteter Exit, $4 = Beschreibung
+  python3 "$HIER/checks/$1" "$2" > /tmp/selbstpruefung.out 2>&1
+  IST=$?
+  if [ "$IST" -eq "$3" ]; then
+    echo "  ja    $4 (Exit $IST wie erwartet)"
+  else
+    echo "  NEIN  $4 (Exit $IST, erwartet $3)"
+    sed 's/^/          /' /tmp/selbstpruefung.out | tail -8
+    FEHLER=$((FEHLER + 1))
+  fi
+}
+
+echo "SELBSTPRUEFUNG DER PRUEFUNGEN"
+echo "============================================================"
+echo "Richtung 1: kaputtes Material MUSS rot werden (Exit 1)"
+lauf fakten-drift.py       "$KAPUTT" 1 "fakten-drift findet den Zahlen-Drift"
+lauf stiller-fehlschlag.py "$KAPUTT" 1 "stiller-fehlschlag findet die Erfolgsluege"
+lauf aussentext.py         "$KAPUTT" 1 "aussentext findet die verbotene Zusage"
+lauf test-blind.py         "$KAPUTT" 1 "test-blind findet die blinden Tests"
+
+echo ""
+echo "Richtung 2: sauberes Material MUSS gruen bleiben (Exit 0)"
+lauf fakten-drift.py       "$SAUBER" 0 "fakten-drift meldet nichts"
+lauf stiller-fehlschlag.py "$SAUBER" 0 "stiller-fehlschlag meldet nichts"
+lauf aussentext.py         "$SAUBER" 0 "aussentext meldet nichts"
+lauf test-blind.py         "$SAUBER" 0 "test-blind meldet nichts"
+
+echo ""
+echo "Richtung 3: die Pruefung darf nicht still schwaecher werden (2026-08-12)"
+lauf aussentext.py "$HIER/negativprobe/regeln-kaputt" 2 \
+  "nicht kompilierbare Regel bricht ab (Exit 2), statt sie zu ueberspringen"
+lauf aussentext.py "$HIER/negativprobe/regeln-mit-oder" 1 \
+  "Regel mit | im Ausdruck laedt und schlaegt an (Trennung von rechts)"
+lauf stiller-fehlschlag.py "$HIER/negativprobe/nur-ausgeschlossenes" 2 \
+  "negativprobe/ wird uebersprungen, uebrig bleibt keine Suchflaeche"
+lauf aussentext.py "$HIER/negativprobe/regeln-prosa-pipe" 2 \
+  "| in der Begruendung wird erkannt, statt das Suchmuster still zu erweitern"
+
+echo "============================================================"
+if [ "$FEHLER" -eq 0 ]; then
+  echo "ERGEBNIS: alle zwoelf Proben bestanden."
+  echo "Die Pruefungen koennen rot werden und sind nicht ueberempfindlich."
+  exit 0
+fi
+echo "ERGEBNIS: $FEHLER Probe(n) fehlgeschlagen."
+echo "Eine Pruefung, die hier durchfaellt, ist selbst der Befund."
+exit 1


### PR DESCRIPTION
## Warum

Die Regel „nicht behaupten, GPS verlasse das Gerät nie" steht seit Monaten in
`CONTRIBUTING.md` — und war trotzdem an fünf Stellen verletzt. Eine Wording-Regel
ohne Test ist eine Bitte, kein Schutz.

## Was

- **Neuer CI-Job `aussentext` (blockierend).** Prüft alle Texte, die nach außen gehen,
  gegen `.pruefungen/aussentext.txt` (7 Regeln). Schritt 1 des Jobs prüft die Prüfung
  selbst (`scripts/pruefungen/selbstpruefung.sh`, 12 Proben), damit ein defekter Prüfer
  nicht grün meldet, ohne etwas zu prüfen.
- **Neuer Job `pruefungen-bericht` (`continue-on-error`).** Drei weitere Prüfungen
  laufen mit und melden, blockieren noch nicht — Begründung steht in der `ci.yml`.
- **`scripts/pruefungen/`** vendoriert; die CI sieht nur, was im Repository liegt.

## Korrigierte Verstöße

| Stelle | Was |
|---|---|
| `README.md` (2×), `CONTRIBUTING.md`, `CHANGELOG.md`, `public/llms.txt` | „GPS verlässt nie den Browser/Client" → „GPS erreicht nie unsere Server". `llms.txt` wiegt am schwersten: Diese Datei lesen KI-Crawler. |
| `CHANGELOG.md` | Kurzform der Firmierung, die es nicht gibt → vollständig |
| `docs/ERROR-ALERTING.md` (2×) | Zuschreibung in dritter Person entfernt |

## Beweise

| Befehl | Ergebnis |
|---|---|
| `npm test --prefix functions` | 753/753 grün |
| `npm run test:frontend` | 315/315 grün |
| `npm run test:e2e` | 18/18 grün, Exit 0 |
| `sh scripts/pruefungen/selbstpruefung.sh` | 12/12, Exit 0 |
| `aussentext.py .` gegen simulierte Auscheckung | 39 Dateien, 7 Regeln, 0 Verstöße |
| Positivkontrolle | 7 absichtliche Verstöße → 7 Treffer, je Regel einer |

## Bekannte Grenzen

- `e2e/a11y.test.js` „Profil-Ansicht ohne ernste Verstöße" ist **flatterhaft**: erster
  Lauf rot, derselbe Test allein grün, zweiter voller Lauf grün — bei null angefassten
  Frontend-Dateien. Reihenfolge-/Zeitabhängigkeit, noch nicht untersucht.
- `fakten-drift` kann Historie nicht von Drift unterscheiden (27 „Testanzahlen" sind
  alte CHANGELOG-Einträge). Einer der Gründe für `continue-on-error`.
- `stiller-fehlschlag` meldet zwei Fehlalarme der Bauart `if … >/dev/null 2>&1; then`,
  wo der Rückgabewert die Bedingung **ist**.
- Eine Sperrliste trifft auch den Text, der die Sperre erklärt — deshalb beschreiben
  `CONTRIBUTING.md` und `CHANGELOG.md` die verbotene Formulierung, statt sie zu zitieren.

## Nicht Teil dieses PRs

Die neuen Jobs sind **nicht** in der Branch Protection eingetragen: Sie laufen, blockieren
aber noch keinen Merge. Das ist eine bewusste Entscheidung für später.

🤖 Generated with [Claude Code](https://claude.com/claude-code)