### PR TITLE
fix(audit): Welle 1 — Riegel, die nicht rot werden konnten, und ein von aussen auslösbarer Alarm

### DIFF
--- a/.pruefungen/aussentext.txt
+++ b/.pruefungen/aussentext.txt
@@ -11,9 +11,10 @@
 # Stand 2026-08-12: Beim Anlegen dieser Liste waren fuenf Stellen im Repo verletzt
 # (README 2x, CONTRIBUTING, CHANGELOG, public/llms.txt) — alle im selben Zug korrigiert.
 
-verl(ae|ä)sst nie den (Browser|Client)|Absolute Zusage, technisch nicht haltbar. Richtig ist: GPS erreicht nie unsere Server.
-
-verlassen nie den (Browser|Client)|Absolute Zusage, technisch nicht haltbar. Richtig ist: GPS erreicht nie unsere Server.
+# DOC-2026-08-12-05: Die ersten beiden Regeln trafen nur den genauen Wortlaut.
+# "NIEMALS den Browser" und "verlaesst nie dein Geraet" rutschten durch. Jetzt
+# deckt EIN Muster die Varianten ab: Verb + nie/niemals + Browser/Client/Geraet.
+(verl(ae|ä)sst|verlassen) (nie|niemals) (den|das|dein|deinen) (Browser|Client|Ger(ae|ä)t)|Absolute Zusage, technisch nicht haltbar. Richtig ist: GPS erreicht nie unsere Server.
 
 malziland e\.U\.|Diese Kurzform der Firmierung existiert nicht. Die vollstaendige Firmierung steht im Impressum und wird unveraendert uebernommen; die reine Marke "malziland" ohne Rechtsform ist erlaubt. Der volle Name steht hier bewusst nicht, weil er selbst das Trennzeichen enthaelt.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,10 @@ Einzelbefehle:
 ## Privacy-Architektur (KRITISCH)
 
 - EXIF wird client-seitig extrahiert (exifr im Browser)
-- GPS verlässt NIEMALS den Browser — Nominatim wird direkt vom Client aufgerufen
+- GPS erreicht NIE unsere Server — Nominatim und die Kartenkacheln ruft der Browser direkt
+  auf, die Koordinaten verlassen das Gerät also sehr wohl, nur nie in Richtung malziME.
+  Diese Formulierung ist verbindlich (DOC-2026-08-12-05); die frühere Fassung war im
+  Netzwerk-Tab widerlegbar und steht auf der Sperrliste in `.pruefungen/aussentext.txt`
 - Server bekommt nur: komprimiertes Bild + Kamera-Metadaten (make, model) OHNE GPS, OHNE dateTimeOriginal
 - Keine externen Scripts: Alles self-hosted (Fonts, Leaflet, exifr). Kein CDN, kein reCAPTCHA, kein Firebase SDK
 - Bot-Schutz: Rate Limiting (IP) + Honeypot + Timing-Check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
 ## [Unveröffentlicht]
 
