### PR TITLE
chore: Cache-Buster 2026081203 und Versionsstempel v3.0.8 (nach dem Deploy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [3.0.8] — 2026-08-12
 
 **Audit-Sanierung, Welle 1 — die Riegel können jetzt rot werden:**
 

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081202" />
+    <link rel="stylesheet" href="./styles.css?v=2026081203" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -44,7 +44,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081202" />
+    <link rel="stylesheet" href="./styles.css?v=2026081203" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -85,7 +85,7 @@
     <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
     <link rel="preconnect" href="https://nominatim.openstreetmap.org" crossorigin />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081202" />
+    <link rel="stylesheet" href="./styles.css?v=2026081203" />
     <script type="application/ld+json">
 [
   {
@@ -309,15 +309,15 @@
         <p class="demo-label" data-i18n="demo.label">Kein Foto zur Hand? Probier ein Beispielbild (mit KI erstellt):</p>
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
-            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081202" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081203" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.selfie">Selfie am Stephansplatz</span>
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
-            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081202" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081203" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.cafe">Im Caf&eacute; in Salzburg</span>
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
-            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081202" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081203" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.hiker">Wanderung bei Hallstatt</span>
           </button>
         </div>
@@ -373,6 +373,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081202"></script>
+    <script type="module" src="./app.js?v=2026081203"></script>
   </body>
 </html>

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -5,9 +5,9 @@ import { klangAktivieren } from "./klang.js";
 import { t } from "./i18n.js";
 
 const DEMO_IMAGES = {
-  selfie: "./img/demo/demo-selfie.jpg?v=2026081202",
-  cafe: "./img/demo/demo-cafe.jpg?v=2026081202",
-  hiker: "./img/demo/demo-hiker.jpg?v=2026081202",
+  selfie: "./img/demo/demo-selfie.jpg?v=2026081203",
+  cafe: "./img/demo/demo-cafe.jpg?v=2026081203",
+  hiker: "./img/demo/demo-hiker.jpg?v=2026081203",
 };
 
 export function initDemo() {

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081202" />
+    <link rel="stylesheet" href="./styles.css?v=2026081203" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081202" />
+    <link rel="stylesheet" href="./styles.css?v=2026081203" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081202"></script>
+    <script type="module" src="./js/stats.js?v=2026081203"></script>
   </body>
 </html>


### PR DESCRIPTION
Stempel **nach** beiden Deployments. Functions (alle neun) und Hosting sind ausgeliefert, Live-Smoke grün, Kennungen identisch (`?v=2026081203`).

**SEC-2026-08-12-08 ist live belegt geschlossen:**

| Aufruf | vorher | jetzt |
|---|---|---|
| `?jobId=a%2Fb` | HTTP 500 + Alarm | **HTTP 400** |
| `?jobId=..%2F..%2Fetc%2Fpasswd` | HTTP 500 + Alarm | **HTTP 400** |
| `?jobId=Zz9Yy8Xx7Ww6Vv5Uu4Tt` | 404 | 404 (unverändert) |
| ERROR-Zeilen am Dienst `jobstatus`, 10 min | — | **keine** |

Positivkontrolle: Derselbe Log-Filter ohne `severity` liefert INFO-Zeilen — die Abfrage sieht den Dienst, die Null ist echt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)