### PR TITLE
fix(OPS-32): Prüfstand-Stempler — auslösbare Plausibilitätsprüfung + Tests

### DIFF
--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 795/796 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 5b728c5, 2026-08-13 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 315/315 grün — `scripts/pruefstand.sh`, Commit 5b728c5, 2026-08-13 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 18/18 grün — `scripts/pruefstand.sh`, Commit 5b728c5, 2026-08-13 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 802/803 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 8eee8db, 2026-08-13 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 315/315 grün — `scripts/pruefstand.sh`, Commit 8eee8db, 2026-08-13 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 18/18 grün — `scripts/pruefstand.sh`, Commit 8eee8db, 2026-08-13 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/functions/src/__tests__/pruefstand-script.test.js
+++ b/functions/src/__tests__/pruefstand-script.test.js
@@ -1,0 +1,153 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+/**
+ * Wächter für scripts/pruefstand.sh (Befund OPS-2026-08-13-32).
+ *
+ * Der Stempler starb wortlos: Ein leeres grep beendet unter `set -e` +
+ * `pipefail` das ganze Skript sofort — die Plausibilitätsprüfung, die genau
+ * diesen Fall melden soll, wurde nie erreicht. Ausgelöst, als ein bewusst
+ * übersprungener Test die Jest-Ausgabe auf "1 skipped, 795 passed" änderte.
+ *
+ * Dazu die zweite Hälfte des Befunds: Die Plausibilitätsprüfung lag HINTER
+ * sechs Minuten Suitenlauf — sie war praktisch nicht auslösbar, und die erste
+ * Negativprobe starb unterwegs an einer flackernden Suite, ohne dass es
+ * auffiel. Deshalb die Einspeisepunkte PRUEFSTAND_PROBE_*: vorbereitete
+ * Suiten-Ausgaben statt echter Läufe, der ganze Rest (Zahlen lesen,
+ * Plausibilität, Stempeln) unverändert. Diese Tests laufen dadurch in
+ * Sekunden statt Minuten.
+ */
+
+const SKRIPT = path.join(__dirname, "../../../scripts/pruefstand.sh");
+
+let basis;
+
+beforeEach(() => {
+  basis = fs.mkdtempSync(path.join(os.tmpdir(), "pruefstand-"));
+});
+
+afterEach(() => {
+  fs.rmSync(basis, { recursive: true, force: true });
+});
+
+function datei(name, inhalt) {
+  const p = path.join(basis, name);
+  fs.writeFileSync(p, inhalt);
+  return p;
+}
+
+/* Eine Matrix mit genau den drei Zeilen, die der Stempler ersetzt. */
+function matrix() {
+  return datei(
+    "matrix.md",
+    [
+      "| Backend-Unit-Tests | lokal `npm test` | alt |",
+      "| Frontend-Unit-Tests | lokal `npm run test:frontend` | alt |",
+      "| E2E kritischster Nutzerfluss (Demo) | lokal `npm run test:e2e` | alt |",
+      "",
+    ].join("\n")
+  );
+}
+
+function lauf(umgebung) {
+  try {
+    const aus = execFileSync("bash", [SKRIPT], {
+      encoding: "utf8",
+      env: { ...process.env, ...umgebung },
+    });
+    return { code: 0, aus, fehler: "" };
+  } catch (e) {
+    return { code: e.status, aus: e.stdout || "", fehler: e.stderr || "" };
+  }
+}
+
+/* Suiten-Ausgaben, wie die drei Werkzeuge sie wirklich drucken. */
+const BACKEND_MIT_SKIP = "Test Suites: 45 passed, 45 total\nTests:       1 skipped, 796 passed, 797 total\n";
+const BACKEND_OHNE_SKIP = "Test Suites: 45 passed, 45 total\nTests:       797 passed, 797 total\n";
+const FRONTEND = "      Tests  315 passed (315)\n";
+const E2E = "  18 passed (2.4m)\n";
+
+describe("pruefstand.sh", () => {
+  test("übersprungener Test: stempelt und weist ihn aus, statt ihn wegzurechnen", () => {
+    const m = matrix();
+    const r = lauf({
+      PRUEFSTAND_PROBE_BACKEND: datei("b.log", BACKEND_MIT_SKIP),
+      PRUEFSTAND_PROBE_FRONTEND: datei("f.log", FRONTEND),
+      PRUEFSTAND_PROBE_E2E: datei("e.log", E2E),
+      PRUEFSTAND_MATRIX: m,
+    });
+    expect(r.code).toBe(0);
+    const inhalt = fs.readFileSync(m, "utf8");
+    /* Der Kern von OPS-32: "796/797 grün (1 übersprungen)" — nicht "796/796". */
+    expect(inhalt).toContain("796/797 grün (1 übersprungen)");
+    expect(inhalt).not.toContain("796/796");
+    expect(inhalt).toContain("315/315 grün");
+    expect(inhalt).toContain("18/18 grün");
+  });
+
+  test("ohne übersprungene Tests bleibt der Stempel schlicht", () => {
+    const m = matrix();
+    const r = lauf({
+      PRUEFSTAND_PROBE_BACKEND: datei("b.log", BACKEND_OHNE_SKIP),
+      PRUEFSTAND_PROBE_FRONTEND: datei("f.log", FRONTEND),
+      PRUEFSTAND_PROBE_E2E: datei("e.log", E2E),
+      PRUEFSTAND_MATRIX: m,
+    });
+    expect(r.code).toBe(0);
+    expect(fs.readFileSync(m, "utf8")).toContain("797/797 grün");
+  });
+
+  test("unlesbares Ausgabeformat: SAGT es und stempelt nichts (der wortlose Tod von OPS-32)", () => {
+    const m = matrix();
+    const vorher = fs.readFileSync(m, "utf8");
+    const r = lauf({
+      PRUEFSTAND_PROBE_BACKEND: datei("b.log", "Suite lief, aber ohne die Zeile, die er sucht\n"),
+      PRUEFSTAND_PROBE_FRONTEND: datei("f.log", FRONTEND),
+      PRUEFSTAND_PROBE_E2E: datei("e.log", E2E),
+      PRUEFSTAND_MATRIX: m,
+    });
+    expect(r.code).toBe(1);
+    /* Vorher: Exit 1 ohne ein Wort. Jetzt: die Meldung der Plausibilitätsprüfung. */
+    expect(r.aus).toMatch(/Testanzahl nicht lesbar/);
+    expect(fs.readFileSync(m, "utf8")).toBe(vorher);
+  });
+
+  test("rote Suite: Abbruch mit Meldung, Matrix unberührt", () => {
+    const m = matrix();
+    const vorher = fs.readFileSync(m, "utf8");
+    /* probe_oder_lauf liest die Datei mit cat — eine fehlende Datei lässt cat
+       (und damit die Suite-Stufe) scheitern, wie eine rote Suite. */
+    const r = lauf({
+      PRUEFSTAND_PROBE_BACKEND: path.join(basis, "gibt-es-nicht.log"),
+      PRUEFSTAND_PROBE_FRONTEND: datei("f.log", FRONTEND),
+      PRUEFSTAND_PROBE_E2E: datei("e.log", E2E),
+      PRUEFSTAND_MATRIX: m,
+    });
+    expect(r.code).toBe(1);
+    expect(r.aus).toMatch(/Backend-Suite rot/);
+    expect(fs.readFileSync(m, "utf8")).toBe(vorher);
+  });
+
+  test("veränderter Tabellenaufbau: Abbruch mit Meldung statt halbem Stempel", () => {
+    const m = datei("matrix.md", "| Ganz andere Tabelle | x | y |\n");
+    const r = lauf({
+      PRUEFSTAND_PROBE_BACKEND: datei("b.log", BACKEND_MIT_SKIP),
+      PRUEFSTAND_PROBE_FRONTEND: datei("f.log", FRONTEND),
+      PRUEFSTAND_PROBE_E2E: datei("e.log", E2E),
+      PRUEFSTAND_MATRIX: m,
+    });
+    expect(r.code).toBe(1);
+    expect(r.aus).toMatch(/Tabellenaufbau geändert/);
+  });
+
+  test("im Betrieb (ohne Einspeisung) bleibt der Aufrufweg unverändert", () => {
+    /* Die Einspeisepunkte dürfen den Normalbetrieb nicht verändern: ohne
+       gesetzte Variablen müssen die echten npm-Kommandos im Skript stehen. */
+    const skript = fs.readFileSync(SKRIPT, "utf8");
+    expect(skript).toMatch(/probe_oder_lauf PRUEFSTAND_PROBE_BACKEND npm test --prefix functions/);
+    expect(skript).toMatch(/probe_oder_lauf PRUEFSTAND_PROBE_FRONTEND npm run test:frontend/);
+    expect(skript).toMatch(/probe_oder_lauf PRUEFSTAND_PROBE_E2E npm run test:e2e/);
+  });
+});

