### PR TITLE
fix(audit): OPS-09 — Wächter über den Alarmweg im Deploy-Riegel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   `enforce_admins: true` blockiert ein wackliger Pflicht-Check jeden Merge, auch den
   eigenen. Ist-Zustand und Rückweg stehen im RUNBOOK.
 
+- **Der Alarmweg hatte keinen Wächter** (`OPS-2026-08-12-09`, P2). Die Richtlinie ist eine
+  Anwesenheits-Bedingung: Ihr eigener Ausfall erzeugt keine Logzeile, ein toter Alarm sieht
+  aus wie „keine Störung". Der Deploy-Riegel prüft jetzt vier Ausfallarten — Richtlinie
+  fehlt, ist aus, hat keinen Kanal, Kanal abgeschaltet. Die Grenze steht ehrlich dabei:
+  Das greift beim Deploy, nicht in der Minute des Ausfalls; der Rest ist als Restrisiko
+  in `docs/SECURITY-MODEL.md` festgehalten.
+
 ## [3.0.9] — 2026-08-12
 
 **Audit-Sanierung, Welle 2 — die Löschkette meldet ihr Scheitern, und die stille

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -106,6 +106,20 @@ Reihenfolge**:
 Das Datum **niemals** ohne echte Prüfung hochsetzen — dann behauptet die
 Webseite etwas Unbelegtes, und genau davor schützt der Wächter.
 
+## Wächter über den Alarmweg (seit 2026-08-12)
+
+`scripts/verify-infrastructure.sh` prüft seit OPS-2026-08-12-09 vor jedem Deploy mit:
+Gibt es noch eine Richtlinie mit `severity>=ERROR`, ist sie scharf, hat sie
+Benachrichtigungskanäle, und sind die Kanäle eingeschaltet? Vier Ausfallarten führen zu
+rot: Richtlinie fehlt, Richtlinie aus, kein Kanal, Kanal abgeschaltet — dazu „nicht
+geprüft" bei einer gescheiterten Messung.
+
+**Grenze dieser Maßnahme, ausdrücklich:** Sie greift zur Deploy-Zeit, nicht in der Minute
+des Ausfalls. Zwischen zwei Deploys kann der Alarmweg tot sein, ohne dass es auffällt. Ein
+laufender Wächter müsste außerhalb dieses Projekts sitzen (der Alarm kann sich nicht
+selbst überwachen) — das bleibt ein benanntes Restrisiko. Eine Zustellprobe von Hand
+steht in `docs/ERROR-ALERTING.md`.
+
 ## Branch Protection auf `main` (Stand 2026-08-12)
 
 Soll-Zustand, auslesbar:

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -103,3 +103,22 @@ muss die Begründung entkräften, nicht nur das Risiko benennen.
 Dieses Dokument wird bei jedem LANGAUDIT und vor jeder Presse-Welle
 gegengelesen. Neue bewusste Abwägungen gehören **hier** hinein — im selben
 Commit wie die Entscheidung.
+
+## Restrisiko: Der Alarmweg kann sich nicht selbst überwachen (seit 2026-08-12)
+
+**Entscheidung.** Der Fehler-Alarm (Log-Richtlinie → E-Mail + ntfy-Push) wird beim Deploy
+auf Existenz, Schärfe und zustellfähige Kanäle geprüft (`verify-infrastructure.sh`), aber
+nicht laufend.
+
+**Begründung.** Die Richtlinie ist eine Anwesenheits-Bedingung auf `severity>=ERROR`: Ihr
+eigener Ausfall erzeugt keine Logzeile, auf die sie feuern könnte. Ein laufender Wächter
+müsste außerhalb des Projekts sitzen und wäre selbst wieder unbewacht — die Kette hat kein
+Ende, nur einen Punkt, an dem man sie abschneidet.
+
+**Betrachtete Alternative.** Den ntfy-Dienst in den Alarmfilter aufnehmen. Verworfen: Der
+Alarm alarmierte dann über sich selbst, und die Störung vom 2026-08-10 (CPU-Drosselung)
+wurde von ntfy mit `severity DEFAULT` geschrieben — sie wäre selbst im Filter nie über die
+Schwelle gekommen.
+
+**Bedingung für Neubewertung.** Sobald das Projekt einen zweiten Betreuer hat (Bus-Faktor
+> 1) oder ein externer Verfügbarkeitsdienst ohnehin läuft, gehört der Alarmweg dorthin.

