### PR TITLE
fix: Fehlalarme der Prüfungen beheben, danach alle vier verbindlich

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,42 +126,32 @@ jobs:
           budgetPath: .github/lighthouse-budget.json
           uploadArtifacts: true
 
-  # ── Formulierungs-Sperrliste: blockierend ──────────────────────────────
+  # ── Die vier Pruefungen: alle blockierend ──────────────────────────────
   # Warum als Pflicht-Check und nicht als Erinnerung: Die Regel "nicht
   # behaupten, GPS verlasse das Geraet nie" stand seit Monaten in CONTRIBUTING
   # und wurde trotzdem an fuenf Stellen verletzt (README 2x, CONTRIBUTING,
   # CHANGELOG, public/llms.txt) — gefunden erst durch diesen Job am 2026-08-12.
   # Eine Wording-Regel ohne Test ist eine Bitte, kein Schutz.
-  # Sperrliste: .pruefungen/aussentext.txt
-  aussentext:
+  #
+  # Am 2026-08-12 liefen drei der vier zunaechst NICHT blockierend, weil sie
+  # 15 Fundstellen meldeten. Beim Nachpruefen war eine davon echt und der Rest
+  # Fehlalarm der Pruefungen selbst. Die Pruefungen wurden geschaerft (jeweils
+  # mit eigener Probe in selbstpruefung.sh), der eine echte Fund behoben.
+  # Seitdem sind alle vier gruen — und deshalb verbindlich.
+  #
+  # Konfiguration im Projekt: .pruefungen/aussentext.txt (Sperrliste) und
+  # .pruefungen/fakten.txt (welche Zahlen genau einen Wert haben duerfen).
+  pruefungen:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Zuerst die Pruefungen selbst pruefen: zwoelf Proben, je Pruefung eine
+      # Zuerst die Pruefungen selbst pruefen: achtzehn Proben, je Pruefung eine
       # gegen kaputtes und eine gegen sauberes Material. Ohne diesen Schritt
       # koennte ein defekter Pruefer gruen melden, ohne etwas zu pruefen.
       - run: sh scripts/pruefungen/selbstpruefung.sh
 
       - run: python3 scripts/pruefungen/checks/aussentext.py .
-
-  # ── Zwei weitere Pruefungen: melden, noch nicht blockieren ─────────────
-  # Stand 2026-08-12 finden sie im Repo echte Kandidaten: 8 stille Fehlschlaege
-  # in scripts/ und 4 Tests von 924, die rechnerisch nicht rot werden koennen.
-  # Sie sofort blockierend zu schalten haette jeden PR rot gemacht; ein dauerhaft
-  # roter Job wird genauso ignoriert wie ein dauerhaft gruener. Deshalb erst
-  # aufraeumen, dann continue-on-error entfernen — dann sind es Kontrollen.
-  #
-  # fakten-drift.py laeuft hier bewusst NICHT mit: Es meldete "Testanzahl mit 27
-  # verschiedenen Werten" und meinte damit die Zahlen alter CHANGELOG-Eintraege.
-  # Die Heuristik kann eine dokumentierte Historie nicht von einem Widerspruch
-  # unterscheiden, und ein Befund, der sich nicht beheben laesst, ohne die
-  # Historie zu faelschen, gehoert nicht in eine Pipeline. Von Hand bleibt es
-  # nuetzlich: python3 scripts/pruefungen/checks/fakten-drift.py .
-  pruefungen-bericht:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: python3 scripts/pruefungen/checks/fakten-drift.py .
       - run: python3 scripts/pruefungen/checks/stiller-fehlschlag.py .
       - run: python3 scripts/pruefungen/checks/test-blind.py .