+**Audit-Sanierung, Welle 1 — die Riegel können jetzt rot werden:**
+
+- **Das Abhängigkeits-Gate meldete grün, ohne gemessen zu haben** (`OPS-2026-08-12-01`,
+  P1). Bei einer Registry-Störung schrieb `npm audit` eine Fehlermeldung auf dieselbe
+  Ausgabe wie einen Bericht; das Gate las daraus „null Lücken" und ließ durch — in einem
+  Pflicht-Check. Jetzt bricht es ab und unterscheidet drei Zustände: 0 sauber, 1 echte
+  Funde, 2 Messung gescheitert.
+- **Die Regionsprüfung im Deploy-Riegel ebenso** (`OPS-2026-08-12-02`, P2). Fiel `gcloud`
+  aus, war die Ausgabe leer — und leer hieß „alle Functions in europe-west1". Sie zählt
+  jetzt, was sie gesehen hat, und meldet „nicht durchgeführt" statt grün.
+- **Jeder Fremde konnte den Störungsalarm auslösen** (`SEC-2026-08-12-08`, P1). Eine
+  Job-Nummer mit ungerader Pfadtiefe (`a/b`) erreichte ungeprüft die Datenbankschicht,
+  die dort warf; der unbehandelte Fehler erzeugte eine ERROR-Logzeile, und die
+  Alarmrichtlinie schickt bei solchen Zeilen E-Mail und Push. Unauthentifiziert,
+  beliebig wiederholbar. `/api/job-status` prüft die Job-Nummer jetzt gegen das echte
+  Firestore-Format und antwortet mit 400, **ohne** die Datenbank überhaupt zu befragen.
+- **Die Sperrliste traf nur den Wortlaut** (`DOC-2026-08-12-05`, P2). „verlässt NIEMALS
+  den Browser" rutschte durch, und `.js`-Dateien wurden gar nicht geprüft — obwohl sie
+  ausgeliefert werden. Ein Muster deckt jetzt die Varianten ab, die Suchfläche umfasst
+  `.js`, `.mjs`, `.ts`. Damit sichtbar geworden und korrigiert: **drei** weitere Stellen
+  in `AGENTS.md`, `docs/ARCHITECTURE.md` und `public/js/api.js`.
+
 **Die Prüfungen prüfen jetzt richtig — und sind deshalb alle vier verbindlich:**
 
 - **Ein Job `pruefungen` statt zwei, alles blockierend.** `continue-on-error` ist weg,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -254,7 +254,10 @@ Bei Misserfolg in allen 4 Stufen: `null` zurueck — der Aufrufer in `mistral.js
 ## Privacy-Architektur
 
 - EXIF wird client-seitig extrahiert (exifr im Browser)
-- GPS verlaesst NIEMALS den Browser — Nominatim wird direkt vom Client aufgerufen
+- GPS erreicht NIE unsere Server — Nominatim und die Kartenkacheln ruft der Browser
+  direkt auf, die Koordinaten verlassen das Geraet also sehr wohl, nur nie in Richtung
+  malziME (Formulierung nach DOC-2026-08-12-05: die alte Fassung war im Netzwerk-Tab
+  widerlegbar)
 - Server bekommt nur: komprimiertes Bild + Kamera-make/model (KEIN GPS, KEIN dateTimeOriginal)
 - Keine externen Scripts: alles self-hosted (Fonts, Leaflet, exifr)
 - CSP nur self + OpenStreetMap Tiles + Nominatim + `/api/…` (gleiche Domain)

--- a/functions/src/__tests__/handle-job-status-livetext.test.js
+++ b/functions/src/__tests__/handle-job-status-livetext.test.js
@@ -37,7 +37,7 @@ function makeRes() {
 const reqMit = (jobId, token) => ({ method: "GET", query: token === undefined ? { jobId } : { jobId, token } });
 
 const PROCESSING_JOB = {
-  id: "job-1",
+  id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg",
   status: "processing",
   resultToken: "ticket-abc",
   liveText: "Du bist neugierig und",
@@ -58,7 +58,7 @@ describe("handleJobStatus — Live-Text bei processing", () => {
   test("mit richtigem Ticket kommen liveText und liveTextStand mit", async () => {
     jobs.getJob.mockResolvedValue(PROCESSING_JOB);
     const res = makeRes();
-    await handleJobStatus(reqMit("job-1", "ticket-abc"), res);
+    await handleJobStatus(reqMit("Aa1Bb2Cc3Dd4Ee5Ff6Gg", "ticket-abc"), res);
     expect(res.statusCode).toBe(200);
     expect(res.body.status).toBe("processing");
     expect(res.body.liveText).toBe("Du bist neugierig und");
@@ -68,7 +68,7 @@ describe("handleJobStatus — Live-Text bei processing", () => {
   test("mit richtigem Ticket kommt auch liveTextBeast mit, sobald der Worker es abgelegt hat", async () => {
     jobs.getJob.mockResolvedValue(PROCESSING_JOB_MIT_BEAST);
     const res = makeRes();
-    await handleJobStatus(reqMit("job-1", "ticket-abc"), res);
+    await handleJobStatus(reqMit("Aa1Bb2Cc3Dd4Ee5Ff6Gg", "ticket-abc"), res);
     expect(res.body.status).toBe("processing");
     expect(res.body.liveText).toBe("Du bist neugierig und");
     expect(res.body.liveTextBeast).toBe("Du bist ein zynisches");
@@ -77,7 +77,7 @@ describe("handleJobStatus — Live-Text bei processing", () => {
   test("solange das Dokument keinen Beast-Text traegt, fehlt liveTextBeast in der Antwort", async () => {
     jobs.getJob.mockResolvedValue(PROCESSING_JOB);
     const res = makeRes();
-    await handleJobStatus(reqMit("job-1", "ticket-abc"), res);
+    await handleJobStatus(reqMit("Aa1Bb2Cc3Dd4Ee5Ff6Gg", "ticket-abc"), res);
     expect(res.body.liveText).toBe("Du bist neugierig und");
     expect(res.body).not.toHaveProperty("liveTextBeast");
   });
@@ -85,7 +85,7 @@ describe("handleJobStatus — Live-Text bei processing", () => {
   test("ohne Ticket KEIN liveText (PRIV-003: Vorgriff aufs Ergebnis bleibt ticket-gebunden)", async () => {
     jobs.getJob.mockResolvedValue(PROCESSING_JOB);
     const res = makeRes();
-    await handleJobStatus(reqMit("job-1"), res);
+    await handleJobStatus(reqMit("Aa1Bb2Cc3Dd4Ee5Ff6Gg"), res);
     expect(res.body.status).toBe("processing");
     expect(res.body).not.toHaveProperty("liveText");
     expect(res.body).not.toHaveProperty("liveTextStand");
@@ -94,7 +94,7 @@ describe("handleJobStatus — Live-Text bei processing", () => {
   test("mit falschem Ticket KEIN liveText und KEIN liveTextBeast (gleiche Ticket-Bindung)", async () => {
     jobs.getJob.mockResolvedValue(PROCESSING_JOB_MIT_BEAST);
     const res = makeRes();
-    await handleJobStatus(reqMit("job-1", "falsch"), res);
+    await handleJobStatus(reqMit("Aa1Bb2Cc3Dd4Ee5Ff6Gg", "falsch"), res);
     expect(res.body.status).toBe("processing");
     expect(res.body).not.toHaveProperty("liveText");
     expect(res.body).not.toHaveProperty("liveTextBeast");
@@ -103,7 +103,7 @@ describe("handleJobStatus — Live-Text bei processing", () => {
   test("ohne Ticket KEIN liveTextBeast (dieselbe PRIV-003-Bindung wie liveText)", async () => {
     jobs.getJob.mockResolvedValue(PROCESSING_JOB_MIT_BEAST);
     const res = makeRes();
-    await handleJobStatus(reqMit("job-1"), res);
+    await handleJobStatus(reqMit("Aa1Bb2Cc3Dd4Ee5Ff6Gg"), res);
     expect(res.body.status).toBe("processing");
     expect(res.body).not.toHaveProperty("liveTextBeast");
   });
@@ -111,15 +111,15 @@ describe("handleJobStatus — Live-Text bei processing", () => {
   test("fehlender liveTextStand wird als null mitgegeben, nicht als undefined", async () => {
     jobs.getJob.mockResolvedValue({ ...PROCESSING_JOB, liveTextStand: undefined });
     const res = makeRes();
-    await handleJobStatus(reqMit("job-1", "ticket-abc"), res);
+    await handleJobStatus(reqMit("Aa1Bb2Cc3Dd4Ee5Ff6Gg", "ticket-abc"), res);
     expect(res.body.liveText).toBe("Du bist neugierig und");
     expect(res.body.liveTextStand).toBeNull();
   });
 
   test("ohne liveText im Dokument (Flag aus) ist die processing-Antwort exakt die heutige", async () => {
-    jobs.getJob.mockResolvedValue({ id: "job-1", status: "processing", resultToken: "ticket-abc" });
+    jobs.getJob.mockResolvedValue({ id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", status: "processing", resultToken: "ticket-abc" });
     const res = makeRes();
-    await handleJobStatus(reqMit("job-1", "ticket-abc"), res);
+    await handleJobStatus(reqMit("Aa1Bb2Cc3Dd4Ee5Ff6Gg", "ticket-abc"), res);
     /* toEqual mit dem VOLLEN Objekt: kein zusaetzliches Feld, nichts fehlt —
        das ist die „ohne Flag aendert sich nichts"-Garantie des Endpoints. */
     expect(res.body).toEqual({ status: "processing", position: 0, etaSeconds: QUEUE_AVG_JOB_SECONDS });
@@ -129,7 +129,7 @@ describe("handleJobStatus — Live-Text bei processing", () => {
 describe("handleJobStatus — done-Antwort bleibt unveraendert", () => {
   test("auch wenn das Dokument noch liveText-Felder traegt, liefert done nur result", async () => {
     jobs.getJob.mockResolvedValue({
-      id: "job-1",
+      id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg",
       status: "done",
       result: { profiles: { normal: {}, boost: {} } },
       resultToken: "ticket-abc",
@@ -139,7 +139,7 @@ describe("handleJobStatus — done-Antwort bleibt unveraendert", () => {
       liveTextStand: 1754900000000,
     });
     const res = makeRes();
-    await handleJobStatus(reqMit("job-1", "ticket-abc"), res);
+    await handleJobStatus(reqMit("Aa1Bb2Cc3Dd4Ee5Ff6Gg", "ticket-abc"), res);
     expect(res.body).toEqual({ status: "done", result: { profiles: { normal: {}, boost: {} } } });
     expect(res.body).not.toHaveProperty("liveText");
     expect(res.body).not.toHaveProperty("liveTextBeast");

--- a/functions/src/__tests__/handle-job-status.test.js
+++ b/functions/src/__tests__/handle-job-status.test.js
@@ -1,4 +1,8 @@
-/* Tests für handle-job-status.js — Polling-Endpoint der Queue-Architektur. */
+/* Tests für handle-job-status.js — Polling-Endpoint der Queue-Architektur.
+   Die Job-Nummern sind bewusst echte Firestore-Auto-IDs (20 Zeichen aus
+   [A-Za-z0-9]): Seit SEC-2026-08-12-08 weist der Handler alles ab, was nicht
+   so aussieht — ein Platzhalter wie "Aa1Bb2Cc3Dd4Ee5Ff6Gg" wuerde am Formatriegel haengen
+   bleiben und die eigentliche Absicht des Tests verdecken. */
 
 jest.mock("../jobs", () => ({
   getJob: jest.fn(),
@@ -50,10 +54,31 @@ describe("handleJobStatus — Abweisungen", () => {
     expect(res.statusCode).toBe(400);
   });
 
+  /* SEC-2026-08-12-08: Eine Job-Nummer mit ungerader Pfadtiefe ("a/b") kam bis
+     in `.doc()` durch, die Firestore-Bibliothek warf, der Handler fing nichts —
+     Ergebnis war eine ERROR-Logzeile, die den Betriebsalarm des Inhabers
+     auslöste. Unauthentifiziert und beliebig wiederholbar. */
+  test.each([
+    ["a/b", "ungerade Pfadtiefe — würde in .doc() werfen"],
+    ["jobs/andere/sammlung", "Pfad statt Kennung"],
+    ["kurz", "zu kurz"],
+    ["Aa1Bb2Cc3Dd4Ee5Ff6Gg7", "ein Zeichen zu lang"],
+    ["Aa1Bb2Cc3Dd4Ee5Ff6G-", "unerlaubtes Zeichen"],
+    ["../../etc/passwd", "Traversal-Versuch"],
+  ])("ungültige jobId %p (%s) → 400, ohne Datenbankzugriff", async (jobId) => {
+    jobs.getJob.mockClear();
+    const res = makeRes();
+    await handleJobStatus(getReq(jobId), res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid jobId" });
+    /* Entscheidend: Es darf gar nicht erst zur Datenbank gehen. */
+    expect(jobs.getJob).not.toHaveBeenCalled();
+  });
+
   test("nicht existierender Job → 404", async () => {
     jobs.getJob.mockResolvedValue(null);
     const res = makeRes();
-    await handleJobStatus(getReq("job-x"), res);
+    await handleJobStatus(getReq("Zz9Yy8Xx7Ww6Vv5Uu4Tt"), res);
     expect(res.statusCode).toBe(404);
   });
 });
@@ -62,61 +87,61 @@ describe("handleJobStatus — Abweisungen", () => {
 
 describe("handleJobStatus — Status-Antworten", () => {
   test("queued → Status, Position und ETA", async () => {
-    jobs.getJob.mockResolvedValue({ id: "job-1", status: "queued" });
+    jobs.getJob.mockResolvedValue({ id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", status: "queued" });
     jobs.getQueuePosition.mockResolvedValue(6);
     const res = makeRes();
-    await handleJobStatus(getReq("job-1"), res);
+    await handleJobStatus(getReq("Aa1Bb2Cc3Dd4Ee5Ff6Gg"), res);
     expect(res.statusCode).toBe(200);
     expect(res.body.status).toBe("queued");
     expect(res.body.position).toBe(6);
     expect(res.body.etaSeconds).toBeGreaterThan(0);
     /* Der Poll ist zugleich der Liveness-Herzschlag. */
-    expect(jobs.touchJob).toHaveBeenCalledWith("job-1");
+    expect(jobs.touchJob).toHaveBeenCalledWith("Aa1Bb2Cc3Dd4Ee5Ff6Gg");
   });
 
   test("Position 0 → ETA 0", async () => {
-    jobs.getJob.mockResolvedValue({ id: "job-1", status: "queued" });
+    jobs.getJob.mockResolvedValue({ id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", status: "queued" });
     jobs.getQueuePosition.mockResolvedValue(0);
     const res = makeRes();
-    await handleJobStatus(getReq("job-1"), res);
+    await handleJobStatus(getReq("Aa1Bb2Cc3Dd4Ee5Ff6Gg"), res);
     expect(res.body.etaSeconds).toBe(0);
   });
 
   test("processing → Status processing, kein Ergebnis", async () => {
-    jobs.getJob.mockResolvedValue({ id: "job-1", status: "processing" });
+    jobs.getJob.mockResolvedValue({ id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", status: "processing" });
     const res = makeRes();
-    await handleJobStatus(getReq("job-1"), res);
+    await handleJobStatus(getReq("Aa1Bb2Cc3Dd4Ee5Ff6Gg"), res);
     expect(res.body.status).toBe("processing");
     expect(res.body.etaSeconds).toBeGreaterThan(0);
   });
 
   test("done → Status done samt Ergebnis (mit Abhol-Ticket)", async () => {
     const result = { profiles: { normal: {}, boost: {} }, meta: { mode: "multimodal" } };
-    jobs.getJob.mockResolvedValue({ id: "job-1", status: "done", result, resultToken: "ticket-abc" });
+    jobs.getJob.mockResolvedValue({ id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", status: "done", result, resultToken: "ticket-abc" });
     const res = makeRes();
-    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, res);
+    await handleJobStatus({ method: "GET", query: { jobId: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", token: "ticket-abc" } }, res);
     expect(res.body.status).toBe("done");
     expect(res.body.result).toEqual(result);
   });
 
   test("failed → Status failed samt Fehlergrund", async () => {
-    jobs.getJob.mockResolvedValue({ id: "job-1", status: "failed", errorReason: "enqueue_failed" });
+    jobs.getJob.mockResolvedValue({ id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", status: "failed", errorReason: "enqueue_failed" });
     const res = makeRes();
-    await handleJobStatus(getReq("job-1"), res);
+    await handleJobStatus(getReq("Aa1Bb2Cc3Dd4Ee5Ff6Gg"), res);
     expect(res.body.status).toBe("failed");
     expect(res.body.errorReason).toBe("enqueue_failed");
   });
 
   test("abandoned → Status abandoned (Client hatte die Seite verlassen)", async () => {
-    jobs.getJob.mockResolvedValue({ id: "job-1", status: "abandoned" });
+    jobs.getJob.mockResolvedValue({ id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", status: "abandoned" });
     const res = makeRes();
-    await handleJobStatus(getReq("job-1"), res);
+    await handleJobStatus(getReq("Aa1Bb2Cc3Dd4Ee5Ff6Gg"), res);
     expect(res.body.status).toBe("abandoned");
   });
 
   test("ein done-Job löst keinen Heartbeat aus — nur wartende Jobs zählen", async () => {
-    jobs.getJob.mockResolvedValue({ id: "job-1", status: "done", result: {} });
-    await handleJobStatus(getReq("job-1"), makeRes());
+    jobs.getJob.mockResolvedValue({ id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", status: "done", result: {} });
+    await handleJobStatus(getReq("Aa1Bb2Cc3Dd4Ee5Ff6Gg"), makeRes());
     expect(jobs.touchJob).not.toHaveBeenCalled();
   });
 });
@@ -125,14 +150,14 @@ describe("handleJobStatus — Status-Antworten", () => {
 
 describe("handleJobStatus — Stale-Timeout", () => {
   test("ein hängender processing-Job wird beim Pollen auf failed gekippt", async () => {
-    jobs.getJob.mockResolvedValue({ id: "job-1", status: "processing" });
+    jobs.getJob.mockResolvedValue({ id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", status: "processing" });
     jobs.markFailedIfStale.mockResolvedValue({
-      id: "job-1",
+      id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg",
       status: "failed",
       errorReason: "processing_timeout",
     });
     const res = makeRes();
-    await handleJobStatus(getReq("job-1"), res);
+    await handleJobStatus(getReq("Aa1Bb2Cc3Dd4Ee5Ff6Gg"), res);
     expect(jobs.markFailedIfStale).toHaveBeenCalled();
     expect(res.body.status).toBe("failed");
     expect(res.body.errorReason).toBe("processing_timeout");
@@ -144,7 +169,7 @@ describe("handleJobStatus — Stale-Timeout", () => {
 describe("handleJobStatus — Auslieferungs-Messung", () => {
   test("erstes Ausliefern eines done-Jobs → markDelivered + job-delivered-Log", async () => {
     jobs.getJob.mockResolvedValue({
-      id: "job-1",
+      id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg",
       status: "done",
       result: {},
       resultToken: "ticket-abc",
@@ -153,10 +178,10 @@ describe("handleJobStatus — Auslieferungs-Messung", () => {
       finishedAt: 5000,
     });
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
-    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, makeRes());
+    await handleJobStatus({ method: "GET", query: { jobId: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", token: "ticket-abc" } }, makeRes());
     /* KA-02: Mit der Erstauslieferung wird der HASH des Realitäts-Check-
        Einmal-Tickets abgelegt (64 Hex-Zeichen = SHA-256, nie das Ticket). */
-    expect(jobs.markDelivered).toHaveBeenCalledWith("job-1", expect.stringMatching(/^[0-9a-f]{64}$/));
+    expect(jobs.markDelivered).toHaveBeenCalledWith("Aa1Bb2Cc3Dd4Ee5Ff6Gg", expect.stringMatching(/^[0-9a-f]{64}$/));
     const delivered = logSpy.mock.calls
       .map((c) => {
         try {
@@ -168,20 +193,20 @@ describe("handleJobStatus — Auslieferungs-Messung", () => {
       .find((o) => o && o.step === "job-delivered");
     logSpy.mockRestore();
     expect(delivered).toBeTruthy();
-    expect(delivered.jobId).toBe("job-1");
+    expect(delivered.jobId).toBe("Aa1Bb2Cc3Dd4Ee5Ff6Gg");
     expect(typeof delivered.deliveryGapMs).toBe("number");
     expect(typeof delivered.totalMs).toBe("number");
   });
 
   test("bereits ausgelieferter Job → kein erneutes markDelivered", async () => {
     jobs.getJob.mockResolvedValue({
-      id: "job-1",
+      id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg",
       status: "done",
       result: {},
       resultToken: "ticket-abc",
       deliveredAt: 9999,
     });
-    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, makeRes());
+    await handleJobStatus({ method: "GET", query: { jobId: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", token: "ticket-abc" } }, makeRes());
     expect(jobs.markDelivered).not.toHaveBeenCalled();
   });
 });
@@ -190,7 +215,7 @@ describe("handleJobStatus — Auslieferungs-Messung", () => {
 
 describe("handleJobStatus — KA-02 Realitäts-Check-Ticket", () => {
   const doneJob = (extra = {}) => ({
-    id: "job-1",
+    id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg",
     status: "done",
     result: { x: 1 },
     resultToken: "ticket-abc",
@@ -203,18 +228,18 @@ describe("handleJobStatus — KA-02 Realitäts-Check-Ticket", () => {
     jobs.getJob.mockResolvedValue(doneJob());
     const res = makeRes();
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
-    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, res);
+    await handleJobStatus({ method: "GET", query: { jobId: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", token: "ticket-abc" } }, res);
     logSpy.mockRestore();
     expect(typeof res.body.rcTicket).toBe("string");
     expect(res.body.rcTicket.length).toBeGreaterThan(0);
     const { sha256Hex } = require("../auth");
-    expect(jobs.markDelivered).toHaveBeenCalledWith("job-1", sha256Hex(res.body.rcTicket));
+    expect(jobs.markDelivered).toHaveBeenCalledWith("Aa1Bb2Cc3Dd4Ee5Ff6Gg", sha256Hex(res.body.rcTicket));
   });
 
   test("wiederholter Abruf (deliveredAt gesetzt): KEIN neues rcTicket — es gibt genau eins je Analyse", async () => {
     jobs.getJob.mockResolvedValue(doneJob({ deliveredAt: 9999 }));
     const res = makeRes();
-    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, res);
+    await handleJobStatus({ method: "GET", query: { jobId: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", token: "ticket-abc" } }, res);
     expect(res.body.status).toBe("done");
     expect(res.body.rcTicket).toBeUndefined();
   });
@@ -222,7 +247,7 @@ describe("handleJobStatus — KA-02 Realitäts-Check-Ticket", () => {
   test("falsches Abhol-Ticket: weder Ergebnis noch rcTicket — dieselbe PRIV-003-Schranke", async () => {
     jobs.getJob.mockResolvedValue(doneJob());
     const res = makeRes();
-    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "falsch" } }, res);
+    await handleJobStatus({ method: "GET", query: { jobId: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", token: "falsch" } }, res);
     expect(res.body.result).toBeNull();
     expect(res.body.rcTicket).toBeUndefined();
     expect(jobs.markDelivered).not.toHaveBeenCalled();
@@ -233,7 +258,7 @@ describe("handleJobStatus — KA-02 Realitäts-Check-Ticket", () => {
 
 describe("handleJobStatus — PRIV-003 Abhol-Ticket", () => {
   const doneJob = (extra = {}) => ({
-    id: "job-1",
+    id: "Aa1Bb2Cc3Dd4Ee5Ff6Gg",
     status: "done",
     result: { profileText: "geheim" },
     resultToken: "ticket-abc",
@@ -245,7 +270,7 @@ describe("handleJobStatus — PRIV-003 Abhol-Ticket", () => {
   test("richtiges Ticket → Ergebnis wird zurückgegeben", async () => {
     jobs.getJob.mockResolvedValue(doneJob());
     const res = makeRes();
-    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "ticket-abc" } }, res);
+    await handleJobStatus({ method: "GET", query: { jobId: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", token: "ticket-abc" } }, res);
     expect(res.body.status).toBe("done");
     expect(res.body.result).toEqual({ profileText: "geheim" });
   });
@@ -253,7 +278,7 @@ describe("handleJobStatus — PRIV-003 Abhol-Ticket", () => {
   test("falsches Ticket → KEIN Ergebnis (tokenRequired), kein markDelivered", async () => {
     jobs.getJob.mockResolvedValue(doneJob());
     const res = makeRes();
-    await handleJobStatus({ method: "GET", query: { jobId: "job-1", token: "falsch" } }, res);
+    await handleJobStatus({ method: "GET", query: { jobId: "Aa1Bb2Cc3Dd4Ee5Ff6Gg", token: "falsch" } }, res);
     expect(res.body.status).toBe("done");
     expect(res.body.result).toBeNull();
     expect(res.body.tokenRequired).toBe(true);
@@ -263,7 +288,7 @@ describe("handleJobStatus — PRIV-003 Abhol-Ticket", () => {
   test("fehlendes Ticket → KEIN Ergebnis", async () => {
     jobs.getJob.mockResolvedValue(doneJob());
     const res = makeRes();
-    await handleJobStatus(getReq("job-1"), res);
+    await handleJobStatus(getReq("Aa1Bb2Cc3Dd4Ee5Ff6Gg"), res);
     expect(res.body.result).toBeNull();
     expect(res.body.tokenRequired).toBe(true);
   });
@@ -274,7 +299,7 @@ describe("handleJobStatus — PRIV-003 Abhol-Ticket", () => {
        fail-closed statt leise offen. */
     jobs.getJob.mockResolvedValue(doneJob({ resultToken: null }));
     const res = makeRes();
-    await handleJobStatus(getReq("job-1"), res);
+    await handleJobStatus(getReq("Aa1Bb2Cc3Dd4Ee5Ff6Gg"), res);
     expect(res.body.result).toBeNull();
     expect(res.body.tokenRequired).toBe(true);
   });

--- a/functions/src/handle-job-status.js
+++ b/functions/src/handle-job-status.js
@@ -20,6 +20,11 @@ const { QUEUE_AVG_JOB_SECONDS, QUEUE_DISPATCH_CONCURRENCY } = require("./config"
 const { getJob, getQueuePosition, markFailedIfStale, touchJob, markDelivered } = require("./jobs");
 const { safeCompare, sha256Hex } = require("./auth");
 
+/* Firestore-Auto-IDs: genau 20 Zeichen aus [A-Za-z0-9] (jobs.js:58 nutzt
+   `jobsRef().doc()` ohne eigenen Namen). Bewusst eng gefasst — alles, was nicht
+   so aussieht, ist keine Job-Nummer dieses Systems. */
+const JOB_ID_MUSTER = /^[A-Za-z0-9]{20}$/;
+
 /* Grobe Wartezeit-Schätzung aus der Warteschlangen-Position.
    Kalibrierung der Konstanten erfolgt in Phase 3/4 (config.js). */
 function etaForPosition(position) {
@@ -35,6 +40,20 @@ async function handleJobStatus(req, res) {
   const jobId = req.query && typeof req.query.jobId === "string" ? req.query.jobId : "";
   if (!jobId) {
     res.status(400).json({ error: "Missing jobId" });
+    return;
+  }
+  /* AUDIT-BEFUND SEC-2026-08-12-08: Ohne Formatprüfung reicht ein Aufruf mit
+     einer Job-Nummer wie "a/b" bis in `.doc()`, wo die Firestore-Bibliothek
+     wirft ("path does not contain an even number of components"). Der Handler
+     fing nichts ab, firebase-functions protokollierte "Unhandled error" mit
+     severity ERROR, und die Alarmrichtlinie feuert auf genau diesen Dienst —
+     ein beliebiger Dritter konnte so ohne Anmeldung E-Mail und Push beim
+     Inhaber auslösen, alle 5 Minuten, kostenlos.
+     Firestore-Auto-IDs sind 20 Zeichen aus [A-Za-z0-9]; alles andere kann kein
+     echter Job sein und wird als Eingabefehler beantwortet, nicht als
+     Serverabsturz. Im Zweifel verweigern (KERN: fail-closed). */
+  if (!JOB_ID_MUSTER.test(jobId)) {
+    res.status(400).json({ error: "Invalid jobId" });
     return;
   }
   /* PRIV-003: Abhol-Ticket fürs Ergebnis (vom enqueue an genau diesen Browser

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -498,8 +498,8 @@ async function renderQueueResult(data, myId, traceId, timings) {
     setStatus(t("error.queueFailed"), traceId);
     return;
   }
-  /* Client-seitige Daten injizieren — GPS/dateTimeOriginal verlassen nie den
-     Browser. Nach einem Reload fehlt state.lastPrepared; dann bleibt GPS leer. */
+  /* Client-seitige Daten injizieren — GPS/dateTimeOriginal erreichen nie unsere
+     Server. Nach einem Reload fehlt state.lastPrepared; dann bleibt GPS leer. */
   if (!data.exif) data.exif = {};
   if (state.lastPrepared && state.lastPrepared.gps) {
     data.exif.gpsLatitude = state.lastPrepared.gps.latitude;

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -45,12 +45,29 @@ function auditLesen(verzeichnis) {
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
   };
+  let bericht;
   try {
-    return JSON.parse(execFileSync("npm", ["audit", "--json", "--omit=dev"], optionen));
+    bericht = JSON.parse(execFileSync("npm", ["audit", "--json", "--omit=dev"], optionen));
   } catch (fehler) {
-    if (fehler.stdout) return JSON.parse(fehler.stdout);
-    throw fehler;
+    /* Exit 1 heisst "Funde gefunden" — dann liegt der Bericht auf stdout. */
+    if (!fehler.stdout) throw fehler;
+    bericht = JSON.parse(fehler.stdout);
   }
+
+  /* AUDIT-BEFUND OPS-2026-08-12-01: Bei einer Registry-Stoerung schreibt
+     `npm audit --json` ebenfalls auf stdout — aber eine Fehlermeldung ohne den
+     Schluessel `vulnerabilities`. Der bisherige Code hat das geparst, `?? {}`
+     machte daraus null Advisories, und das Gate meldete GRUEN, ohne gemessen zu
+     haben. Ein Fehlschlag darf nie wie ein bestandener Lauf enden (KERN 5c).
+     Nachgestellt mit `npm_config_registry=http://127.0.0.1:1/`. */
+  if (!bericht || typeof bericht.vulnerabilities !== "object" || bericht.vulnerabilities === null) {
+    const grund = bericht?.error?.summary ?? bericht?.message ?? "unbekannter Fehler";
+    throw new Error(
+      `npm audit hat keinen auswertbaren Bericht geliefert (${verzeichnis}): ${grund}\n` +
+        "Das ist ein Fehlschlag, kein Freispruch — ungeprueft gilt als nicht bestanden."
+    );
+  }
+  return bericht;
 }
 
 /**
@@ -108,7 +125,16 @@ function heute() {
 
 const alleAdvisories = new Map();
 for (const verzeichnis of ziele) {
-  for (const [kennung, advisory] of advisoriesSammeln(auditLesen(verzeichnis), verzeichnis)) {
+  let bericht;
+  try {
+    bericht = auditLesen(verzeichnis);
+  } catch (fehler) {
+    /* Klartext statt Stapelabzug — und Exit 2, damit ein Messfehler von einem
+       echten Fund (Exit 1) unterscheidbar bleibt. */
+    console.error(`\nGate ROT — die Messung selbst ist gescheitert.\n${fehler.message}`);
+    process.exit(2);
+  }
+  for (const [kennung, advisory] of advisoriesSammeln(bericht, verzeichnis)) {
     const vorhanden = alleAdvisories.get(kennung);
     if (vorhanden) {
       for (const v of advisory.verzeichnisse) vorhanden.verzeichnisse.add(v);

--- a/scripts/pruefungen/checks/aussentext.py
+++ b/scripts/pruefungen/checks/aussentext.py
@@ -26,8 +26,11 @@ import os
 import re
 import sys
 
+# DOC-2026-08-12-05: ".js" fehlte — der Kommentar in public/js/api.js wird an
+# jeden Besucher ausgeliefert und trug monatelang eine widerlegbare Zusage, ohne
+# dass die Sperrliste ihn je gesehen haette.
 ENDUNGEN = (".md", ".html", ".htm", ".txt", ".json", ".yml", ".yaml", ".vue", ".jsx",
-            ".tsx", ".svelte")
+            ".tsx", ".svelte", ".js", ".mjs", ".ts")
 # "negativprobe" enthaelt das absichtlich kaputte Beispielmaterial dieser Pruefungen.
 # Ohne den Ausschluss meldet jeder Lauf im eigenen Verzeichnis Dauerfunde aus dem
 # eigenen Testmaterial — und ein Pruefer, der nie gruen werden kann, wird ignoriert.

--- a/scripts/verify-infrastructure.sh
+++ b/scripts/verify-infrastructure.sh
@@ -135,20 +135,38 @@ for DIENST in processjob reapjobs; do
 done
 
 # ── 5. Alle Functions in der EU-Region ──
+# AUDIT-BEFUND OPS-2026-08-12-02: Diese Prüfung meldete GRÜN, wenn ihre Messung
+# scheiterte. `gcloud … 2>/dev/null | python3 … || true` liefert bei abgelaufener
+# Anmeldung, API-Fehler oder geändertem JSON-Format eine LEERE Ausgabe — und leer
+# hieß „keine Function außerhalb europe-west1". Ausgerechnet die Prüfung, die das
+# EU-Versprechen trägt, konnte nicht rot werden. Jetzt zählt sie, was sie gesehen
+# hat: null gefundene Functions ist ein Messfehler, kein Freispruch (KERN 5c).
 echo "— Functions-Regionen"
-AUSSERHALB=$(gcloud functions list --project="$PROJECT" --format=json 2>/dev/null \
-  | python3 -c '
+FUNKTIONEN_JSON=$(gcloud functions list --project="$PROJECT" --format=json 2>&1) || FUNKTIONEN_JSON=""
+BEFUND=$(printf '%s' "$FUNKTIONEN_JSON" | python3 -c '
 import json, sys
-for f in json.load(sys.stdin):
-    teile = f["name"].split("/")           # projects/P/locations/REGION/functions/NAME
+try:
+    daten = json.load(sys.stdin)
+except Exception:
+    print("MESSFEHLER:Antwort nicht lesbar"); raise SystemExit(0)
+if not isinstance(daten, list) or len(daten) == 0:
+    print("MESSFEHLER:keine Function in der Antwort"); raise SystemExit(0)
+aussen = []
+for f in daten:
+    teile = f.get("name", "").split("/")   # projects/P/locations/REGION/functions/NAME
+    if len(teile) < 6:
+        print("MESSFEHLER:unerwartetes Namensformat"); raise SystemExit(0)
     if teile[3] != "europe-west1":
-        print(teile[3] + ":" + teile[5])
-' || true)
-if [ -z "$AUSSERHALB" ]; then
-  gruen "alle Functions in $REGION"
-else
-  rot "Functions außerhalb $REGION: $AUSSERHALB"
-fi
+        aussen.append(teile[3] + ":" + teile[5])
+print(("AUSSERHALB:" + ",".join(aussen)) if aussen else "OK:%d" % len(daten))
+' 2>/dev/null)
+
+case "$BEFUND" in
+  OK:*)         gruen "alle ${BEFUND#OK:} Functions in $REGION" ;;
+  AUSSERHALB:*) rot   "Functions außerhalb $REGION: ${BEFUND#AUSSERHALB:}" ;;
+  MESSFEHLER:*) rot   "Regionsprüfung NICHT durchgeführt (${BEFUND#MESSFEHLER:}) — ungeprüft gilt als nicht bestanden" ;;
+  *)            rot   "Regionsprüfung NICHT durchgeführt (keine auswertbare Ausgabe) — ungeprüft gilt als nicht bestanden" ;;
+esac
 
 # ── 6. Logging: Routine-Ausschlüsse + Diagnose-Sink ──
 echo "— Logging"


