### PR TITLE
chore: Release v3.1.0 — Cache-Buster 2026081204 und Audit-Zusammenfassung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,32 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [3.1.0] — 2026-08-12
 
-**Audit-Sanierung, Welle 2 (Fortsetzung):**
+**Das TIEF-Audit und seine Sanierung.**
+
+Am 12. August lief das erste vollständige TIEF-Audit dieses Projekts: sechs unabhängige
+Prüfer entlang von Prüffragen, ein eigener Widerleger für den schwersten Befund, dazu die
+Regressionsfläche des Vorberichts. Ergebnis: **29 Befunde** — 3 schwere, 14 mittlere,
+12 leichte. Zehn von elf Befunden des vorigen Audits waren belegt behoben.
+
+**Das Muster hinter fast allem:** Nicht das Projekt war kaputt, sondern seine Wächter.
+Vier Prüfungen, die als Riegel gebaut waren, meldeten „in Ordnung", wenn ihre Messung
+gescheitert war — darunter der einzige Riegel gegen Sicherheitslücken in Fremdbibliotheken
+und die Prüfung, die das EU-Versprechen trägt. Dazu kamen Zusagen, die als verbindlich
+beschrieben waren, ohne es zu sein, und eine Löschkette, die ihr eigenes Scheitern nicht
+meldete.
+
+**Der einzige von außen erreichbare Befund:** Ein Aufruf mit falsch geformter Job-Nummer
+brachte eine Funktion zum Absturz; der Absturz löste die Störungsmeldung aus. Ein Fremder
+konnte damit ohne Anmeldung den einzigen Alarmkanal des Projekts unbrauchbar machen —
+beliebig oft. Behoben und live belegt.
+
+Die Sanierung lief in Wellen; `3.0.8` und `3.0.9` waren die ersten beiden. Was seither
+dazukam, steht hier. Der vollständige Bericht liegt unter `docs/audit/` (nicht im
+öffentlichen Repository).
+
+### Welle 2, Fortsetzung — die Riegel greifen wirklich
 
 - **Der Prüfer blockiert jetzt wirklich** (`OPS-2026-08-12-04`, P1). Der Job `pruefungen`
   lief zwar bei jedem Pull-Request, stand aber nicht in der Branch Protection — ein roter
@@ -23,7 +46,7 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   Das greift beim Deploy, nicht in der Minute des Ausfalls; der Rest ist als Restrisiko
   in `docs/SECURITY-MODEL.md` festgehalten.
 
-## [Unveröffentlicht]
+### Welle 3 — Außentexte
 
 **Audit-Sanierung, Welle 3 — vier Sätze, die mehr versprachen als das System hält:**
 

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081203" />
+    <link rel="stylesheet" href="./styles.css?v=2026081204" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -44,7 +44,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081203" />
+    <link rel="stylesheet" href="./styles.css?v=2026081204" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -85,7 +85,7 @@
     <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
     <link rel="preconnect" href="https://nominatim.openstreetmap.org" crossorigin />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081203" />
+    <link rel="stylesheet" href="./styles.css?v=2026081204" />
     <script type="application/ld+json">
 [
   {
@@ -309,15 +309,15 @@
         <p class="demo-label" data-i18n="demo.label">Kein Foto zur Hand? Probier ein Beispielbild (mit KI erstellt):</p>
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
-            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081203" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081204" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.selfie">Selfie am Stephansplatz</span>
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
-            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081203" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081204" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.cafe">Im Caf&eacute; in Salzburg</span>
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
-            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081203" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081204" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.hiker">Wanderung bei Hallstatt</span>
           </button>
         </div>
@@ -373,6 +373,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081203"></script>
+    <script type="module" src="./app.js?v=2026081204"></script>
   </body>
 </html>

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -5,9 +5,9 @@ import { klangAktivieren } from "./klang.js";
 import { t } from "./i18n.js";
 
 const DEMO_IMAGES = {
-  selfie: "./img/demo/demo-selfie.jpg?v=2026081203",
-  cafe: "./img/demo/demo-cafe.jpg?v=2026081203",
-  hiker: "./img/demo/demo-hiker.jpg?v=2026081203",
+  selfie: "./img/demo/demo-selfie.jpg?v=2026081204",
+  cafe: "./img/demo/demo-cafe.jpg?v=2026081204",
+  hiker: "./img/demo/demo-hiker.jpg?v=2026081204",
 };
 
 export function initDemo() {

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081203" />
+    <link rel="stylesheet" href="./styles.css?v=2026081204" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081203" />
+    <link rel="stylesheet" href="./styles.css?v=2026081204" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081203"></script>
+    <script type="module" src="./js/stats.js?v=2026081204"></script>
   </body>
 </html>


### PR DESCRIPTION
Stempel **nach** dem Hosting-Deployment. Der CHANGELOG fasst unter `[3.1.0]` das ganze TIEF-Audit zusammen statt es über Wellen zu zersplittern.

| Beweis | Ergebnis |
|---|---|
| Riegel vor dem Deploy | Infrastruktur grün, inkl. neuem Alarmweg-Wächter |
| Live-Smoke danach | vier Proben grün |
| Kennungsvergleich | live = lokal (`?v=2026081204`) |
| Live-Probe der drei korrigierten Sätze | alle drei in neuer Fassung auf malzi.me/datenschutz |

`3.0.8` und `3.0.9` bleiben als erste zwei Wellen stehen — sie sind ausgeliefert und getaggt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)