--- a/scripts/pruefstand.sh
+++ b/scripts/pruefstand.sh
@@ -16,13 +16,35 @@ cd "$(dirname "$0")/.."
 
 DATUM=$(date +%Y-%m-%d)
 COMMIT=$(git rev-parse --short HEAD)
-MATRIX="docs/VERIFICATION.md"
+MATRIX="${PRUEFSTAND_MATRIX:-docs/VERIFICATION.md}"
+
+# ── Einspeisepunkte für Proben (OPS-2026-08-13-32, zweiter Teil) ──
+#
+# Die Plausibilitätsprüfung weiter unten lag HINTER allen drei Suiten. Sie
+# auszulösen kostete sechs Minuten und ging bei jedem Flackern der E2E-Suite
+# unterwegs verloren — genau daran ist die erste Negativprobe gestorben, ohne
+# dass es jemandem auffiel. Ein Riegel, den man nicht auslösen kann, ist ein
+# Riegel, von dem niemand weiß, ob er hält.
+#
+# Sind diese Variablen gesetzt, liest das Skript vorbereitete Suiten-Ausgaben
+# aus Dateien, statt die Suiten zu fahren. Der ganze Rest — Zahlen lesen,
+# Plausibilität, Stempeln — läuft unverändert. Im Betrieb ist nichts gesetzt.
+probe_oder_lauf() {
+  # $1 = Name der Probe-Variable, $2… = auszuführendes Kommando
+  eval "DATEI=\${$1:-}"
+  if [ -n "$DATEI" ]; then
+    cat "$DATEI"
+  else
+    shift
+    "$@" 2>&1
+  fi
+}
 
 echo "Prüfstand-Lauf auf Commit $COMMIT ($DATUM) — alle drei Suiten, danach Stempel."
 
 # ── 1. Backend (Jest) ──
 echo "— Backend-Suite läuft…"