### PR DESCRIPTION
Erste Welle der Sanierung aus dem TIEF-Audit (`docs/audit/2026-08-12-tief-b1c43d6.md`).
Zwei von drei P1 und zwei P2.

## Was drin ist

| Befund | Kern | Verifikation |
|---|---|---|
| **OPS-01** (P1) | Das Abhängigkeits-Gate meldete `Gate GRÜN` bei jeder Registry-Störung — in einem Pflicht-Check | Registry unerreichbar → Exit 2 statt 0 |
| **OPS-02** (P2) | Die Regionsprüfung im Deploy-Riegel meldete „alle in europe-west1", wenn `gcloud` ausfiel | Leere Eingabe, kaputtes JSON, leere Liste → je rot |
| **SEC-08** (P1) | `GET /api/job-status?jobId=a%2Fb` löste ohne Anmeldung den Betriebsalarm des Inhabers aus | 6 Fälle, je 400 **ohne** Datenbankzugriff; Rückbauprobe: Riegel aus → genau diese 6 fallen |
| **DOC-05** (P2) | Die Sperrliste traf nur den Wortlaut, `.js` fehlte ganz in der Suchfläche | 5 Varianten → 5 Treffer (vorher 1) |

## Drei Stellen, die erst durch DOC-05 sichtbar wurden

`AGENTS.md:122`, `docs/ARCHITECTURE.md:257`, `public/js/api.js:501` trugen weiterhin die
Formulierung, die am 2026-08-12 als widerlegbar erklärt wurde. Die erste wiegt am
schwersten: `AGENTS.md` ist die Datei, die eine neue Sitzung zuerst liest.

## Beweise

| Befehl | Ergebnis |
|---|---|
| `npm test --prefix functions` | 759 passed, 1 skipped |
| `npm run test:frontend` | 315/315 |
| `npm run test:e2e` | 18/18, Exit 0 |
| Selbstprüfung + vier Prüfungen gegen simulierte CI-Auscheckung | alle Exit 0 |

## Hinweis zu den Tests

Die Tests für `job-status` benutzten Platzhalter wie `"job-1"`, die kein echtes
Firestore-Format haben. Statt die neue Zusicherung zu lockern, tragen sie jetzt echte
Auto-IDs — das war ohnehin ihre Absicht.

## Deploy

`SEC-08` wirkt erst nach einem Functions-Deploy. Rückweg: RUNBOOK Hebel 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)