### PR TITLE
fix(audit): Welle 2 — Löschkette meldet ihr Scheitern, stille Erinnerung bekommt einen Wächter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # AUDIT-BEFUND OPS-2026-08-12-11: Die harte Frist-Bremse (zusagen-frische.test.js)
+  # haengt in `test-backend` — lief aber nur bei Push und Pull-Request. Ohne Commit
+  # kein Lauf, ohne Lauf keine Bremse. Damit waren BEIDE Schichten (Wochen-
+  # Erinnerung und CI-Waechter) ereignisgesteuert und konnten gemeinsam
+  # verstummen. Der Zeitplan gibt der Bremse eine eigene Uhr.
+  schedule:
+    - cron: "17 6 * * 1" # montags 06:17 UTC, vor der Wochen-Erinnerung um 07:00 UTC
 
 jobs:
   test-backend:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+**Audit-Sanierung, Welle 2 — die Löschkette meldet ihr Scheitern, und die stille
+Erinnerung bekommt einen Wächter:**
+
+- **Bildlöschung ohne Erfolgsprüfung** (`PRIV-2026-08-12-26`, P2). `deleteImage`
+  verschluckte jeden Fehler in eine Logzeile unterhalb der Alarmschwelle und gab nichts
+  zurück; der Aufrufer löschte danach das Job-Dokument mitsamt dem einzigen Verweis auf
+  die Datei. Gemessen: 11 solcher Fehlschläge in 30 Tagen, alle unbemerkt. Jetzt meldet
+  die Funktion Erfolg oder Misserfolg, ein echter Fehler geht mit `severity: ERROR` raus,
+  und der Reaper lässt das Dokument stehen, statt den Pfad wegzuwerfen.
+- **Kein zweites Netz für die fertigen Profile** (`ARCH-2026-08-12-27`, P2). Räumte der
+  Reaper nicht, blieben Job-Dokumente unbegrenzt liegen. Neu: ein Ablauf-Feld je Job und
+  eine automatische Löschregel in der Datenbank — bewusst bei 24 Stunden statt bei 2, das
+  Netz soll den Ausfall des Reapers fangen und ihm nicht ins Handwerk pfuschen.
+  Eingerichtet, während die Sammlung leer war; keine Migration nötig.
+- **Nonce und Admin-Token waren kryptografisch dasselbe** (`SEC-2026-08-12-17`, P2). Der
+  30-Minuten-Token steht im Klartext in der Push-Mitteilung; wer ihn sah, konnte ihn im
+  Nonce-Feld einsetzen und die Bestätigungsseite überspringen. Beide tragen jetzt ihren
+  Verwendungszweck in der Signatur. Zusätzlich hat der Boost eine Obergrenze (doppeltes
+  Stundenlimit) und lehnt fail-closed ab, wenn die aktuelle Grenze nicht lesbar ist.
+- **Die Wochen-Erinnerung schwieg in jedem Fehlerfall** (`OPS-2026-08-12-11`, P2) — und
+  bis zum ersten fälligen Push im Februar 2027 wäre ihr Ausfall 180 Tage lang nicht von
+  korrektem Verhalten zu unterscheiden gewesen. Sie hinterlässt jetzt bei jedem Lauf ein
+  Lebenszeichen; der Reaper liest es jede Minute und meldet laut, wenn es älter als neun
+  Tage ist. Der Reaper eignet sich dafür, weil er in der Alarmrichtlinie steht — die
+  Erinnerung selbst bleibt bewusst leise. Dazu bekommt die CI einen wöchentlichen
+  Zeitplan: Die harte Frist-Bremse lief bisher nur bei Push und Pull-Request, damit waren
+  **beide** Schichten ereignisgesteuert und konnten gemeinsam verstummen.
+
 ## [3.0.8] — 2026-08-12
 
 **Audit-Sanierung, Welle 1 — die Riegel können jetzt rot werden:**

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -106,6 +106,38 @@ Reihenfolge**:
 Das Datum **niemals** ohne echte Prüfung hochsetzen — dann behauptet die
 Webseite etwas Unbelegtes, und genau davor schützt der Wächter.
 
+## Automatische Löschregel der Datenbank (seit 2026-08-12)
+
+Soll-Zustand: `jobs/expiresAt`, Status `ACTIVE`, Datenbank `malzime-eu`.
+
+    gcloud firestore fields ttls list --database=malzime-eu --project=malzime
+
+Das ist das **Netz unter dem Reaper**, nicht die eigentliche Löschung: Der Reaper räumt
+Job-Dokumente nach 2 Stunden ab, die Regel greift erst nach 24 Stunden. Der Abstand ist
+Absicht — eine knapp gesetzte Regel würde laufende Jobs mitten im Betrieb löschen.
+
+Rückweg, falls sie je stört:
+
+    gcloud firestore fields ttls update expiresAt --collection-group=jobs \
+      --database=malzime-eu --project=malzime --disable-ttl
+
+Eingerichtet am 2026-08-12, als die Sammlung `jobs` nachweislich 0 Dokumente hatte
+(ARCH-2026-08-12-27). Eine Migration bestehender Dokumente war deshalb nicht nötig.
+
+## Lebenszeichen der Wochen-Erinnerung (seit 2026-08-12)
+
+Die Erinnerung schreibt bei jedem Lauf `config/erinnerung.letzterLauf`. Der Reaper liest
+das jede Minute und meldet mit `severity: ERROR`, wenn es älter als neun Tage ist —
+Marker `erinnerung-lebenszeichen-veraltet`. Damit fällt ein Ausfall der Erinnerung auf,
+obwohl sie selbst bewusst leise bleibt (OPS-2026-08-12-11).
+
+Prüfen von Hand:
+
+    gcloud logging read 'jsonPayload.error="erinnerung-lebenszeichen-veraltet"' \
+      --project=malzime --freshness=14d
+
+Erwartet: keine Zeile.
+
 ## Rollback-Hebel
 
 Vom schnellsten zum gründlichsten. Alle Flag-Hebel wirken **ohne Deploy** binnen