--- a/.pruefungen/fakten.txt
+++ b/.pruefungen/fakten.txt
@@ -1,0 +1,23 @@
+# Fakten, die in malziME genau EINEN Wert haben duerfen (KERN 11).
+#
+# Format:  Bezeichnung|regulaerer Ausdruck mit genau EINER Klammergruppe
+# Zeilen mit # sind Kommentare.
+#
+# Wichtig: Sobald diese Datei existiert, gelten NUR diese Muster — die
+# eingebauten sind abgeschaltet. Das ist Absicht. Generische Muster wie
+# "(\d+) Tage" halten Aufbewahrungsfrist, Karenzzeit und Pruefperiode fuer
+# denselben Fakt und melden Widersprueche, die keine sind.
+#
+# Nicht aufgenommen und warum:
+#   Testanzahl — steht bewusst nirgends fest, der CI-Lauf ist der Beleg.
+#   "N Tage"   — bezeichnet im Projekt mehrere verschiedene Fristen.
+#   Version    — steht im CHANGELOG naturgemaess vielfach; Historiendateien
+#                werden ohnehin uebersprungen.
+
+Node-Hauptversion|[Nn]ode(?:\.js)?[^0-9\n]{0,12}(\d\d)\b
+
+Stundenlimit (Analysen pro Stunde)|(\d+)\s+Analysen\s*/\s*Stunde
+
+IP-Rate-Limit (Requests pro 10 Minuten)|Rate.?Limit[^0-9\n]{0,20}(\d+)\s*Requests
+
+Aufbewahrung der Diagnose-Logs in Tagen|client-diagnostics[^0-9\n]{0,40}(\d+)\s*Tage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+**Die Prüfungen prüfen jetzt richtig — und sind deshalb alle vier verbindlich:**
+
+- **Ein Job `pruefungen` statt zwei, alles blockierend.** `continue-on-error` ist weg,
+  `fakten-drift` ist zurück in der Pipeline. Vorbedingung war, dass die Prüfungen
+  stimmen: Von 15 gemeldeten Fundstellen war **eine echt**, der Rest Fehlalarm der
+  Prüfungen selbst.
+- **Fünf Fehlalarm-Ursachen behoben**, jede mit eigener Probe in
+  `selbstpruefung.sh` (jetzt 18 statt 12): `if … >/dev/null 2>&1; then` ist kein
+  verworfener Rückgabewert · eine Zusicherung hinter einem mehrzeiligen Text wird
+  gefunden · ein Sammel-Berichter mit eigenem Fehler-Exit braucht kein `set -e` ·
+  ein geprüftes Suchergebnis gilt nicht als still gelesen (das Erfolgswort muss in
+  einer Meldung stehen, nicht in einem Suchmuster oder einem Shell-Schlüsselwort) ·
+  ein Changelog mit alten Zahlen ist Historie, kein Drift.
+- **`.pruefungen/fakten.txt` (neu):** Das Projekt legt fest, welche Zahlen genau einen
+  Wert haben dürfen. Sobald die Datei existiert, gelten nur ihre Muster — die
+  eingebauten halten „30 Tage Aufbewahrung", „7 Tage Karenz" und „183 Tage Frist" für
+  denselben Fakt und melden Widersprüche, die keine sind.
+- **Der eine echte Fund, behoben:** `cloudtasks-scripts.test.js` erzeugte ohne
+  installiertes `gcloud` einen Test mit `expect(true).toBe(true)`. Der zählte als
+  bestanden und behauptete eine Abdeckung, die es nicht gab. Jetzt wird er als
+  **übersprungen** ausgewiesen — 923 Tests, die alle scheitern können, statt 924, von
+  denen einer nicht kann.
+
 ## [3.0.7] — 2026-08-12
 
 **Formulierungs-Sperrliste als Pflicht-Check — und fünf Verstöße, die sie sofort

--- a/README.md
+++ b/README.md
@@ -265,8 +265,7 @@ GitHub Actions Workflow `.github/workflows/ci.yml`:
 - **Secret-Scan** via gitleaks (prueft auf versehentlich committete API-Keys)
 - **Dependabot** prueft monatlich auf Updates (npm + GitHub Actions, je Bereich zu einem PR gebuendelt) und oeffnet bei gemeldeten Sicherheitsluecken sofort einen Reparatur-PR
 - **Audit-Gate** im Backend-Job (`scripts/audit-gate.mjs`): blockiert bei hohen und kritischen Schwachstellen. Laesst sich eine Luecke tief in einer fremden Abhaengigkeitskette nachweislich (noch) nicht reparieren, kann sie **begruendet und mit Ablaufdatum** in `.github/audit-allowlist.json` ausgenommen werden — danach faellt das Gate von selbst wieder auf rot