--- a/functions/src/__tests__/verify-infrastructure-script.test.js
+++ b/functions/src/__tests__/verify-infrastructure-script.test.js
@@ -26,6 +26,9 @@ const ERLAUBTE_LESE_MUSTER = [
   /gcloud (tasks queues|storage buckets|firestore databases|functions|run services|logging sinks) (describe|list|get-iam-policy)\b/,
   /gcloud auth list\b/,
   /command -v gcloud/,
+  /* OPS-2026-08-12-09: Waechter ueber den Alarmweg. Beides reine list-Abfragen —
+     `policies list` und `channels list` lesen nur, sie schalten nichts. */
+  /gcloud alpha monitoring (policies|channels) list\b/,
 ];
 
 function gcloudZeilen(inhalt) {

--- a/scripts/verify-infrastructure.sh
+++ b/scripts/verify-infrastructure.sh
@@ -182,6 +182,70 @@ case " $(printf "%s" "$SINKS" | tr '\n' ' ') " in
   *) rot "Diagnose-Sink »client-diagnostics-sink« fehlt" ;;
 esac
 
+# ── 7. Alarmweg: existiert er noch, ist er scharf, hat er zustellfähige Kanäle? ──
+# AUDIT-BEFUND OPS-2026-08-12-09: Der Alarmweg hatte keinen Wächter. Die Richtlinie
+# ist eine Anwesenheits-Bedingung auf severity>=ERROR — ihr EIGENER Ausfall erzeugt
+# keine Logzeile. Wird sie deaktiviert, ihr Filter verstellt oder ein Kanal
+# gelöscht, sieht das exakt aus wie „keine Störung": Stille. Bei Bus-Faktor 1 ist
+# das der Unterschied zwischen „ich erfahre es" und „ich erfahre es nie".
+# Diese Prüfung ist deploy-zeitlich, nicht laufend — sie fängt den Fall beim
+# nächsten Deploy, nicht in der Minute des Ausfalls. Das ist die Grenze dieser
+# Maßnahme und steht so im RUNBOOK.
+echo "— Alarmweg"
+POLICY_JSON=$(gcloud alpha monitoring policies list --project="$PROJECT" --format=json 2>&1) || POLICY_JSON=""
+ALARM=$(printf '%s' "$POLICY_JSON" | python3 -c '
+import json, sys
+try:
+    daten = json.load(sys.stdin)
+except Exception:
+    print("MESSFEHLER:Antwort nicht lesbar"); raise SystemExit(0)
+if not isinstance(daten, list) or not daten:
+    print("MESSFEHLER:keine Richtlinie in der Antwort"); raise SystemExit(0)
+for pol in daten:
+    filter_text = " ".join(
+        (b.get("conditionMatchedLog") or {}).get("filter", "") for b in pol.get("conditions", [])
+    )
+    if "severity>=ERROR" not in filter_text.replace(" ", ""):
+        continue
+    if not pol.get("enabled", False):
+        print("AUS:" + pol.get("displayName", "?")); raise SystemExit(0)
+    kanaele = pol.get("notificationChannels", [])
+    if not kanaele:
+        print("OHNE_KANAL:" + pol.get("displayName", "?")); raise SystemExit(0)
+    print("OK:%s:%d" % (pol.get("displayName", "?"), len(kanaele))); raise SystemExit(0)
+print("FEHLT:keine Richtlinie mit severity>=ERROR")
+' 2>/dev/null)
+
+case "$ALARM" in
+  OK:*)         gruen "Fehler-Alarm scharf: »$(printf '%s' "${ALARM#OK:}" | cut -d: -f1)«, $(printf '%s' "$ALARM" | rev | cut -d: -f1 | rev) Kanal/Kanäle" ;;
+  AUS:*)        rot   "Fehler-Alarm ist DEAKTIVIERT: ${ALARM#AUS:}" ;;
+  OHNE_KANAL:*) rot   "Fehler-Alarm hat KEINEN Benachrichtigungskanal: ${ALARM#OHNE_KANAL:}" ;;
+  FEHLT:*)      rot   "Kein Fehler-Alarm gefunden — eine Stoerung wuerde niemanden erreichen" ;;
+  MESSFEHLER:*) rot   "Alarmweg NICHT geprueft (${ALARM#MESSFEHLER:}) — ungeprueft gilt als nicht bestanden" ;;
+  *)            rot   "Alarmweg NICHT geprueft (keine auswertbare Ausgabe)" ;;
+esac
+
+# Und die Kanäle selbst: ein Kanal kann verwaist oder abgeschaltet sein.
+KANAL_JSON=$(gcloud alpha monitoring channels list --project="$PROJECT" --format=json 2>&1) || KANAL_JSON=""
+KANAELE=$(printf '%s' "$KANAL_JSON" | python3 -c '
+import json, sys
+try:
+    daten = json.load(sys.stdin)
+except Exception:
+    print("MESSFEHLER"); raise SystemExit(0)
+if not isinstance(daten, list) or not daten:
+    print("MESSFEHLER"); raise SystemExit(0)
+aktiv = [k for k in daten if k.get("enabled")]
+aus = [k.get("displayName", "?") for k in daten if not k.get("enabled")]
+print(("AUS:" + ", ".join(aus)) if aus else "OK:%d" % len(aktiv))
+' 2>/dev/null)
+
+case "$KANAELE" in
+  OK:*)  gruen "Benachrichtigungskanäle aktiv: ${KANAELE#OK:}" ;;
+  AUS:*) rot   "Abgeschaltete Benachrichtigungskanäle: ${KANAELE#AUS:}" ;;
+  *)     rot   "Kanäle NICHT geprueft — ungeprueft gilt als nicht bestanden" ;;
+esac
+
 # ── Ergebnis ──
 echo ""
 echo "Hinweis: Die Zero-Data-Retention-Zusage von Mistral ist VERTRAGLICH und"