--- a/functions/src/__tests__/auth.test.js
+++ b/functions/src/__tests__/auth.test.js
@@ -202,3 +202,30 @@ describe("cleanupNonces", () => {
     expect(mockCommit).toHaveBeenCalled();
   });
 });
+
+/* SEC-2026-08-12-17: Token und Nonce trugen dieselbe Nutzlast und waren damit
+   austauschbar. Der 30-Minuten-Token steht im Klartext in der ntfy-Mitteilung;
+   wer ihn sah, konnte ihn im Nonce-Feld einsetzen und die Bestaetigungsseite
+   (SEC-001) ueberspringen. */
+describe("SEC-2026-08-12-17 — Token und Nonce sind nicht austauschbar", () => {
+  const SECRET = "geheim-fuer-den-test";
+
+  test("ein Admin-Token gilt NICHT als Nonce", () => {
+    const token = createAdminToken("boost", SECRET);
+    expect(verifyAdminToken(token, "boost", SECRET)).toBe(true);
+    expect(verifyNonce(token, "boost", SECRET)).toBe(false);
+  });
+
+  test("eine Nonce gilt NICHT als Admin-Token", () => {
+    const nonce = createNonce("boost", SECRET);
+    expect(verifyNonce(nonce, "boost", SECRET)).toBe(true);
+    expect(verifyAdminToken(nonce, "boost", SECRET)).toBe(false);
+  });
+
+  test("die Action-Bindung gilt weiterhin fuer beide", () => {
+    const token = createAdminToken("boost", SECRET);
+    const nonce = createNonce("boost", SECRET);
+    expect(verifyAdminToken(token, "reset", SECRET)).toBe(false);
+    expect(verifyNonce(nonce, "reset", SECRET)).toBe(false);
+  });
+});