-- **Formulierungs-Sperrliste** (`aussentext`): blockiert, wenn ein Text, der nach aussen geht, eine Formulierung aus `.pruefungen/aussentext.txt` enthaelt — etwa eine Datenschutz-Zusage, die im Netzwerk-Tab widerlegbar waere. Der Job prueft zuerst die Pruefung selbst (`scripts/pruefungen/selbstpruefung.sh`)
-- **Weitere Pruefungen** (`pruefungen-bericht`): driftende Fakten, stille Fehlschlaege in Skripten, Tests ohne Zusicherung — laufen mit und melden, blockieren noch nicht
+- **Vier Pruefungen** (`pruefungen`, alle blockierend): verbotene Formulierungen in Aussentexten (`.pruefungen/aussentext.txt`), Zahlen mit mehr als einem Wert (`.pruefungen/fakten.txt`), stille Fehlschlaege in Skripten, Tests ohne Zusicherung. Der Job prueft zuerst die Pruefungen selbst — 18 Proben, je Pruefung eine gegen kaputtes und eine gegen sauberes Material, damit ein defekter Pruefer nicht gruen meldet, ohne etwas zu pruefen
 - **Branch Protection** fuer `main`: Merges erst nach gruenen Status-Checks (`test-backend`, `test-frontend`, `test-e2e`, `secret-scan`)
 - Deploy erfolgt manuell per `npx firebase deploy`
 

--- a/functions/src/__tests__/cloudtasks-scripts.test.js
+++ b/functions/src/__tests__/cloudtasks-scripts.test.js
@@ -96,11 +96,12 @@ describe("Cloud-Tasks-Scripts", () => {
     90000
   );
 
-  if (!gcloudDa) {
-    test("Hinweis: gcloud fehlt, Parameter-Abgleich übersprungen", () => {
-      /* Kein Fehlschlag — in der CI ist gcloud nicht installiert. Der Abgleich
-         läuft dann lokal vor einem Deploy. */
-      expect(true).toBe(true);
-    });
-  }
+  // Fehlt gcloud (so in der CI), wird der Abgleich mit test.skip als übersprungen
+  // AUSGEWIESEN, statt einen immer wahren Test zu erfinden. Ein `expect(true)`
+  // stand vorher hier: Er zählte als bestanden und behauptete damit eine
+  // Abdeckung, die es nicht gab. Übersprungen ist ehrlicher als grün.
+  test.skip.each(gcloudDa ? [] : [["gcloud nicht installiert"]])(
+    "Parameter-Abgleich gegen die gcloud-Hilfe (%s)",
+    () => {}
+  );
 });

--- a/scripts/pruefungen/README.md
+++ b/scripts/pruefungen/README.md
@@ -1,13 +1,12 @@
 # PRUEFUNGEN — vier Kontrollen statt vier Bitten
 
-> **Herkunft:** Dieses Verzeichnis ist eine Kopie des Werkzeugkastens aus der
-> Audit-Familie (`~/.claude/skills/audit-familie/pruefungen`, Stand 2026-08-12,
-> Paket 1.0 plus vier Korrekturen). Es liegt hier, weil die CI nur sieht, was im
-> Repository liegt. Aenderungen bitte an BEIDEN Stellen — die Familie ist die Quelle.
+> **Herkunft:** Kopie des Werkzeugkastens aus der Audit-Familie
+> (`~/.claude/skills/audit-familie/pruefungen`, Repository `malziland/audit-familie`).
+> Sie liegt hier, weil die CI nur sieht, was im Repository liegt. Aenderungen bitte an
+> BEIDEN Stellen — die Familie ist die Quelle.
 >
-> Der Ordner `negativprobe/` enthaelt **absichtlich fehlerhaftes Beispielmaterial**
-> (Skripte mit Erfolgsluegen, Tests ohne Zusicherung, widerspruechliche Zahlen). Das
-> ist kein Code dieses Projekts und wird von allen Pruefungen uebersprungen.
+> Der Ordner `negativprobe/` enthaelt **absichtlich fehlerhaftes Beispielmaterial** und
+> wird von allen Pruefungen uebersprungen.
 
 Diese vier Pruefungen setzen Regeln der Familie in Programme um, die rot werden koennen.
 Der Unterschied ist der Kern der ganzen Sache: Eine Regel im Prompt wirkt vielleicht,

--- a/scripts/pruefungen/checks/fakten-drift.py
+++ b/scripts/pruefungen/checks/fakten-drift.py
@@ -24,6 +24,14 @@ ENDUNGEN = (".md", ".markdown", ".txt", ".rst", ".adoc")
 UEBERSPRINGEN = {".git", "node_modules", "vendor", "dist", "build", ".venv",
                  "__pycache__", ".next", "target", "coverage", "negativprobe"}
 
