### PR TITLE
chore: Stempel v3.1.0 nach dem Deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,9 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [3.1.0] — 2026-08-13
 
 **Das TIEF-Audit und seine Sanierung.**
-
-> Dieser Eintrag bekommt die Nummer `3.1.0`, sobald alle 29 Befunde erledigt sind.
-> Solange er unveröffentlicht ist, ist die Sanierung nicht fertig — die Nummer wird
-> vergeben, wenn sie stimmt, nicht vorher.
 
 Am 12. August lief das erste vollständige TIEF-Audit dieses Projekts: sechs unabhängige
 Prüfer entlang von Prüffragen, ein eigener Widerleger für den schwersten Befund, dazu die
@@ -29,12 +25,11 @@ brachte eine Funktion zum Absturz; der Absturz löste die Störungsmeldung aus. 
 konnte damit ohne Anmeldung den einzigen Alarmkanal des Projekts unbrauchbar machen —
 beliebig oft. Behoben und live belegt.
 
-Vorlauf und Sanierung stehen hier vollständig an einer Stelle. `3.0.7`, `3.0.8` und
-`3.0.9` waren Zwischen-Auslieferungen derselben Arbeit — sie tragen Tags, weil sie
-tatsächlich deployt wurden, aber ihr Inhalt steht hier. Der vollständige Auditbericht mit
-allen 29 Befunden liegt unter `docs/audit/` (bewusst nicht im öffentlichen Repository).
+Vorlauf und Sanierung stehen hier vollständig an einer Stelle. Der vollständige
+Auditbericht mit allen 29 Befunden liegt unter `docs/audit/` (bewusst nicht im
+öffentlichen Repository).
 
-### Vorlauf — die Sperrliste für Außentexte (ausgeliefert als `3.0.7`)
+### Vorlauf — die Sperrliste für Außentexte
 
 Der Anlass für das Audit. Eine Regel, die seit Monaten in `CONTRIBUTING.md` steht, war an
 fünf Stellen verletzt — sie stand eben nur als Prosa da und lief nirgends als Prüfung.
@@ -264,7 +259,7 @@ fünf Stellen verletzt — sie stand eben nur als Prosa da und lief nirgends als
   vergleicht jeden dort genannten Job mit denen, die es wirklich gibt. Die Probenzahl
   steht nur noch an einer Stelle und wird gezählt statt geschrieben.
 
-**Zwei neue Funde, die erst die Sanierung zutage gefördert hat:**
+**Drei neue Funde, die erst die Sanierung zutage gefördert hat:**
 
 - **Der Release-Wächter konnte den Tag einer bereits ausgelieferten Version umhängen**
   (`OPS-2026-08-12-30`, P2). Er suchte die „oberste Version" mit einem Zahlenmuster.
@@ -278,6 +273,14 @@ fünf Stellen verletzt — sie stand eben nur als Prosa da und lief nirgends als
   jetzt in einem eigenen Skript und entscheidet nach der obersten Überschrift, gleich
   welcher Art. Neun Tests, darunter ein Rückfall-Wächter und ein Lauf gegen das echte
   CHANGELOG.