--- a/functions/src/__tests__/counter.test.js
+++ b/functions/src/__tests__/counter.test.js
@@ -568,13 +568,44 @@ describe("getStats", () => {
 
 describe("boostLimit", () => {
   test("increments limit by specified amount", async () => {
+    mockGet.mockResolvedValue({ exists: true, data: () => ({ limit: 500 }) });
     await boostLimit(200);
     expect(mockSet).toHaveBeenCalledWith({ limit: { __increment: 200 } }, { merge: true });
   });
 
   test("defaults to 100 when no amount given", async () => {
+    mockGet.mockResolvedValue({ exists: true, data: () => ({ limit: 500 }) });
     await boostLimit();
     expect(mockSet).toHaveBeenCalledWith({ limit: { __increment: 100 } }, { merge: true });
+  });
+
+  /* SEC-2026-08-12-17: Der Boost erhoehte ohne Obergrenze. Der Link steht im
+     Klartext in der ntfy-Mitteilung; wer ihn sah, konnte 30 Minuten lang beliebig
+     oft anheben und die einzige globale Kostenbremse praktisch abschalten. */
+  test("ueber der Obergrenze (2x Stundenlimit) wird abgelehnt und laut gemeldet", async () => {
+    mockGet.mockResolvedValue({ exists: true, data: () => ({ limit: 950 }) });
+    const fehlerSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const ergebnis = await boostLimit(100);
+
+    expect(ergebnis.abgelehnt).toBe(true);
+    expect(mockSet).not.toHaveBeenCalled();
+    const zeile = JSON.parse(fehlerSpy.mock.calls[0][0]);
+    expect(zeile.severity).toBe("ERROR");
+    expect(zeile.error).toBe("boost-obergrenze-erreicht");
+    fehlerSpy.mockRestore();
+  });
+
+  test("ist die aktuelle Grenze nicht lesbar, wird NICHT erhoeht (fail-closed)", async () => {
+    mockGet.mockRejectedValue(new Error("firestore weg"));
+    const fehlerSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const ergebnis = await boostLimit(100);
+
+    expect(ergebnis.abgelehnt).toBe(true);
+    expect(mockSet).not.toHaveBeenCalled();
+    expect(JSON.parse(fehlerSpy.mock.calls[0][0]).error).toBe("boost-limit-nicht-lesbar");
+    fehlerSpy.mockRestore();
   });
 });
 

--- a/functions/src/__tests__/handle-reap.test.js
+++ b/functions/src/__tests__/handle-reap.test.js
@@ -16,6 +16,11 @@ jest.mock("../queue-storage", () => ({
 jest.mock("../counter", () => ({
   releaseHourlySlot: jest.fn(),
 }));
+/* OPS-2026-08-12-11: Der Reaper liest das Lebenszeichen der Wochen-Erinnerung. */
+const mockLebenszeichenGet = jest.fn();
+jest.mock("../db", () => ({
+  datenbank: () => ({ doc: () => ({ get: mockLebenszeichenGet }) }),
+}));
 
 const { reapJobs } = require("../handle-reap");
 const jobs = require("../jobs");
@@ -23,6 +28,7 @@ const storage = require("../queue-storage");
 const counter = require("../counter");
 
 beforeEach(() => {
+  mockLebenszeichenGet.mockResolvedValue({ exists: true, data: () => ({ letzterLauf: Date.now() }) });
   jest.clearAllMocks();
   jobs.findAbandonedJobs.mockResolvedValue([]);
   jobs.findUeberfaelligeJobs.mockResolvedValue([]);
@@ -167,5 +173,51 @@ describe("SEC-003 — Jobs, die nur durch Pollen am Leben bleiben", () => {
     expect(storage.deleteImage).not.toHaveBeenCalled();
     expect(counter.releaseHourlySlot).not.toHaveBeenCalled();
     expect(r.ueberfaellig).toBe(0);
+  });
+});
+
+/* ── Waechter ueber die Wochen-Erinnerung (OPS-2026-08-12-11) ────────── */
+
+describe("Reaper als Waechter der Wochen-Erinnerung", () => {
+  const leer = () => {
+    jobs.findAbandonedJobs.mockResolvedValue([]);
+    jobs.findUeberfaelligeJobs.mockResolvedValue([]);
+    jobs.findStaleProcessingJobs.mockResolvedValue([]);
+    jobs.findZugestellteJobs.mockResolvedValue([]);
+    jobs.findExpiredJobs.mockResolvedValue([]);
+  };
+
+  test("frisches Lebenszeichen -> keine Meldung", async () => {
+    leer();
+    mockLebenszeichenGet.mockResolvedValue({ exists: true, data: () => ({ letzterLauf: Date.now() }) });
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await reapJobs();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  test("Lebenszeichen aelter als neun Tage -> laute Meldung mit severity ERROR", async () => {
+    leer();
+    const zehnTage = Date.now() - 10 * 24 * 60 * 60 * 1000;
+    mockLebenszeichenGet.mockResolvedValue({ exists: true, data: () => ({ letzterLauf: zehnTage }) });
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await reapJobs();
+
+    const zeilen = spy.mock.calls.map((c) => JSON.parse(c[0]));
+    const meldung = zeilen.find((z) => z.error === "erinnerung-lebenszeichen-veraltet");
+    expect(meldung).toBeDefined();
+    expect(meldung.severity).toBe("ERROR");
+    expect(meldung.alterTage).toBeGreaterThanOrEqual(9);
+    spy.mockRestore();
+  });
+
+  test("noch nie gelaufen -> keine Meldung (vor dem ersten Montag normal)", async () => {
+    leer();
+    mockLebenszeichenGet.mockResolvedValue({ exists: false, data: () => null });
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await reapJobs();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });

--- a/functions/src/__tests__/jobs.test.js
+++ b/functions/src/__tests__/jobs.test.js
@@ -91,7 +91,13 @@ jest.mock("firebase-admin/firestore", () => {
       return fn(tx);
     },
   };
-  return { getFirestore: () => db };
+  /* ARCH-2026-08-12-27: Die Attrappe muss `Timestamp` mitliefern — createJob legt
+     seit dem 2026-08-12 ein echtes Zeitstempel-Feld `expiresAt` an, auf dem die
+     Firestore-Loeschregel als Sicherheitsnetz unter dem Reaper sitzt. */
+  const Timestamp = {
+    fromMillis: (ms) => ({ _millis: ms, toMillis: () => ms }),
+  };
+  return { getFirestore: () => db, Timestamp };
 });
 
 const jobs = require("../jobs");
@@ -118,6 +124,23 @@ describe("createJob", () => {
     expect(typeof job.createdAt).toBe("number");
     /* Liveness: bei Anlage gilt der Client als anwesend. */
     expect(job.lastSeenAt).toBe(job.createdAt);
+  });
+
+  /* ARCH-2026-08-12-27: Firestore-Loeschregel als Netz UNTER dem Reaper.
+     Entscheidend ist der Abstand: Greift die TTL frueher als der Reaper, loescht
+     sie laufende Jobs mitten im Betrieb — die Massnahme waere dann gefaehrlicher
+     als der Befund. */
+  test("legt ein Ablauf-Feld an, das DEUTLICH nach der Reaper-Frist liegt", async () => {
+    const vorher = Date.now();
+    const id = await jobs.createJob({ lang: "de" });
+    const job = await jobs.getJob(id);
+
+    expect(job.expiresAt).toBeDefined();
+    const ablauf = job.expiresAt.toMillis();
+    /* Netz spaeter als die eigentliche Loeschung … */
+    expect(ablauf - vorher).toBeGreaterThan(JOB_RETENTION_MS);
+    /* … und mit deutlichem Abstand, nicht knapp dahinter. */
+    expect(ablauf - vorher).toBeGreaterThanOrEqual(12 * 60 * 60 * 1000);
   });
 
   test("setzt Default-Sprache de wenn keine angegeben", async () => {

--- a/functions/src/__tests__/queue-storage.test.js
+++ b/functions/src/__tests__/queue-storage.test.js
@@ -22,7 +22,12 @@ function fakeBucket() {
           return [{ contentType: f ? f.contentType : undefined }];
         },
         async delete() {
-          if (!files.has(path)) throw new Error("object not found");
+          if (!files.has(path)) {
+            /* Wie GCS: ein nicht vorhandenes Objekt meldet 404. */
+            const err = new Error("object not found");
+            err.code = 404;
+            throw err;
+          }
           files.delete(path);
         },
       };
@@ -78,12 +83,41 @@ describe("deleteImage", () => {
     expect(bucket._files.has(path)).toBe(false);
   });
 
-  test("ein bereits gelöschtes Bild wirft keinen Fehler (Lifecycle räumt nach)", async () => {
-    await expect(storage.deleteImage("queue-uploads/nicht-da.jpg")).resolves.toBeUndefined();
+  test("ein bereits gelöschtes Bild (404) gilt als erfolgreich, ohne Meldung", async () => {
+    const fehlerSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(storage.deleteImage("queue-uploads/nicht-da.jpg")).resolves.toBe(true);
+    expect(fehlerSpy).not.toHaveBeenCalled();
+    fehlerSpy.mockRestore();
   });
 
-  test("leerer Pfad ist ein No-Op", async () => {
-    await expect(storage.deleteImage(null)).resolves.toBeUndefined();
+  test("leerer Pfad ist ein No-Op und gilt als erfolgreich", async () => {
+    await expect(storage.deleteImage(null)).resolves.toBe(true);
+  });
+
+  /* PRIV-2026-08-12-26 / OPS-2026-08-12-10: Bis zum 2026-08-12 verschluckte
+     deleteImage JEDEN Fehler in eine console.log-Zeile ohne severity — also
+     unterhalb der Alarmschwelle — und gab nichts zurück. Der Aufrufer löschte
+     danach das Job-Dokument mitsamt dem einzigen Verweis auf die Datei.
+     Gemessen: 11 solcher Fehlschläge in 30 Tagen, alle unbemerkt. */
+  test("ein echter Löschfehler gibt false zurück UND meldet mit severity ERROR", async () => {
+    const pfad = await storage.storeImage(Buffer.from("x"), "image/jpeg");
+    const echterFehler = new Error("permission denied");
+    echterFehler.code = 403;
+    jest.spyOn(bucket, "file").mockReturnValue({
+      async delete() {
+        throw echterFehler;
+      },
+    });
+    const fehlerSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(storage.deleteImage(pfad)).resolves.toBe(false);
+
+    expect(fehlerSpy).toHaveBeenCalledTimes(1);
+    const zeile = JSON.parse(fehlerSpy.mock.calls[0][0]);
+    expect(zeile.severity).toBe("ERROR");
+    expect(zeile.error).toBe("queue-image-delete-failed");
+    expect(zeile.path).toBe(pfad);
+    fehlerSpy.mockRestore();
   });
 });
 
@@ -114,7 +148,8 @@ describe("Lokal-Modus (QUEUE_LOCAL=1, Emulator)", () => {
     await expect(storage.loadImage(objectPath)).rejects.toBeDefined();
   });
 
-  test("deleteImage auf eine fehlende Datei wirft nicht", async () => {
-    await expect(storage.deleteImage("queue-uploads/gibt-es-nicht.jpg")).resolves.toBeUndefined();
+  test("deleteImage auf eine fehlende Datei wirft nicht und gilt als erfolgreich", async () => {
+    /* Im Lokal-Modus meldet fs.unlink ENOENT — wie GCS' 404 der Normalfall. */
+    await expect(storage.deleteImage("queue-uploads/gibt-es-nicht.jpg")).resolves.toBe(true);
   });
 });

--- a/functions/src/auth.js
+++ b/functions/src/auth.js
@@ -17,10 +17,7 @@ const ZWECK_TOKEN = "token";
 const ZWECK_NONCE = "nonce";
 
 function signiere(zweck, action, expires, secret) {
-  return crypto
-    .createHmac("sha256", secret)
-    .update(`${zweck}.${action}.${expires}`)
-    .digest("hex");
+  return crypto.createHmac("sha256", secret).update(`${zweck}.${action}.${expires}`).digest("hex");
 }
 
 function createAdminToken(action, secret, ttlMs = DEFAULT_TTL_MS, zweck = ZWECK_TOKEN) {

--- a/functions/src/auth.js
+++ b/functions/src/auth.js
@@ -7,18 +7,32 @@ const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 Minuten
  * Format: {expires}.{signature}
  * Der Token ist an eine bestimmte Action gebunden (z.B. "boost", "reset").
  */
-function createAdminToken(action, secret, ttlMs = DEFAULT_TTL_MS) {
+/* AUDIT-BEFUND SEC-2026-08-12-17: Token und Nonce trugen dieselbe Nutzlast
+   (`${action}.${expires}`) und waren damit kryptografisch nicht unterscheidbar.
+   Ein 30-Minuten-Token aus der ntfy-Push-URL liess sich deshalb im Nonce-Feld
+   einsetzen und die Bestaetigungsseite (SEC-001) ueberspringen. Die Nutzlast
+   traegt jetzt den Verwendungszweck; ein Token fuer den einen Zweck ist fuer den
+   anderen ungueltig. */
+const ZWECK_TOKEN = "token";
+const ZWECK_NONCE = "nonce";
+
+function signiere(zweck, action, expires, secret) {
+  return crypto
+    .createHmac("sha256", secret)
+    .update(`${zweck}.${action}.${expires}`)
+    .digest("hex");
+}
+
+function createAdminToken(action, secret, ttlMs = DEFAULT_TTL_MS, zweck = ZWECK_TOKEN) {
   const expires = Date.now() + ttlMs;
-  const payload = `${action}.${expires}`;
-  const signature = crypto.createHmac("sha256", secret).update(payload).digest("hex");
-  return `${expires}.${signature}`;
+  return `${expires}.${signiere(zweck, action, expires, secret)}`;
 }
 
 /**
  * Validiert einen HMAC-signierten Admin-Token.
  * Prueft: Format, Ablaufzeit, Action-Bindung, Signatur (timing-safe).
  */
-function verifyAdminToken(token, action, secret) {
+function verifyAdminToken(token, action, secret, zweck = ZWECK_TOKEN) {
   if (!token || typeof token !== "string") return false;
 
   const dotIndex = token.indexOf(".");
@@ -30,8 +44,7 @@ function verifyAdminToken(token, action, secret) {
   const expires = Number(expiresStr);
   if (isNaN(expires) || Date.now() >= expires) return false;
 
-  const payload = `${action}.${expiresStr}`;
-  const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+  const expected = signiere(zweck, action, expiresStr, secret);
 
   if (signature.length !== expected.length) return false;
   return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
@@ -44,14 +57,14 @@ const NONCE_TTL_MS = 5 * 60 * 1000; // 5 Minuten
  * Format: {expires}.{signature} — wie ein Token, aber mit 5 Min TTL.
  */
 function createNonce(action, secret) {
-  return createAdminToken(action, secret, NONCE_TTL_MS);
+  return createAdminToken(action, secret, NONCE_TTL_MS, ZWECK_NONCE);
 }
 
 /**
  * Validiert eine Nonce. Wrapper um verifyAdminToken.
  */
 function verifyNonce(nonce, action, secret) {
-  return verifyAdminToken(nonce, action, secret);
+  return verifyAdminToken(nonce, action, secret, ZWECK_NONCE);
 }
 
 /**

--- a/functions/src/counter.js
+++ b/functions/src/counter.js
@@ -281,9 +281,49 @@ async function getStats() {
  * Erhöht das Limit um den angegebenen Betrag (Admin-Funktion, für ntfy-Buttons).
  * Wenn der aktuelle Count unter dem neuen Limit liegt, ist das System sofort frei.
  */
+/* AUDIT-BEFUND SEC-2026-08-12-17: `FieldValue.increment` ohne Obergrenze. Wer den
+   Boost-Link einmal sah (er steht im Klartext in der ntfy-Mitteilung), konnte 30
+   Minuten lang beliebig oft anheben und die einzige globale Kostenbremse damit
+   praktisch abschalten. Der Deckel begrenzt den Schaden auf das Doppelte des
+   regulaeren Stundenlimits — genug fuer den gedachten Zweck (eine Schulklasse
+   mehr), zu wenig fuer eine Kostenlawine. */
+const BOOST_OBERGRENZE = 2 * HOURLY_LIMIT;
+
 async function boostLimit(amount = 100) {
   const db = datenbank();
   const ref = db.doc(CURRENT_DOC);
+  /* Fail-closed: Wer die aktuelle Grenze nicht lesen kann, darf sie nicht anheben.
+     Eine Kostenbremse, die im Zweifel oeffnet, ist keine. */
+  let snap;
+  try {
+    snap = await ref.get();
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        severity: "ERROR",
+        error: "boost-limit-nicht-lesbar",
+        message: err && err.message,
+        hinweis: "Boost abgelehnt, weil die aktuelle Grenze nicht gelesen werden konnte.",
+      })
+    );
+    return { limit: null, abgelehnt: true };
+  }
+  const daten = snap && snap.exists ? snap.data() : null;
+  const aktuell = Number((daten && daten.limit) || HOURLY_LIMIT);
+  const gewuenscht = aktuell + amount;
+  if (gewuenscht > BOOST_OBERGRENZE) {
+    console.error(
+      JSON.stringify({
+        severity: "ERROR",
+        error: "boost-obergrenze-erreicht",
+        aktuell,
+        angefragt: gewuenscht,
+        obergrenze: BOOST_OBERGRENZE,
+        hinweis: "Boost abgelehnt. Haeufige Ablehnungen koennen auf einen abgeflossenen Boost-Link hindeuten.",
+      })
+    );
+    return { limit: aktuell, abgelehnt: true };
+  }
   await ref.set({ limit: FieldValue.increment(amount) }, { merge: true });
 }
 

--- a/functions/src/handle-erinnerung.js
+++ b/functions/src/handle-erinnerung.js
@@ -21,10 +21,15 @@
  * und nie den Fehleralarm ausloesen (kein severity ERROR).
  */
 
+const { datenbank } = require("./db");
 const { SITE_URL } = require("./domains");
 const { leseZdrPruefdatum, bewerteFrist, formatiereDatum, FRIST_TAGE } = require("./zusagen");
 
 const MISTRAL_DATENSCHUTZ_URL = "https://admin.mistral.ai/plateforme/privacy";
+/* OPS-2026-08-12-11: Ablageort des Lebenszeichens. Bewusst neben den uebrigen
+   Betriebsdaten und nicht in `jobs` — dort greift seit ARCH-2026-08-12-27 eine
+   automatische Loeschregel. */
+const LEBENSZEICHEN_DOC = "config/erinnerung";
 const ABRUF_TIMEOUT_MS = 8000;
 
 /** Baut den Meldungstext — inklusive der drei Schritte in der richtigen Reihenfolge. */
@@ -122,7 +127,28 @@ async function pruefeZusagen({ ntfyUrl, ntfyTopic, abruf = fetch, jetzt = Date.n
   } catch (err) {
     console.log(JSON.stringify({ warning: "erinnerung-fehler", error: err.message }));
     return { gesendet: false, grund: "fehler" };
+  } finally {
+    /* AUDIT-BEFUND OPS-2026-08-12-11: Diese Funktion schweigt in JEDEM Fehlerfall
+       — bewusst, damit sie nicht den Fehleralarm ausloest (RUNBOOK). Die Folge
+       war aber, dass eine tote und eine gesunde Erinnerung 180 Tage lang
+       ununterscheidbar sind: Bis zum ersten faelligen Push ist Schweigen das
+       korrekte Verhalten. Deshalb hinterlaesst jeder Lauf ein Lebenszeichen.
+       Wer darauf schaut, ist der Reaper (handle-reap.js) — er laeuft jede Minute
+       und steht in der Alarmrichtlinie. Ein ausbleibendes Lebenszeichen wird so
+       laut, ohne dass die Erinnerung selbst laut werden muss. */
+    await schreibeLebenszeichen();
   }
 }
 
-module.exports = { pruefeZusagen, baueMeldung };
+/* Lebenszeichen: ein einziges Feld, kein Personenbezug, keine Nutzdaten. */
+async function schreibeLebenszeichen() {
+  try {
+    await datenbank().doc(LEBENSZEICHEN_DOC).set({ letzterLauf: Date.now() }, { merge: true });
+  } catch (err) {
+    /* Schlaegt selbst das fehl, ist der Lauf ohnehin gestoert — und der Reaper
+       meldet das ausbleibende Lebenszeichen wenig spaeter. */
+    console.log(JSON.stringify({ warning: "erinnerung-lebenszeichen-fehlgeschlagen", error: err.message }));
+  }
+}
+
+module.exports = { pruefeZusagen, baueMeldung, schreibeLebenszeichen, LEBENSZEICHEN_DOC };

--- a/functions/src/handle-reap.js
+++ b/functions/src/handle-reap.js
@@ -39,6 +39,7 @@ const {
   failJob,
   deleteJob,
 } = require("./jobs");
+const { datenbank } = require("./db");
 const { deleteImage } = require("./queue-storage");
 const { releaseHourlySlot } = require("./counter");
 
@@ -106,7 +107,12 @@ async function reapJobs() {
   let reapedZugestellt = 0;
   for (const job of zugestellt) {
     try {
-      if (job.imagePath) await deleteImage(job.imagePath);
+      /* PRIV-2026-08-12-26: Erst loeschen, dann pruefen. Scheitert die Bild-
+         loeschung, bleibt das Job-Dokument mit seinem `imagePath` stehen — sonst
+         verschwindet der einzige Verweis auf die Datei und niemand kann sie je
+         wieder finden. Der naechste Reaper-Lauf versucht es erneut; spaetestens
+         Zweig (3) raeumt das Dokument nach 2 h ab. */
+      if (job.imagePath && !(await deleteImage(job.imagePath))) continue;
       await deleteJob(job.id);
       reapedZugestellt += 1;
     } catch (err) {
@@ -131,7 +137,24 @@ async function reapJobs() {
          Loeschung — und Zweig (2) sucht nur nach `processing`, findet ihn also
          nie wieder. Deckelt die Verweildauer auf 2 h statt auf die
          Lifecycle-Regel (1 Tag). */
-      if (job.imagePath) await deleteImage(job.imagePath);
+      /* PRIV-2026-08-12-26: Auch hier erst pruefen. Anders als in Zweig (2c)
+         wird das Dokument hier trotzdem geloescht, wenn die Bildloeschung
+         dauerhaft scheitert — sonst sammelten sich abgelaufene Dokumente mit
+         Nutzerdaten unbegrenzt an, und das waere der schwerere Verstoss. Der
+         Fehlschlag ist dank deleteImage laut (severity ERROR) und faellt damit
+         in die Alarmrichtlinie. */
+      const bildWeg = job.imagePath ? await deleteImage(job.imagePath) : true;
+      if (!bildWeg) {
+        console.error(
+          JSON.stringify({
+            severity: "ERROR",
+            error: "reap-bild-blieb-liegen",
+            jobId: job.id,
+            path: job.imagePath,
+            hinweis: "Dokument wird trotzdem geraeumt; das Bild faellt auf die Lifecycle-Regel zurueck.",
+          })
+        );
+      }
       await deleteJob(job.id);
       reapedExpired += 1;
     } catch (err) {
@@ -140,6 +163,16 @@ async function reapJobs() {
       );
     }
   }
+
+  /* AUDIT-BEFUND OPS-2026-08-12-11: Waechter ueber die Wochen-Erinnerung.
+     Die Erinnerung laeuft montags und schweigt in jedem Fehlerfall — bis zum
+     ersten faelligen Push (2027-02) waere ihr Ausfall 180 Tage lang nicht von
+     korrektem Verhalten zu unterscheiden. Sie hinterlaesst deshalb bei jedem
+     Lauf ein Lebenszeichen; hier wird es gelesen. Der Reaper eignet sich dafuer,
+     weil er jede Minute laeuft und in der Alarmrichtlinie steht — anders als die
+     Erinnerung selbst, die bewusst leise bleibt.
+     Schwelle 9 Tage: ein ausgefallener Montag allein loest noch nichts aus. */
+  await pruefeErinnerungsLebenszeichen();
 
   console.log(
     JSON.stringify({
@@ -161,3 +194,33 @@ async function reapJobs() {
 }
 
 module.exports = { reapJobs };
+
+/* Liest das Lebenszeichen der Wochen-Erinnerung und meldet laut, wenn es fehlt
+   oder veraltet ist (OPS-2026-08-12-11). */
+const LEBENSZEICHEN_DOC = "config/erinnerung";
+const LEBENSZEICHEN_MAX_ALTER_MS = 9 * 24 * 60 * 60 * 1000;
+
+async function pruefeErinnerungsLebenszeichen() {
+  try {
+    const snap = await datenbank().doc(LEBENSZEICHEN_DOC).get();
+    const letzterLauf = snap.exists && snap.data() ? Number(snap.data().letzterLauf) : 0;
+    if (!letzterLauf) return; /* Noch nie gelaufen — vor dem ersten Montag normal. */
+    const alter = Date.now() - letzterLauf;
+    if (alter <= LEBENSZEICHEN_MAX_ALTER_MS) return;
+    console.error(
+      JSON.stringify({
+        severity: "ERROR",
+        error: "erinnerung-lebenszeichen-veraltet",
+        letzterLauf: new Date(letzterLauf).toISOString(),
+        alterTage: Math.floor(alter / (24 * 60 * 60 * 1000)),
+        hinweis:
+          "Die Wochen-Erinnerung hat seit ueber neun Tagen nicht gelaufen. Sie meldet " +
+          "ihren eigenen Ausfall bewusst nicht — deshalb diese Meldung. Zeitplan und " +
+          "Function pruefen (RUNBOOK).",
+      })
+    );
+  } catch (err) {
+    /* Nicht lesbar ist nicht dasselbe wie veraltet — kein Fehlalarm. */
+    console.log(JSON.stringify({ warning: "lebenszeichen-nicht-lesbar", error: err.message }));
+  }
+}

--- a/functions/src/jobs.js
+++ b/functions/src/jobs.js
@@ -23,8 +23,15 @@
  * vergleichbar, konsistent mit counter.js, kein FieldValue nötig.
  */
 
+const { Timestamp } = require("firebase-admin/firestore");
 const { datenbank } = require("./db");
 const { LIVENESS_GRACE_MS, JOB_RETENTION_MS, ZUSTELLUNG_AUFBEWAHRUNG_MS } = require("./config");
+
+/* ARCH-2026-08-12-27: Frist des Sicherheitsnetzes (Firestore-TTL). Bewusst weit
+   ueber JOB_RETENTION_MS (2 h): Der Reaper ist die Loeschung, die TTL faengt nur
+   seinen Ausfall ab. Ein knapper Wert wuerde laufende Jobs mitten im Betrieb
+   loeschen — genau die Gefahr, die diese Massnahme nicht schaffen darf. */
+const TTL_NETZ_MS = 24 * 60 * 60 * 1000;
 
 const JOBS_COLLECTION = "jobs";
 
@@ -60,6 +67,16 @@ async function createJob({ lang, traceId, imagePath, exif, resultToken }) {
   await ref.set({
     status: "queued",
     createdAt: now,
+    /* ARCH-2026-08-12-27: Sicherheitsnetz UNTER dem Reaper. Der Reaper räumt
+       Job-Dokumente nach JOB_RETENTION_MS (2 h) ab — er ist die eigentliche
+       Löschung. Steht er still (pausierter Zeitplan, verlorene Berechtigung),
+       gab es bisher nichts darunter: Dokumente mit fertigen Profilen wären
+       unbegrenzt liegengeblieben, zugesagt sind "spätestens rund 2 Stunden".
+       Firestore löscht Dokumente automatisch, sobald dieses Zeitstempel-Feld
+       in der Vergangenheit liegt. Bewusst DEUTLICH später als der Reaper
+       (24 h statt 2 h): Das Netz soll fangen, wenn der Reaper ausfällt, und ihm
+       nicht ins Handwerk pfuschen, solange er läuft. */
+    expiresAt: Timestamp.fromMillis(now + TTL_NETZ_MS),
     lastSeenAt: now,
     startedAt: null,
     finishedAt: null,

--- a/functions/src/queue-storage.js
+++ b/functions/src/queue-storage.js
@@ -105,20 +105,46 @@ async function loadImage(objectPath) {
 }
 
 /**
- * Löscht ein Bild. Ein bereits gelöschtes / nie existentes Objekt ist KEIN
- * harter Fehler — die Lifecycle-Regel räumt ohnehin nach. Der Aufrufer
- * (processJob) soll deshalb nie an einer fehlgeschlagenen Löschung scheitern.
+ * Löscht ein Bild und meldet, OB es geklappt hat.
+ *
+ * Rückgabe: true = gelöscht oder war schon weg, false = Löschung gescheitert.
+ *
+ * AUDIT-BEFUND PRIV-2026-08-12-26 / OPS-2026-08-12-10: Bisher verschluckte diese
+ * Funktion jeden Fehler in eine `console.log`-Zeile ohne severity — also unterhalb
+ * der Alarmschwelle — und gab nichts zurück. Der Aufrufer löschte danach das
+ * Job-Dokument, und mit ihm den einzigen Verweis auf die Datei: Nach einem
+ * Fehlschlag kannte niemand mehr den Pfad. Gemessen: 11 solcher Fehlschläge in
+ * 30 Tagen. Die Zusage lautet "unmittelbar gelöscht"; das 1-Tages-Netz der
+ * Lifecycle-Regel steht in keinem Außentext.
+ *
+ * Ein bereits gelöschtes Objekt (404) bleibt KEIN Fehler — das ist der Normalfall,
+ * wenn der Worker schon aufgeräumt hat. Alles andere ist einer und wird laut.
  */
 async function deleteImage(objectPath) {
-  if (!objectPath) return;
+  if (!objectPath) return true;
   try {
     if (isLocalQueueMode()) {
       await fs.promises.unlink(localPathFor(objectPath));
-      return;
+      return true;
     }
     await bucket().file(objectPath).delete();
+    return true;
   } catch (err) {
-    console.log(JSON.stringify({ warning: "queue-image-delete-failed", path: objectPath, error: err.message }));
+    /* 404 = schon weg. Kein Fehler, keine Meldung. */
+    if (err && (err.code === 404 || err.code === "ENOENT")) return true;
+    console.error(
+      JSON.stringify({
+        severity: "ERROR",
+        error: "queue-image-delete-failed",
+        path: objectPath,
+        message: err && err.message,
+        hinweis:
+          "Bild konnte nicht aktiv geloescht werden. Es faellt jetzt auf die " +
+          "Lifecycle-Regel (1 Tag) zurueck — die Zusage 'unmittelbar geloescht' " +
+          "ist fuer dieses Bild nicht eingehalten.",
+      })
+    );
+    return false;
   }
 }
 


### PR DESCRIPTION
Zweite Welle aus dem TIEF-Audit. Vier P2, alle mit Rückbauprobe.

| Befund | Kern | Verifikation |
|---|---|---|
| **PRIV-26 + OPS-10** | `deleteImage` verschluckte jeden Fehler und warf danach den einzigen Verweis auf die Datei weg. **11 Fehlschläge in 30 Tagen, alle unbemerkt.** | Löschfehler → `false` + `severity: ERROR`; Rückbau → 3 Tests fallen |
| **ARCH-27** | Kein zweites Netz für Job-Dokumente mit fertigen Profilen | Löschregel `jobs/expiresAt` **ACTIVE**; Test prüft den Abstand zur Reaper-Frist |
| **SEC-17** | Nonce und 30-Minuten-Token waren kryptografisch dasselbe; Boost ohne Obergrenze | 5 Tests: Token gilt nicht als Nonce, Nonce nicht als Token, Deckel, fail-closed |
| **OPS-11** | Die Erinnerung schwieg in jedem Fehlerfall — **180 Tage** bis ihr Ausfall aufgefallen wäre | Lebenszeichen + Wächter im Reaper; 3 Tests; CI bekommt einen wöchentlichen Zeitplan |

## Zwei Entscheidungen im Detail

**Warum das Netz bei 24 Stunden liegt und nicht bei 2:** Der Reaper ist die Löschung, die
Regel fängt nur seinen Ausfall. Eine knapp gesetzte Regel würde laufende Jobs mitten im
Betrieb löschen — die Maßnahme wäre dann gefährlicher als der Befund. Eingerichtet, während
die Sammlung nachweislich **0 Dokumente** hatte.

**Warum der Reaper der Wächter ist:** Er läuft jede Minute und steht in der
Alarmrichtlinie. Die Erinnerung selbst bleibt bewusst leise — diese Entscheidung steht im
RUNBOOK und wird nicht angetastet. Ein Wächter von außen löst das, ohne sie umzubauen.

## Beweise

| Befehl | Ergebnis |
|---|---|
| `npm test --prefix functions` | 769 passed, 1 skipped |
| `npm run test:frontend` | 315/315 |
| `npm run test:e2e` | 18/18, Exit 0 |
| `gcloud firestore fields ttls list` | `jobs/expiresAt ACTIVE` |

RUNBOOK um zwei Rezepte ergänzt: Löschregel (inkl. Rückweg) und Lebenszeichen-Prüfung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)