+# Historien-Dokumente halten vergangene Staende fest. Dass dort andere Zahlen
+# stehen als heute, ist ihr Zweck und kein Widerspruch — ein Changelog mit 27
+# verschiedenen Testzahlen ist ein gutes Changelog. Sie als Drift zu melden
+# erzeugt einen Befund, der sich nur beheben laesst, indem man die Historie
+# faelscht (Fehlalarm bis 2026-08-12).
+HISTORIENDATEIEN = ("changelog", "history", "releases", "release-notes",
+                    "aenderungen", "changes")
+
 # Eingebaute Muster. Bezeichnung -> regulaerer Ausdruck mit einer Klammergruppe.
 MUSTER = {
     "Testanzahl": r"(\d[\d.']*)\s*(?:Tests?|Testfaelle|test cases?)\b",
@@ -65,8 +73,12 @@ def dateien(wurzel):
         unterordner[:] = [u for u in unterordner
                           if u not in UEBERSPRINGEN and not u.startswith(".")]
         for name in namen:
-            if name.lower().endswith(ENDUNGEN):
-                yield os.path.join(ordner, name)
+            if not name.lower().endswith(ENDUNGEN):
+                continue
+            stamm = os.path.splitext(name)[0].lower()
+            if stamm in HISTORIENDATEIEN:
+                continue
+            yield os.path.join(ordner, name)
 
 
 def main():
@@ -75,8 +87,15 @@ def main():
         print(f"FEHLER: kein Verzeichnis: {wurzel}")
         return 2
 
-    muster = dict(MUSTER)
-    muster.update(eigene_muster(wurzel))
+    # Legt das Projekt eigene Muster fest, gelten NUR diese. Die eingebauten sind
+    # ein Startpunkt fuer Projekte, die noch nicht entschieden haben, welche Zahlen
+    # bei ihnen kanonisch sind — als Dauerbetrieb taugen sie nicht: "(\d+) Tage"
+    # haelt eine Aufbewahrungsfrist, eine Karenzzeit und eine Pruefperiode fuer
+    # denselben Fakt und meldet Widersprueche, die keine sind (Fehlalarm bis
+    # 2026-08-12). Wer die Pruefung in eine Pipeline haengt, schreibt seine Muster
+    # in .pruefungen/fakten.txt.
+    eigene = eigene_muster(wurzel)
+    muster = eigene if eigene else dict(MUSTER)
 
     # bezeichnung -> wert -> Liste von Fundstellen
     funde = {name: {} for name in muster}
@@ -101,7 +120,8 @@ def main():
 
     print("FAKTEN-DRIFT")
     print(f"Geprueft: {geprueft} Textdateien unter {os.path.abspath(wurzel)}")
-    print(f"Muster: {len(muster)} ({len(muster) - len(MUSTER)} eigene)")
+    herkunft = "aus .pruefungen/fakten.txt" if eigene else "eingebaut, nicht konfiguriert"
+    print(f"Muster: {len(muster)} ({herkunft})")
     print("-" * 60)
 
     if geprueft == 0:

--- a/scripts/pruefungen/checks/stiller-fehlschlag.py
+++ b/scripts/pruefungen/checks/stiller-fehlschlag.py
@@ -35,7 +35,12 @@ REGELN = [
     ),
     (
         "Ausgabe verworfen und Fehler mit",
-        re.compile(r">\s*/dev/null\s+2>&1\s*(?:;|$)", re.M),
+        # Die Umleitung muss die Zeile BEENDEN (optional mit Semikolon). Steht
+        # danach noch etwas, wird der Rueckgabewert ausgewertet und nicht
+        # verworfen — "if cmd >/dev/null 2>&1; then" ist die haeufigste Form und
+        # war bis 2026-08-12 ein Fehlalarm. Faelle wie
+        # "cmd >/dev/null 2>&1; echo fertig" faengt die erste Regel ab.
+        re.compile(r">\s*/dev/null\s+2>&1\s*;?\s*$", re.M),
         "Ohne anschliessende Pruefung des Rueckgabewerts ist nicht unterscheidbar, "
         "ob der Befehl lief oder scheiterte.",
     ),
@@ -47,15 +52,31 @@ REGELN = [
     ),
     (
         "Leeres Suchergebnis als Ergebnis gelesen",
+        # Zwischen der Suche und dem Erfolgswort darf KEINE Pruefung stehen. Vorher
+        # sprang der Ausdruck ueber beliebig viele Zeilen bis zum naechsten
+        # Erfolgswort und uebersah eine Plausibilitaetspruefung drei Zeilen
+        # darunter — der haeufigste Fehlalarm dieser Regel (bis 2026-08-12).
         re.compile(r"(?:grep|rg|ag)\b[^\n|]*\|\s*(?:wc|head|tail)\b[^\n]*\n"
-                   r"(?![^\n]*(?:if|test|\[)).*?" + ERFOLGSWORT, re.I | re.S),
+                   # Die Vorausschau muss die GANZE Zeile pruefen, nicht nur ihren
+                   # Anfang: "  if ! [[ ... ]]" beginnt mit Leerzeichen und rutschte
+                   # sonst als harmlose Zeile durch.
+                   r"(?:(?![^\n]*(?:\bif\b|\btest\b|\[\[|\bcase\b|\bexit\b))[^\n]*\n)*?"
+                   # Und das Erfolgswort muss in einer MELDUNG stehen. Ohne diese
+                   # Bedingung galten "passed" innerhalb eines Suchmusters und das
+                   # Shell-Schluesselwort "done" einer Schleife als Erfolgsmeldung.
+                   r"[^\n]*(?:echo|print|printf)[^\n]*" + ERFOLGSWORT, re.I),
         "Eine Suche, die nichts findet, und eine Suche, die scheitert, sehen gleich "
         "aus. Positivkontrolle noetig: an bekannter Fundstelle muss sie anschlagen.",
     ),
 ]
 