-BACKEND_LOG=$(npm test --prefix functions 2>&1) || { echo "$BACKEND_LOG" | tail -20; echo "ABBRUCH: Backend-Suite rot — es wird nichts gestempelt."; exit 1; }
+BACKEND_LOG=$(probe_oder_lauf PRUEFSTAND_PROBE_BACKEND npm test --prefix functions) || { echo "$BACKEND_LOG" | tail -20; echo "ABBRUCH: Backend-Suite rot — es wird nichts gestempelt."; exit 1; }
 # OPS-2026-08-13-32: Zwei Fehler in einer Zeile, beide erst sichtbar, als ein
 # Test bewusst uebersprungen wurde und die Ausgabe "1 skipped, 795 passed,
 # 796 total" lautete:
@@ -39,12 +61,12 @@ BACKEND_GESAMT=$(printf "%s" "$BACKEND_LOG" | grep -E "^Tests:" | grep -Eo "[0-9
 
 # ── 2. Frontend (Vitest) ──
 echo "— Frontend-Suite läuft…"
-FRONTEND_LOG=$(npm run test:frontend 2>&1) || { echo "$FRONTEND_LOG" | tail -20; echo "ABBRUCH: Frontend-Suite rot — es wird nichts gestempelt."; exit 1; }
+FRONTEND_LOG=$(probe_oder_lauf PRUEFSTAND_PROBE_FRONTEND npm run test:frontend) || { echo "$FRONTEND_LOG" | tail -20; echo "ABBRUCH: Frontend-Suite rot — es wird nichts gestempelt."; exit 1; }
 FRONTEND=$(printf "%s" "$FRONTEND_LOG" | grep -Eo "Tests\s+[0-9]+ passed" | grep -Eo "[0-9]+" | head -1 || true)
 
 # ── 3. E2E (Playwright) ──
 echo "— E2E-Suite läuft (dauert am längsten)…"
-E2E_LOG=$(npm run test:e2e 2>&1) || { echo "$E2E_LOG" | tail -20; echo "ABBRUCH: E2E-Suite rot — es wird nichts gestempelt."; exit 1; }
+E2E_LOG=$(probe_oder_lauf PRUEFSTAND_PROBE_E2E npm run test:e2e) || { echo "$E2E_LOG" | tail -20; echo "ABBRUCH: E2E-Suite rot — es wird nichts gestempelt."; exit 1; }
 E2E=$(printf "%s" "$E2E_LOG" | grep -Eo "[0-9]+ passed" | grep -Eo "[0-9]+" | tail -1 || true)
 
 # ── Plausibilität: alle drei Zahlen müssen da sein ──


### PR DESCRIPTION
Zweite Hälfte von `OPS-2026-08-13-32`. Die Plausibilitätsprüfung des Stemplers lag hinter sechs Minuten Suitenlauf und war praktisch nicht auslösbar — die erste Negativprobe starb unterwegs an einer flackernden Suite, ohne dass es auffiel (und wurde trotzdem als erbracht gemeldet; dieser PR korrigiert auch das).

- **Einspeisepunkte** für vorbereitete Suiten-Ausgaben — die Prüf- und Stempellogik läuft unverändert, Proben dauern Sekunden statt Minuten. Im Betrieb ist nichts gesetzt (per Test abgesichert).
- **6 neue Tests**, inkl. des Wortlos-Tod-Falls: unlesbares Format → Meldung + Matrix unberührt. Rückbauprobe belegt.
- **Ernstfall im selben Lauf:** Beim ersten echten Stempel-Lauf war E2E rot (dritter Flacker der Nacht, dritter verschiedener Test) — der Stempler brach ab **und sagte es**. Zweiter Lauf grün: Stempel **802/803 (1 übersprungen) · 315 · 18** auf `8eee8db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)