+- **Der Prüfstand-Stempler starb wortlos** (`OPS-2026-08-13-32`, P3). Er liest die
+  Testzahlen aus der Ausgabe der Suiten. Seit ein Test bewusst übersprungen wird, lautet
+  die Zeile „1 übersprungen, 795 bestanden" — sein Muster erwartete die Zahl unmittelbar
+  hinter „Tests:" und griff nicht mehr. Seine eigene Plausibilitätsprüfung hätte genau
+  das melden sollen, wurde aber nie erreicht: Eine leere Suche beendet unter den strengen
+  Shell-Einstellungen das ganze Skript sofort. Ergebnis: Abbruch ohne ein Wort. Behoben —
+  und der übersprungene Test wird jetzt ausgewiesen statt weggerechnet („795/796 grün,
+  1 übersprungen").
 - **Ein E2E-Test scheitert selten — und sagt beim Scheitern nicht, woran**
   (`TEST-2026-08-13-31`, P3). Im vollen Lauf fiel „Beast Mode überlebt ein Neuladen"
   einmal durch, in drei Einzelläufen danach nicht wieder. Die Meldung lautete, ein
@@ -289,22 +292,8 @@ fünf Stellen verletzt — sie stand eben nur als Prosa da und lief nirgends als
   überhaupt da ist. Beim nächsten Auftreten steht die Ursache in der Meldung, statt eine
   Stunde zu kosten.
 
-## [3.0.9] — 2026-08-12
-
-Zwischen-Auslieferung der Audit-Sanierung (Welle 2). Der vollständige Eintrag steht im
-Abschnitt „Das TIEF-Audit und seine Sanierung" ganz oben.
 
 
-## [3.0.8] — 2026-08-12
-
-Zwischen-Auslieferung der Audit-Sanierung (Welle 1). Der vollständige Eintrag steht im
-Abschnitt „Das TIEF-Audit und seine Sanierung" ganz oben.
-
-
-## [3.0.7] — 2026-08-12
-
-Sperrliste für Außentexte — der Vorlauf zum Audit. Der vollständige Eintrag steht im
-Abschnitt „Das TIEF-Audit und seine Sanierung" ganz oben.
 
 ## [3.0.6] — 2026-08-12
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 734/734 grün — `scripts/pruefstand.sh`, Commit 626cb70, 2026-08-12 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 315/315 grün — `scripts/pruefstand.sh`, Commit 626cb70, 2026-08-12 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 18/18 grün — `scripts/pruefstand.sh`, Commit 626cb70, 2026-08-12 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 795/796 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 5b728c5, 2026-08-13 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 315/315 grün — `scripts/pruefstand.sh`, Commit 5b728c5, 2026-08-13 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 18/18 grün — `scripts/pruefstand.sh`, Commit 5b728c5, 2026-08-13 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `pruefungen`: `node scripts/audit-gate.mjs functions .` — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/scripts/pruefstand.sh
+++ b/scripts/pruefstand.sh
@@ -23,17 +23,29 @@ echo "Prüfstand-Lauf auf Commit $COMMIT ($DATUM) — alle drei Suiten, danach S
 # ── 1. Backend (Jest) ──
 echo "— Backend-Suite läuft…"
 BACKEND_LOG=$(npm test --prefix functions 2>&1) || { echo "$BACKEND_LOG" | tail -20; echo "ABBRUCH: Backend-Suite rot — es wird nichts gestempelt."; exit 1; }
-BACKEND=$(printf "%s" "$BACKEND_LOG" | grep -Eo "Tests:\s+[0-9]+ passed, [0-9]+ total" | grep -Eo "[0-9]+" | head -1)
+# OPS-2026-08-13-32: Zwei Fehler in einer Zeile, beide erst sichtbar, als ein
+# Test bewusst uebersprungen wurde und die Ausgabe "1 skipped, 795 passed,
+# 796 total" lautete:
+#   1. Das Muster verlangte "passed" unmittelbar hinter "Tests:" und traf nicht
+#      mehr.
+#   2. Schwerer: Ohne `|| true` beendet ein leeres grep unter `set -e` und
+#      `pipefail` das ganze Skript SOFORT. Die Plausibilitaetspruefung weiter
+#      unten, die genau diesen Fall melden soll, wurde nie erreicht — der
+#      Stempler starb wortlos mit Exit 1. Ein Werkzeug, das beim Melden eines
+#      Problems selbst verstummt, ist die Ausfallform, gegen die dieses Projekt
+#      ueberall anschreibt.
+BACKEND=$(printf "%s" "$BACKEND_LOG" | grep -E "^Tests:" | grep -Eo "[0-9]+ passed" | grep -Eo "[0-9]+" | head -1 || true)
+BACKEND_GESAMT=$(printf "%s" "$BACKEND_LOG" | grep -E "^Tests:" | grep -Eo "[0-9]+ total" | grep -Eo "[0-9]+" | head -1 || true)
 
 # ── 2. Frontend (Vitest) ──
 echo "— Frontend-Suite läuft…"
 FRONTEND_LOG=$(npm run test:frontend 2>&1) || { echo "$FRONTEND_LOG" | tail -20; echo "ABBRUCH: Frontend-Suite rot — es wird nichts gestempelt."; exit 1; }
-FRONTEND=$(printf "%s" "$FRONTEND_LOG" | grep -Eo "Tests\s+[0-9]+ passed" | grep -Eo "[0-9]+" | head -1)
+FRONTEND=$(printf "%s" "$FRONTEND_LOG" | grep -Eo "Tests\s+[0-9]+ passed" | grep -Eo "[0-9]+" | head -1 || true)
 
 # ── 3. E2E (Playwright) ──
 echo "— E2E-Suite läuft (dauert am längsten)…"
 E2E_LOG=$(npm run test:e2e 2>&1) || { echo "$E2E_LOG" | tail -20; echo "ABBRUCH: E2E-Suite rot — es wird nichts gestempelt."; exit 1; }
-E2E=$(printf "%s" "$E2E_LOG" | grep -Eo "[0-9]+ passed" | grep -Eo "[0-9]+" | tail -1)
+E2E=$(printf "%s" "$E2E_LOG" | grep -Eo "[0-9]+ passed" | grep -Eo "[0-9]+" | tail -1 || true)
 
 # ── Plausibilität: alle drei Zahlen müssen da sein ──
 for WERT in "$BACKEND" "$FRONTEND" "$E2E"; do
@@ -46,7 +58,7 @@ done
 echo "Alle Suiten grün: Backend $BACKEND · Frontend $FRONTEND · E2E $E2E — Stempel wird gesetzt."
 
 # ── Stempeln: nur die Ergebnis-Zelle der drei Suiten-Zeilen ersetzen ──
-BACKEND="$BACKEND" FRONTEND="$FRONTEND" E2E="$E2E" COMMIT="$COMMIT" DATUM="$DATUM" python3 - "$MATRIX" <<'EOF'
+BACKEND="$BACKEND" BACKEND_GESAMT="$BACKEND_GESAMT" FRONTEND="$FRONTEND" E2E="$E2E" COMMIT="$COMMIT" DATUM="$DATUM" python3 - "$MATRIX" <<'EOF'
 import os, re, sys
 
 pfad = sys.argv[1]
@@ -54,8 +66,15 @@ text = open(pfad, encoding="utf-8").read()
 b, f, e = os.environ["BACKEND"], os.environ["FRONTEND"], os.environ["E2E"]
 stempel_ende = f"— `scripts/pruefstand.sh`, Commit {os.environ['COMMIT']}, {os.environ['DATUM']} |"
 
+# Ein uebersprungener Test wird AUSGEWIESEN, nicht weggerechnet: "795/795 gruen"
+# bei 796 Tests waere eine stille Schoenung genau der Art, die dieses Projekt
+# beim Audit an sich selbst gefunden hat.
+gesamt = os.environ.get("BACKEND_GESAMT") or b
+uebersprungen = int(gesamt) - int(b) if gesamt.isdigit() else 0
+b_text = f"{b}/{gesamt} grün ({uebersprungen} übersprungen)" if uebersprungen else f"{b}/{b} grün"
+
 ersetzungen = [
-    (r"(\| Backend-Unit-Tests \|[^|]+\|) [^|]+\|",  rf"\1 ✅ {b}/{b} grün {stempel_ende}"),
+    (r"(\| Backend-Unit-Tests \|[^|]+\|) [^|]+\|",  rf"\1 ✅ {b_text} {stempel_ende}"),
     (r"(\| Frontend-Unit-Tests \|[^|]+\|) [^|]+\|", rf"\1 ✅ {f}/{f} grün {stempel_ende}"),
     (r"(\| E2E kritischster Nutzerfluss[^|]*\|[^|]+\|) [^|]+\|", rf"\1 ✅ {e}/{e} grün {stempel_ende}"),
 ]


### PR DESCRIPTION
Stempel nach der Auslieferung (RELEASE Schritt 3). Functions sind live, Live-Smoke grün.

- CHANGELOG `[Unveröffentlicht]` → `[3.1.0] — 2026-08-13`
- Die drei Zwischen-Einträge `3.0.7`/`3.0.8`/`3.0.9` entfernt (Ansage des Inhabers) — der ganze Audit-Zug steht an einer Stelle. Die Tags bleiben stehen, sie markieren echte Auslieferungen.
- `VERIFICATION.md`: **795/796 (1 übersprungen) · 315 · 18**, gestempelt von `scripts/pruefstand.sh` auf Commit 5b728c5.

**Neuer Fund beim Stempeln:** `OPS-2026-08-13-32` — der Stempler starb wortlos, weil ein leeres `grep` unter `set -e` + `pipefail` das Skript sofort beendet; seine eigene Plausibilitätsprüfung wurde nie erreicht. Behoben, mit Negativprobe. Der übersprungene Test wird jetzt ausgewiesen statt weggerechnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)