-# Fuer Shell-Skripte zusaetzlich: fehlendes set -e ist die Grundform des Problems.
+# Fuer Shell-Skripte zusaetzlich: fehlendes set -e ist die Grundform des Problems —
+# ABER nur bei einem Skript, das seinen Fehlschlag nicht selbst zurueckgibt.
+# Ein Sammel-Berichter zaehlt Fehler und endet mit einem eigenen "exit 1"; mit
+# set -e wuerde er beim ersten Punkt abbrechen, statt alle zu zeigen. Ihn dafuer
+# zu ruegen war ein Fehlalarm (bis 2026-08-12).
 SET_E = re.compile(r"^\s*set\s+-[a-z]*e", re.M)
+EIGENER_FEHLER_EXIT = re.compile(r"^\s*exit\s+[1-9]", re.M)
 SHELL_ENDUNGEN = (".sh", ".bash", ".zsh")
 
 
@@ -96,11 +117,15 @@ def main():
                 text = treffer.group(0).strip().splitlines()[0][:70]
                 funde.append((kurz, zeile, name, text, rat))
 
-        if pfad.lower().endswith(SHELL_ENDUNGEN) and not SET_E.search(inhalt):
+        if (pfad.lower().endswith(SHELL_ENDUNGEN)
+                and not SET_E.search(inhalt)
+                and not EIGENER_FEHLER_EXIT.search(inhalt)):
             funde.append((kurz, 1, "Kein set -e",
-                          "Skript bricht bei Fehlern nicht ab",
+                          "Skript bricht bei Fehlern nicht ab und gibt auch keinen "
+                          "eigenen Fehler-Rueckgabewert zurueck",
                           "Ohne set -e laeuft das Skript nach einem Fehlschlag weiter "
-                          "und kann am Ende Erfolg melden."))
+                          "und kann am Ende Erfolg melden. Entweder set -e setzen oder "
+                          "Fehler sammeln und mit einem eigenen exit zurueckgeben."))
 
     if geprueft == 0:
         print("Keine Skript- oder Pipeline-Dateien gefunden. Ohne Suchflaeche keine")

--- a/scripts/pruefungen/checks/test-blind.py
+++ b/scripts/pruefungen/checks/test-blind.py
@@ -64,19 +64,33 @@ def einruecken(zeile):
     return len(zeile) - len(zeile.lstrip())
 
 