### PR DESCRIPTION
Der Alarm kann sich nicht selbst überwachen: Die Richtlinie feuert auf ERROR-Logzeilen, ihr eigener Ausfall erzeugt aber keine. Ein toter Alarmkanal sieht aus wie ein ruhiges System.

`verify-infrastructure.sh` prüft jetzt vor jedem Deploy vier Ausfallarten:

| Fall | Ergebnis |
|---|---|
| Richtlinie fehlt | rot |
| Richtlinie deaktiviert | rot |
| Kein Benachrichtigungskanal | rot |
| Kanal abgeschaltet | rot |
| Messung gescheitert | rot (nicht grün!) |

Echter Lauf: `Fehler-Alarm scharf: »malziME Function Errors«, 2 Kanäle`. Negativprobe für alle vier Fälle durchgeführt.

**Grenze, ausdrücklich benannt:** Das greift zur Deploy-Zeit, nicht in der Minute des Ausfalls. Ein laufender Wächter müsste außerhalb des Projekts sitzen und wäre selbst unbewacht. Als Restrisiko in `docs/SECURITY-MODEL.md` festgehalten, samt der verworfenen Alternative (ntfy in den Filter — der Alarm alarmierte dann über sich selbst, und die Störung vom 10.08. lag ohnehin unter der Schwelle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)