### PR TITLE
chore: Versionsstempel v3.0.9 (nach dem Functions-Deploy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [3.0.9] — 2026-08-12
 
 **Audit-Sanierung, Welle 2 — die Löschkette meldet ihr Scheitern, und die stille
 Erinnerung bekommt einen Wächter:**


### PR DESCRIPTION
Stempel **nach** dem Deployment. Nur `functions` ausgeliefert — Welle 2 berührt keine Datei unter `public/`, deshalb kein Hosting-Deploy und bewusst **kein** neuer Cache-Buster.

| Beweis | Ergebnis |
|---|---|
| Riegel vor dem Deploy | 769 passed, 1 skipped · Infrastruktur grün |
| Live-Smoke danach | vier Proben grün |
| Reaper mit neuem Code | Logzeilen im Minutentakt |
| Neuer Wächter | **keine** Meldung `erinnerung-lebenszeichen-veraltet` — korrekt, die Erinnerung ist vor dem ersten Montag nie gelaufen |
| Löschregel | `jobs/expiresAt` ACTIVE |

🤖 Generated with [Claude Code](https://claude.com/claude-code)