+def offen_danach(zeile, offen):
+    """Steht nach dieser Zeile noch ein mehrzeiliger Text offen? Gezaehlt werden
+    Backticks (JS/TS) und dreifache Anfuehrungszeichen (Python)."""
+    marken = zeile.count("`") + zeile.count('"""') + zeile.count("'''")
+    return (offen + marken) % 2
+
+
 def bloecke(zeilen):
     """Grobe Blockbildung: von einem Testbeginn bis zum naechsten oder bis die
-    Einrueckung wieder auf oder unter das Ausgangsniveau faellt."""
+    Einrueckung wieder auf oder unter das Ausgangsniveau faellt.
+
+    Innerhalb eines mehrzeiligen Textes zaehlt die Einrueckung NICHT. Ein
+    Textblock enthaelt regelmaessig Zeilen ohne jede Einrueckung; ohne diese
+    Ausnahme endete der Block dort, die Zusicherung dahinter blieb ungesehen und
+    der Test galt faelschlich als blind (Fehlalarm bis 2026-08-12)."""
     treffer = [i for i, z in enumerate(zeilen) if TESTBEGINN.search(z)]
     for pos, start in enumerate(treffer):
         ende = treffer[pos + 1] if pos + 1 < len(treffer) else len(zeilen)
         basis = einruecken(zeilen[start])
+        offen = offen_danach(zeilen[start], 0)
         for i in range(start + 1, ende):
             roh = zeilen[i]
-            if roh.strip() and einruecken(roh) <= basis and not roh.strip().startswith(
-                    ("}", ")", "]")):
+            if not offen and roh.strip() and einruecken(roh) <= basis \
+                    and not roh.strip().startswith(("}", ")", "]")):
                 ende = i
                 break
+            offen = offen_danach(roh, offen)
         yield start, ende
 
 

--- a/scripts/pruefungen/negativprobe/berichter-ohne-set-e/bericht.sh
+++ b/scripts/pruefungen/negativprobe/berichter-ohne-set-e/bericht.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# ERWARTUNG: keine Fundstelle. Kein set -e, aber das Skript sammelt Fehler und
+# gibt am Ende einen eigenen Rueckgabewert zurueck. Mit set -e wuerde es beim
+# ersten Fehlschlag abbrechen, statt alle Punkte zu zeigen.
+FEHLER=0
+
+pruefe_eins() { FEHLER=$((FEHLER + 1)); }
+pruefe_zwei() { FEHLER=$((FEHLER + 1)); }
+
+pruefe_eins
+pruefe_zwei
+
+if [ "$FEHLER" -eq 0 ]; then
+  echo "alles in Ordnung"
+  exit 0
+fi
+echo "$FEHLER Punkt(e) offen"
+exit 1

--- a/scripts/pruefungen/negativprobe/echte-bedingung/pruefen.sh
+++ b/scripts/pruefungen/negativprobe/echte-bedingung/pruefen.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# ERWARTUNG: keine Fundstelle. Der Rueckgabewert ist hier die Bedingung,
+# er wird also ausgewertet und nicht verworfen.
+set -eu
+
+if command -v firebase >/dev/null 2>&1; then
+  echo "firebase vorhanden"
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "gcloud fehlt"
+  exit 1
+fi
+
+if [ -d .git ] || git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Repository"
+fi

--- a/scripts/pruefungen/negativprobe/eigene-muster/.pruefungen/fakten.txt
+++ b/scripts/pruefungen/negativprobe/eigene-muster/.pruefungen/fakten.txt
@@ -1,0 +1,3 @@
+# ERWARTUNG: Exit 1. Nur DIESES Muster gilt; die eingebauten sind abgeschaltet,
+# sobald ein Projekt eigene festlegt.
+Stundenlimit|Stundenlimit von (\d+)

--- a/scripts/pruefungen/negativprobe/eigene-muster/BETRIEB.md
+++ b/scripts/pruefungen/negativprobe/eigene-muster/BETRIEB.md
@@ -1,0 +1,3 @@
+# Betrieb
+Stundenlimit von 900 Analysen — widerspricht dem README, DAS ist der Drift.
+Die Suite umfasst 42 Tests, Aufbewahrung 7 Tage — beides gilt hier nicht als Fakt.

--- a/scripts/pruefungen/negativprobe/eigene-muster/README.md
+++ b/scripts/pruefungen/negativprobe/eigene-muster/README.md
@@ -1,0 +1,2 @@
+# Beispielprojekt
+Stundenlimit von 500 Analysen. Die Suite umfasst 611 Tests, Aufbewahrung 30 Tage.

--- a/scripts/pruefungen/negativprobe/geprueftes-suchergebnis/stempel.sh
+++ b/scripts/pruefungen/negativprobe/geprueftes-suchergebnis/stempel.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# ERWARTUNG: keine Fundstelle. Die Zahl wird per grep geholt UND danach geprueft;
+# ein leeres oder unplausibles Ergebnis bricht ab, statt gestempelt zu werden.
+# Die Erfolgsmeldung am Ende steht bewusst drin: Genau sie loeste den Fehlalarm
+# aus, weil die Regel ueber mehrere Zeilen bis zum naechsten Erfolgswort suchte
+# und die Pruefung dazwischen nicht sah (bis 2026-08-12).
+set -eu
+
+LOG=$(cat testlauf.txt)
+ANZAHL=$(printf "%s" "$LOG" | grep -Eo "Tests: [0-9]+ passed" | grep -Eo "[0-9]+" | head -1)
+
+if ! echo "$ANZAHL" | grep -qE "^[0-9]+$" || [ "$ANZAHL" -eq 0 ]; then
+  echo "ABBRUCH: Anzahl nicht lesbar — Ausgabeformat geaendert?"
+  exit 1
+fi
+
+echo "Alle Suiten gruen: $ANZAHL — Stempel wird gesetzt."

--- a/scripts/pruefungen/negativprobe/geprueftes-suchergebnis/testlauf.txt
+++ b/scripts/pruefungen/negativprobe/geprueftes-suchergebnis/testlauf.txt
@@ -1,0 +1,1 @@
+Tests: 42 passed

--- a/scripts/pruefungen/negativprobe/kaputt/CHANGELOG.md
+++ b/scripts/pruefungen/negativprobe/kaputt/CHANGELOG.md
@@ -1,2 +1,5 @@
 # Aenderungen
-Jetzt 726 Tests. Coverage 91%.
+## [1.1.0]
+Jetzt 998 Tests. Coverage 99%.
+## [1.0.0]
+Damals 12 Tests. Coverage 40%.

--- a/scripts/pruefungen/negativprobe/kaputt/docs/VERIFICATION.md
+++ b/scripts/pruefungen/negativprobe/kaputt/docs/VERIFICATION.md
@@ -1,0 +1,2 @@
+# Verifikationsmatrix
+Jetzt 726 Tests. Coverage 91%.

--- a/scripts/pruefungen/negativprobe/nur-historie/CHANGELOG.md
+++ b/scripts/pruefungen/negativprobe/nur-historie/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Aenderungen
+# ERWARTUNG: keine Fundstelle. Ein Changelog HAELT vergangene Staende fest;
+# dass dort andere Zahlen stehen als heute, ist sein Zweck, kein Widerspruch.
+## [2.0.0]
+Jetzt 812 Tests. Coverage 94%.
+## [1.0.0]
+Damals 210 Tests. Coverage 61%.

--- a/scripts/pruefungen/negativprobe/nur-historie/README.md
+++ b/scripts/pruefungen/negativprobe/nur-historie/README.md
@@ -1,0 +1,2 @@
+# Beispielprojekt
+Die aktuellen Zahlen stehen in docs/VERIFICATION.md, hier bewusst keine.

--- a/scripts/pruefungen/negativprobe/test-mit-textblock/tests/beispiel.test.js
+++ b/scripts/pruefungen/negativprobe/test-mit-textblock/tests/beispiel.test.js
@@ -1,0 +1,19 @@
+// ERWARTUNG: keine Fundstelle. Beide Tests haben eine Zusicherung — sie steht
+// nur hinter einem mehrzeiligen Text, dessen Zeilen keine Einrueckung haben.
+test("liest die deutsche Zeile", () => {
+  const beschreibung = `SUBJECT: HUMAN
+
+Eine Person steht vor einem Schild.
+
+Sichtbarer Text: Hauptstrasse 12`;
+  expect(lies(beschreibung)).toBe("Hauptstrasse 12");
+});
+
+test("liest die englische Zeile", () => {
+  const beschreibung = `SUBJECT: HUMAN
+
+A person in front of a sign.
+
+Visible text: Main Street 12`;
+  expect(lies(beschreibung)).toBe("Main Street 12");
+});

--- a/scripts/pruefungen/selbstpruefung.sh
+++ b/scripts/pruefungen/selbstpruefung.sh
@@ -54,9 +54,24 @@ lauf stiller-fehlschlag.py "$HIER/negativprobe/nur-ausgeschlossenes" 2 \
 lauf aussentext.py "$HIER/negativprobe/regeln-prosa-pipe" 2 \
   "| in der Begruendung wird erkannt, statt das Suchmuster still zu erweitern"
 
+echo ""
+echo "Richtung 4: kein Fehlalarm, sonst wird die Pruefung abgeschaltet (2026-08-12)"
+lauf stiller-fehlschlag.py "$HIER/negativprobe/echte-bedingung" 0 \
+  "if ... >/dev/null 2>&1; then gilt nicht als verworfener Fehler"
+lauf test-blind.py "$HIER/negativprobe/test-mit-textblock" 0 \
+  "Zusicherung hinter einem mehrzeiligen Text wird gefunden"
+lauf stiller-fehlschlag.py "$HIER/negativprobe/berichter-ohne-set-e" 0 \
+  "Sammel-Berichter mit eigenem Fehler-Exit braucht kein set -e"
+lauf stiller-fehlschlag.py "$HIER/negativprobe/geprueftes-suchergebnis" 0 \
+  "geprueftes Suchergebnis gilt nicht als still gelesen"
+lauf fakten-drift.py "$HIER/negativprobe/eigene-muster" 1 \
+  "eigene Muster gelten allein, die eingebauten schweigen"
+lauf fakten-drift.py "$HIER/negativprobe/nur-historie" 0 \
+  "ein Changelog mit alten Zahlen ist Historie, kein Drift"
+
 echo "============================================================"
 if [ "$FEHLER" -eq 0 ]; then
-  echo "ERGEBNIS: alle zwoelf Proben bestanden."
+  echo "ERGEBNIS: alle achtzehn Proben bestanden."
   echo "Die Pruefungen koennen rot werden und sind nicht ueberempfindlich."
   exit 0
 fi


### PR DESCRIPTION
Die vier Prüfungen meldeten **15 Fundstellen**. Beim Nachprüfen war **eine echt**.
Statt die Meldungen zu ertragen oder Prüfungen abzuschalten, sind die Ursachen behoben.

Fehlalarme sind gefährlicher als Lücken: Sie sind der Grund, warum Prüfungen nach drei
Wochen abgeschaltet werden.

## Fünf Fehlalarm-Ursachen, je mit eigener Probe

`selbstpruefung.sh` wächst von 12 auf **18 Proben** — jede der fünf Korrekturen war vorher rot.

| Prüfung | War falsch | Jetzt |
|---|---|---|
| `stiller-fehlschlag` | `if cmd >/dev/null 2>&1; then` galt als verworfener Fehler | Die Umleitung muss die Zeile beenden — sonst ist der Rückgabewert die Bedingung |
| `stiller-fehlschlag` | „Kein `set -e`" bei jedem Skript | Nur noch, wenn das Skript auch keinen eigenen Fehler-Exit hat |
| `stiller-fehlschlag` | `passed` in einem Suchmuster und `done` einer Schleife galten als Erfolgsmeldung; die Vorausschau prüfte nur den Zeilenanfang | Das Erfolgswort muss in einer Meldung stehen, die Vorausschau prüft die ganze Zeile |
| `test-blind` | Ein Testblock endete mitten in einem mehrzeiligen Text, die Zusicherung dahinter blieb ungesehen | Innerhalb eines Textes zählt die Einrückung nicht |
| `fakten-drift` | Ein Changelog mit 27 historischen Testzahlen galt als Drift | Historien-Dokumente werden übersprungen |

## Der eine echte Fund

`cloudtasks-scripts.test.js` erzeugte ohne installiertes `gcloud` einen Test mit
`expect(true).toBe(true)`. Der zählte als bestanden und behauptete eine Abdeckung, die es
nicht gab. Jetzt `test.skip` — **übersprungen ist ehrlicher als grün**. 923 Tests, die alle
scheitern können, statt 924, von denen einer nicht kann.

## Neu: `.pruefungen/fakten.txt`

Das Projekt legt fest, welche Zahlen genau einen Wert haben dürfen. Sobald die Datei
existiert, gelten nur ihre Muster. Grund steht in der Datei: Die eingebauten halten
„30 Tage Aufbewahrung", „7 Tage Karenz" und „183 Tage Frist" für denselben Fakt.

## CI

Ein Job `pruefungen` statt zweier, **ohne `continue-on-error`**, mit allen vier Prüfungen.
`fakten-drift` ist zurück in der Pipeline.

## Beweise

| Befehl | Ergebnis |
|---|---|
| `sh scripts/pruefungen/selbstpruefung.sh` | 18/18, Exit 0 |
| vier Prüfungen gegen simulierte CI-Auscheckung | alle Exit 0 |
| Positivkontrolle `fakten-drift` | zwei Dateien mit widersprüchlichem Node und Stundenlimit → 2 Drifts gemeldet |
| `npm test --prefix functions` | 753 passed, 1 skipped |
| `npm run test:frontend` | 315/315 |
| `npx jest doku-drift` | 3/3 |

E2E nicht lokal gelaufen — keine ausgelieferte Datei berührt, der PR-Lauf deckt es ab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)