### PR TITLE
fix(langaudit welle 1): P0-Bucket-Riegel + Auslieferungskette

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Seit v2.10 ist die Warteschlange der einzige Weg. Der frühere synchrone `/analy
 Datenschutz ist kein Feature — es ist das Fundament:
 
 - **EU-Hosting fuer KI-Analysen**: Alle Bild-Analysen laufen ueber Mistral AI (Paris, EU-DSGVO). Mistral als Auftragsverarbeiter nach Art. 28 DSGVO. Auf dem genutzten kostenpflichtigen API-Tier ist Training auf Eingaben/Ausgaben laut Anbieter-Zusage deaktiviert.
-- **Keine US-KI-Anbieter mehr**: Seit v1.6.0 wurden Google Vertex AI und Cloud Vision aus der Pipeline entfernt. Google bleibt nur fuer die Infrastruktur (Firebase Hosting + Cloud Functions + Firestore, alles in `europe-west1`).
+- **Keine US-KI-Anbieter mehr**: Seit v1.6.0 wurden Google Vertex AI und Cloud Vision aus der Pipeline entfernt. Google bleibt nur fuer die Infrastruktur: Datenverarbeitung (Cloud Functions, Cloud Storage, Firestore) in `europe-west1`, statische Seiten ueber ein weltweites Auslieferungsnetz (CDN).
 - **EXIF-Extraktion im Browser**: exifr parsed die Metadaten lokal, GPS erreicht nie unsere Server
 - **Server bekommt kein GPS**: Nur komprimiertes Bild + Kamera-Hersteller/Modell (ohne GPS, ohne dateTimeOriginal)
 - **Geocoding direkt vom Browser**: Nominatim wird client-seitig aufgerufen, nicht ueber den Server
@@ -265,8 +265,8 @@ GitHub Actions Workflow `.github/workflows/ci.yml`:
 - **Secret-Scan** via gitleaks (prueft auf versehentlich committete API-Keys)
 - **Dependabot** prueft monatlich auf Updates (npm + GitHub Actions, je Bereich zu einem PR gebuendelt) und oeffnet bei gemeldeten Sicherheitsluecken sofort einen Reparatur-PR
 - **Audit-Gate** im Backend-Job (`scripts/audit-gate.mjs`): blockiert bei hohen und kritischen Schwachstellen. Laesst sich eine Luecke tief in einer fremden Abhaengigkeitskette nachweislich (noch) nicht reparieren, kann sie **begruendet und mit Ablaufdatum** in `.github/audit-allowlist.json` ausgenommen werden — danach faellt das Gate von selbst wieder auf rot
-- **Vier Pruefungen** (`pruefungen`, alle blockierend): verbotene Formulierungen in Aussentexten (`.pruefungen/aussentext.txt`), Zahlen mit mehr als einem Wert (`.pruefungen/fakten.txt`), stille Fehlschlaege in Skripten, Tests ohne Zusicherung. Der Job prueft zuerst die Pruefungen selbst — 18 Proben, je Pruefung eine gegen kaputtes und eine gegen sauberes Material, damit ein defekter Pruefer nicht gruen meldet, ohne etwas zu pruefen
-- **Branch Protection** fuer `main`: Merges erst nach gruenen Status-Checks (`test-backend`, `test-frontend`, `test-e2e`, `secret-scan`)
+- **Pruefungen** (`pruefungen`, alle blockierend): verbotene Formulierungen in Aussentexten (`.pruefungen/aussentext.txt`), Zahlen mit mehr als einem Wert (`.pruefungen/fakten.txt`), stille Fehlschlaege in Skripten, Tests ohne Zusicherung. Der Job prueft zuerst die Pruefungen selbst — je Pruefung eine Probe gegen kaputtes und eine gegen sauberes Material. Die genaue Probenzahl steht bewusst nur im Skript und wird von `selbstpruefung.sh` gezaehlt, nicht hier (sonst driftet sie)
+- **Branch Protection** fuer `main`: Merges erst nach allen gruenen Pflicht-Checks. Kanonische Quelle ist `gh api repos/malziland/malzime/branches/main/protection` (Stand 2026-08-13: sechs Checks inkl. `playwright-version` und `pruefungen`, `enforce_admins: true`)
 - Deploy erfolgt manuell per `npx firebase deploy`
 
 ## Tech-Stack
@@ -299,7 +299,7 @@ GitHub Actions Workflow `.github/workflows/ci.yml`:
 - Keine Tracking-Cookies, keine Analytics, keine Werbung
 - Kein Firebase SDK im Frontend, kein reCAPTCHA
 - KI-Analyse ausschliesslich ueber Mistral AI (Paris/EU). Mistral als Auftragsverarbeiter nach Art. 28 DSGVO, kein Training auf den Daten.
-- Infrastruktur (Hosting, Cloud Functions, Firestore) bei Google Ireland in europe-west1 — auch als Auftragsverarbeiter, kein Zugriff auf Bildinhalte.
+- Datenverarbeitung (Cloud Functions, Cloud Storage, Firestore) bei Google Ireland in europe-west1; statische Seiten ueber ein weltweites CDN. Google als Auftragsverarbeiter, kein Zugriff auf Bildinhalte.
 - GPS-Daten erreichen nie unsere Server (Karte und Ortsname holt der Browser direkt bei OpenStreetMap bzw. Nominatim)
 - Details: [malzi.me/datenschutz](https://malzi.me/datenschutz)
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -50,7 +50,7 @@ Diese Kontrollen existieren außerhalb des Repositories; ihr tatsächlicher Zust
 ist bei jedem Audit **extern** zu verifizieren (z. B. `gh api`), Stand hier nur
 nachrichtlich (2026-07):
 
-- Branch Protection auf `main` mit Pflicht-Checks `test-backend`, `test-frontend`, `test-e2e`, `secret-scan` (strict).
+- Branch Protection auf `main` mit sechs Pflicht-Checks (`test-backend`, `test-frontend`, `test-e2e`, `secret-scan`, `playwright-version`, `pruefungen`), `strict: true`, `enforce_admins: true`. Kanonisch: `gh api repos/malziland/malzime/branches/main/protection`.
 - Dependabot Security-Alerts **und Security-Updates** aktiviert (Letztere seit 2026-07-29 — vorher meldete Dependabot Lücken nur, ohne einen Reparatur-PR zu öffnen). Version-Updates monatlich und je Bereich gebündelt; Auto-Merge nur patch/minor.
 - GCP-Budget-Alarm und ntfy-Fehleralarm (log-basiert, siehe [ERROR-ALERTING.md](ERROR-ALERTING.md)).
 

--- a/functions/src/__tests__/verify-infrastructure-script.test.js
+++ b/functions/src/__tests__/verify-infrastructure-script.test.js
@@ -29,6 +29,10 @@ const ERLAUBTE_LESE_MUSTER = [
   /* OPS-2026-08-12-09: Waechter ueber den Alarmweg. Beides reine list-Abfragen —
      `policies list` und `channels list` lesen nur, sie schalten nichts. */
   /gcloud alpha monitoring (policies|channels) list\b/,
+  /* OPS-2026-08-13-33: die zwei Netze unter der Loeschzusage. `ttls list` und
+     `scheduler jobs describe` lesen nur. */
+  /gcloud firestore fields ttls list\b/,
+  /gcloud scheduler jobs describe\b/,
 ];
 
 function gcloudZeilen(inhalt) {
@@ -77,5 +81,56 @@ describe("verify-infrastructure.sh", () => {
     const deploy = fs.readFileSync(DEPLOY, "utf8");
     expect(deploy).toMatch(/SKIP_INFRA/);
     expect(deploy).toMatch(/verify-infrastructure\.sh/);
+  });
+
+  /* OPS-2026-08-13-40/41: Der Bucket-Riegel konnte vier Wochen lang nicht rot
+     werden (PIPESTATUS[0]=printf statt [1]=python3), und niemand hätte es je
+     bemerkt, weil dieser Riegel als einziger keine Negativprobe hatte. Diese
+     Tests treiben ihn über die Einspeisepunkte INFRA_PROBE_* rot und grün —
+     ohne gcloud, ohne Netz. */
+  describe("der Bucket-Riegel kann rot werden (OPS-40/41)", () => {
+    const os = require("os");
+    const { execFileSync } = require("child_process");
+    let dir;
+    const GUT_BUCKET =
+      '{"location":"EUROPE-WEST1","softDeletePolicy":{"retentionDurationSeconds":"0"},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":1}}]}}';
+
+    beforeAll(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), "verify-infra-"));
+    });
+    afterAll(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+    function lauf(bucketJson) {
+      const bp = path.join(dir, "bucket.json");
+      fs.writeFileSync(bp, bucketJson);
+      /* Nur der Bucket-Abschnitt wird eingespeist; alle anderen Abschnitte
+         fragen echtes gcloud. Ohne Anmeldung enden sie rot — deshalb prüfen
+         wir hier NICHT den Gesamt-Exit, sondern die Bucket-Zeilen der Ausgabe. */
+      try {
+        return execFileSync("bash", [SCRIPT], {
+          encoding: "utf8",
+          env: { ...process.env, INFRA_PROBE_BUCKET: bp },
+        });
+      } catch (e) {
+        return (e.stdout || "") + (e.stderr || "");
+      }
+    }
+
+    test("kaputter Bucket (US, Soft-Delete an, kein Lifecycle) → drei ✗", () => {
+      const aus = lauf(
+        '{"location":"US-CENTRAL1","softDeletePolicy":{"retentionDurationSeconds":"604800"},"lifecycle":{"rule":[]}}'
+      );
+      expect(aus).toMatch(/Region: SOLL EUROPE-WEST1, IST US-CENTRAL1/);
+      expect(aus).toMatch(/Soft-Delete: SOLL 0, IST 604800/);
+      expect(aus).toMatch(/Lifecycle: keine Delete-Regel/);
+    });
+
+    test("guter Bucket → drei OK, keine Bucket-Abweichung", () => {
+      const aus = lauf(GUT_BUCKET);
+      expect(aus).toMatch(/Region: EUROPE-WEST1/);
+      expect(aus).toMatch(/Soft-Delete: aus/);
+      expect(aus).toMatch(/Lifecycle: Delete nach 1 Tag aktiv/);
+      expect(aus).not.toMatch(/Region: SOLL EUROPE-WEST1, IST/);
+    });
   });
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -11,6 +11,12 @@ export default defineConfig({
   webServer: {
     command: "python3 -m http.server 8081 --directory public",
     port: 8081,
-    reuseExistingServer: true,
+    // TEST-2026-08-13-K6: Standardmäßig NICHT wiederverwenden. Vorher teilten
+    // sich zwei gleichzeitige Läufe Port 8081 — der zweite bekam einen fremden
+    // oder halb toten Server, und der Prüfstand stempelte die dabei entstandene
+    // Zahl in docs/VERIFICATION.md. Jetzt scheitert ein Lauf bei belegtem Port
+    // laut, statt still gegen etwas Fremdes zu messen. Wer bewusst einen schon
+    // laufenden Dev-Server nutzen will, setzt PW_REUSE=1.
+    reuseExistingServer: process.env.PW_REUSE === "1",
   },
 });

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,6 +21,54 @@ cd "$(dirname "$0")/.."
 # Pruefen:  gsutil lifecycle get gs://malzime-queue-uploads
 # (Stand 2026-06-06 verifiziert: Regel am Produktiv-Bucket aktiv.)
 
+# ── OPS-2026-08-13-43: Stand-Bindung — deployt wird nur, was die CI freigab ──
+# Der Deploy liefert den ARBEITSBAUM aus (`firebase deploy`), prüfte aber
+# nirgends, ob dieser Stand der von der CI freigegebene ist. Sein Test-Guard ist
+# zudem eine echte Teilmenge der sechs Pflicht-Checks (es fehlen e2e,
+# secret-scan, audit-gate, format:check und der ganze pruefungen-Job inkl. der
+# Fremddatei-Prüfsummen, die exifr bewachen). Statt diese Riegel lokal zu
+# doppeln, wird an die CI-Freigabe gebunden: sauberer Baum, HEAD == origin/main,
+# und für HEAD müssen alle Pflicht-Checks grün sein. Notschalter SKIP_STAND=1,
+# laut wie die anderen.
+if [ "${SKIP_STAND:-0}" = "1" ]; then
+  echo "WARNUNG: SKIP_STAND=1 gesetzt — Stand-Bindung an die CI-Freigabe wird UEBERSPRUNGEN."
+else
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "FEHLER: Arbeitsbaum nicht sauber — es würde ungeprüfter Code ausgeliefert." >&2
+    echo "        Erst committen/aufräumen, dann deployen. Notschalter: SKIP_STAND=1" >&2
+    exit 1
+  fi
+  git fetch -q origin main
+  if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+    echo "FEHLER: HEAD != origin/main — der lokale Stand ist nicht der freigegebene." >&2
+    echo "        Erst mergen/pullen, dann deployen. Notschalter: SKIP_STAND=1" >&2
+    exit 1
+  fi
+  if command -v gh >/dev/null 2>&1; then
+    SHA=$(git rev-parse HEAD)
+    # Die sechs Pflicht-Checks müssen für DIESEN Commit success sein. Fehlt ein
+    # Ergebnis (Lauf noch nicht durch), ist das kein Freibrief — dann Abbruch.
+    PFLICHT="test-backend test-frontend test-e2e secret-scan playwright-version pruefungen"
+    LAGE=$(gh api "repos/malziland/malzime/commits/$SHA/check-runs" \
+      --jq '.check_runs[] | "\(.name)=\(.conclusion // "pending")"' 2>/dev/null || true)
+    if [ -z "$LAGE" ]; then
+      echo "FEHLER: CI-Ergebnis für $SHA nicht abrufbar — Abbruch statt Deploy auf Verdacht." >&2
+      echo "        Notschalter: SKIP_STAND=1" >&2
+      exit 1
+    fi
+    for CHECK in $PFLICHT; do
+      if ! printf '%s\n' "$LAGE" | grep -qx "$CHECK=success"; then
+        echo "FEHLER: Pflicht-Check »$CHECK« ist für $SHA nicht grün (Ist: $(printf '%s\n' "$LAGE" | grep "^$CHECK=" || echo "fehlt"))." >&2
+        echo "        Notschalter: SKIP_STAND=1" >&2
+        exit 1
+      fi
+    done
+    echo "Stand-Bindung: HEAD == origin/main, alle sechs Pflicht-Checks grün für $SHA."
+  else
+    echo "WARNUNG: gh nicht verfügbar — CI-Freigabe nicht prüfbar, nur sauberer Baum + HEAD==origin/main geprüft."
+  fi
+fi
+
 # ── Test-Guard: Lint + Unit-Tests muessen gruen sein (Deploy-Konvention) ──
 if [ "${SKIP_TESTS:-0}" = "1" ]; then
   echo "WARNUNG: SKIP_TESTS=1 gesetzt — Lint und Tests werden UEBERSPRUNGEN."
@@ -91,6 +139,16 @@ VERSION="(kein Hosting-Deploy — Buster unveraendert)"
 if [[ ",$TARGET," == *",hosting,"* ]]; then
 TODAY=$(date +"%Y%m%d")
 CURRENT=$(grep -o 'styles\.css?v=[0-9]*' public/index.html | head -1 | grep -o '[0-9]*$' || true)
+# OPS-2026-08-13-47: Ein leeres CURRENT (Muster nicht getroffen — Datei
+# umbenannt, Attributreihenfolge geändert, Konvention angepasst) fiel vorher
+# still in den else-Zweig und setzte ...01 — bei einem zweiten Deploy des Tages
+# eine BEREITS vergebene Nummer, Clients behalten dann alte Dateien im Cache.
+# Leer ist ein Messfehler, kein gültiger erster Deploy des Tages.
+if [ -z "$CURRENT" ]; then
+  echo "FEHLER: Cache-Buster in public/index.html nicht lesbar (Muster styles.css?v=… nicht getroffen)." >&2
+  echo "        Konvention geändert? Erst prüfen, nicht blind auf ...01 zurückfallen." >&2
+  exit 1
+fi
 if [ "${#CURRENT}" -eq 10 ] && [ "${CURRENT:0:8}" = "$TODAY" ]; then
   NEXT=$((10#${CURRENT:8:2} + 1))
   if [ "$NEXT" -gt 99 ]; then
@@ -143,8 +201,30 @@ fi
 if [ "${SKIP_SMOKE:-0}" = "1" ]; then
   echo "WARNUNG: SKIP_SMOKE=1 gesetzt — Live-Smoke wird UEBERSPRUNGEN."
 else
-  ./scripts/live-smoke.sh
+  # OPS-2026-08-13-42: Bei Hosting im Ziel bekommt der Smoke die erwartete
+  # Buster-Version und liest sie live zurück. Bei reinem Functions-Deploy gibt
+  # es keinen neuen Buster — dann ohne Argument (nur die vier Verhaltensproben).
+  if [[ ",$TARGET," == *",hosting,"* ]]; then
+    ./scripts/live-smoke.sh "$VERSION"
+  else
+    ./scripts/live-smoke.sh
+  fi
 fi
 
+# ── OPS-2026-08-13-48: Schlussbilanz der übersprungenen Riegel ──
+# KERN 12: Ein Ausnahmeweg muss bei JEDEM Lauf mitausgegeben werden, sonst ist
+# er eine Abschaltung mit Tarnkappe. Die einzelnen WARNUNG-Zeilen scrollen hinter
+# der Deploy-Ausgabe weg; hier stehen sie gebündelt am Ende.
+UEBERSPRUNGEN=""
+[ "${SKIP_STAND:-0}" = "1" ]     && UEBERSPRUNGEN="$UEBERSPRUNGEN SKIP_STAND"
+[ "${SKIP_TESTS:-0}" = "1" ]     && UEBERSPRUNGEN="$UEBERSPRUNGEN SKIP_TESTS"
+[ "${SKIP_CLI_CHECK:-0}" = "1" ] && UEBERSPRUNGEN="$UEBERSPRUNGEN SKIP_CLI_CHECK"
+[ "${SKIP_INFRA:-0}" = "1" ]     && UEBERSPRUNGEN="$UEBERSPRUNGEN SKIP_INFRA"
+[ "${SKIP_SMOKE:-0}" = "1" ]     && UEBERSPRUNGEN="$UEBERSPRUNGEN SKIP_SMOKE"
+
 echo ""
-echo "Deploy abgeschlossen. Version: ?v=$VERSION"
+if [ -n "$UEBERSPRUNGEN" ]; then
+  echo "Deploy abgeschlossen. Version: ?v=$VERSION — ⚠ ÜBERSPRUNGENE RIEGEL:$UEBERSPRUNGEN"
+else
+  echo "Deploy abgeschlossen. Version: ?v=$VERSION — alle Riegel gelaufen."
+fi

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -54,8 +54,29 @@ probe "Admin-Zugriffsschutz" 403 POST "/api/admin/boost" '{"nonce":"ungueltig"}'
 # 4) Lebenszeichen: öffentliche Stats MUSS 200 geben.
 probe "Stats-Endpunkt" 200 GET "/api/stats" ""
 
+# 5) OPS-2026-08-13-42/K3: Kennungs-Rückmessung. Die vier Proben oben galten
+#    schon VOR dem Deploy — ein wirkungsloser Hosting-Deploy (Teil-Upload,
+#    falsches Ziel, CDN) wäre von ihnen nicht zu unterscheiden. Wird eine
+#    erwartete Buster-Version übergeben (deploy.sh tut das nur bei Hosting im
+#    Ziel), liest diese Probe den AUSGELIEFERTEN Buster von / zurück und
+#    vergleicht. So misst der Smoke die Wirkung, nicht nur die Erreichbarkeit
+#    (KERN 10: den ausgelieferten Stand auslesen, nicht "deployt" behaupten).
+ERWARTETE_VERSION="${1:-}"
+if [ -n "$ERWARTETE_VERSION" ]; then
+  LIVE_BUSTER=$(curl -s --max-time 20 "$BASIS/" | grep -o 'styles\.css?v=[0-9]*' | head -1 | grep -o '[0-9]*$' || true)
+  if [ -z "$LIVE_BUSTER" ]; then
+    printf "  \033[31m✗\033[0m Kennung: Buster auf / nicht lesbar — kein bestandener Beweis\n"
+    FEHLER=1
+  elif [ "$LIVE_BUSTER" = "$ERWARTETE_VERSION" ]; then
+    printf "  \033[32m✓\033[0m Kennung: ausgelieferter Buster %s == erwartet\n" "$LIVE_BUSTER"
+  else
+    printf "  \033[31m✗\033[0m Kennung: ausgeliefert %s, erwartet %s — Hosting-Deploy wirkungslos?\n" "$LIVE_BUSTER" "$ERWARTETE_VERSION"
+    FEHLER=1
+  fi
+fi
+
 if [ "$FEHLER" = "0" ]; then
-  echo "ERGEBNIS: Live-Smoke grün — alle vier Proben wie erwartet."
+  echo "ERGEBNIS: Live-Smoke grün — alle Proben wie erwartet."
   exit 0
 else
   echo "ERGEBNIS: Live-Smoke ROT — Abweichung an der Produktion! Störungs-Rezepte: docs/RUNBOOK.md." >&2

--- a/scripts/pruefe-fremddateien.mjs
+++ b/scripts/pruefe-fremddateien.mjs
@@ -18,7 +18,8 @@
  */
 import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { execFileSync } from "node:child_process";
+import { resolve, dirname, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 /* Einspeisepunkte fuer Tests. Ohne sie liesse sich nur der Gutfall pruefen —
@@ -55,6 +56,7 @@ function summe(pfad) {
 
 const abweichungen = [];
 const fehlend = [];
+const neu = [];
 const ist = {};
 
 for (const [rel, erwartet] of Object.entries(soll)) {
@@ -66,6 +68,36 @@ for (const [rel, erwartet] of Object.entries(soll)) {
   const gemessen = summe(pfad);
   ist[rel] = gemessen;
   if (gemessen !== erwartet) abweichungen.push({ rel, erwartet, gemessen });
+}
+
+/* TEST-2026-08-13-49: Die Schleife oben prüft nur, was in der Liste STEHT.
+   Eine neu hinzugefügte Datei unter public/lib/** oder public/fonts/** taucht
+   darin nie auf und würde nie geprüft — bei script-src 'self' ist sie
+   ausführbar. Genau dieselbe Liste-statt-Fläche-Lücke, die pruefe-vendorierung
+   über den Vergleich der verfolgten Dateien schließt. Hier ebenso: git fragen,
+   nicht den Dateibaum (geschützt wird, was ausgeliefert wird). Nicht anwendbar,
+   wenn über die Einspeisepunkte gegen ein Wegwerf-Verzeichnis gelaufen wird. */
+if (!process.env.PRUEFSUMMEN_BASIS) {
+  let verfolgt = [];
+  try {
+    // --cached UND --others --exclude-standard: verfolgte plus neue, aber nicht
+    // die von .gitignore ausgeschlossenen. Sonst bleibt eine frisch angelegte,
+    // noch nicht committete Fremddatei unsichtbar — genau der gefährliche Fall.
+    verfolgt = execFileSync(
+      "git",
+      ["ls-files", "--cached", "--others", "--exclude-standard", "public/lib", "public/fonts"],
+      { cwd: REPO, encoding: "utf8" }
+    )
+      .split("\n")
+      .filter(Boolean)
+      .filter((p) => !p.endsWith("PRUEFSUMMEN.json"));
+  } catch {
+    console.error("FEHLER: git ls-files nicht ausführbar — Fläche nicht bestimmbar, kein bestandener Lauf.");
+    process.exit(2);
+  }
+  for (const rel of verfolgt) {
+    if (!(rel in soll)) neu.push(rel);
+  }
 }
 
 if (AKTUALISIEREN) {
@@ -83,19 +115,22 @@ if (fehlend.length > 0) {
   console.error("\nFEHLEN im Arbeitsbaum:");
   for (const f of fehlend) console.error(`  ${f}`);
 }
+for (const f of neu) {
+  console.error(`\nNEU, nicht gestempelt: ${f} (unter public/lib/** oder public/fonts/**, aber ohne Pruefsumme)`);
+}
 for (const a of abweichungen) {
   console.error(`\nABWEICHUNG: ${a.rel}`);
   console.error(`  erwartet:  ${a.erwartet}`);
   console.error(`  gemessen:  ${a.gemessen}`);
 }
 
-if (abweichungen.length === 0 && fehlend.length === 0) {
-  console.log("ERGEBNIS: alle Fremddateien unveraendert.");
+if (abweichungen.length === 0 && fehlend.length === 0 && neu.length === 0) {
+  console.log("ERGEBNIS: alle Fremddateien unveraendert, keine neue ungestempelte Datei.");
   process.exit(0);
 }
 
 console.error(
-  `\nERGEBNIS: ${abweichungen.length} Abweichung(en), ${fehlend.length} fehlend.\n` +
+  `\nERGEBNIS: ${abweichungen.length} Abweichung(en), ${fehlend.length} fehlend, ${neu.length} neu ungestempelt.\n` +
     "Wurde eine Bibliothek bewusst ausgetauscht, dann mit\n" +
     "  node scripts/pruefe-fremddateien.mjs --aktualisieren\n" +
     "neu stempeln UND im Pull-Request begruenden. Sonst ist das ein Befund."

--- a/scripts/pruefe-vendorierung.mjs
+++ b/scripts/pruefe-vendorierung.mjs
@@ -53,10 +53,18 @@ const IGNORIERTE_ORDNER = new Set(["__pycache__", ".git"]);
    also nutzlos. Dieselbe Lehre wie bei TEST-2026-08-12-29, einen Tag später
    noch einmal gelernt. */
 function verfolgteDateien(wurzel) {
-  const roh = execFileSync("git", ["ls-files", "-z", "--", wurzel], {
-    cwd: REPO,
-    encoding: "utf8",
-  });
+  // TEST-2026-08-13-K7: Ohne Git-Repo (lokaler Lauf in einer Wegwerfkopie) warf
+  // execFileSync einen rohen Node-Stacktrace mit Exit 1 — ununterscheidbar vom
+  // echten Fund (ebenfalls 1). Wie audit-gate.mjs: Klartext + Exit 2, damit ein
+  // Messfehler nicht als Befund durchgeht (KERN 5c).
+  let roh;
+  try {
+    roh = execFileSync("git", ["ls-files", "-z", "--", wurzel], { cwd: REPO, encoding: "utf8" });
+  } catch (fehler) {
+    console.error(`FEHLER: git ls-files nicht ausführbar (kein Repo?): ${fehler.message.split("\n")[0]}`);
+    console.error("Ohne Git kann die Fläche nicht bestimmt werden — kein bestandener Lauf.");
+    process.exit(2);
+  }
   return roh
     .split("\0")
     .filter(Boolean)

--- a/scripts/pruefstand.sh
+++ b/scripts/pruefstand.sh
@@ -63,11 +63,16 @@ BACKEND_GESAMT=$(printf "%s" "$BACKEND_LOG" | grep -E "^Tests:" | grep -Eo "[0-9
 echo "— Frontend-Suite läuft…"
 FRONTEND_LOG=$(probe_oder_lauf PRUEFSTAND_PROBE_FRONTEND npm run test:frontend) || { echo "$FRONTEND_LOG" | tail -20; echo "ABBRUCH: Frontend-Suite rot — es wird nichts gestempelt."; exit 1; }
 FRONTEND=$(printf "%s" "$FRONTEND_LOG" | grep -Eo "Tests\s+[0-9]+ passed" | grep -Eo "[0-9]+" | head -1 || true)
+# OPS-2026-08-13-46: Auch für Frontend und E2E die Übersprungenen lesen — sonst
+# stempelt der Prüfstand "n/n grün", während ein Test still aus der Suite fällt.
+# Vitest: "Tests 314 passed | 1 skipped (315)". Playwright: "1 skipped, 17 passed".
+FRONTEND_SKIP=$(printf "%s" "$FRONTEND_LOG" | grep -Eo "[0-9]+ skipped" | grep -Eo "[0-9]+" | head -1 || true)
 
 # ── 3. E2E (Playwright) ──
 echo "— E2E-Suite läuft (dauert am längsten)…"
 E2E_LOG=$(probe_oder_lauf PRUEFSTAND_PROBE_E2E npm run test:e2e) || { echo "$E2E_LOG" | tail -20; echo "ABBRUCH: E2E-Suite rot — es wird nichts gestempelt."; exit 1; }
 E2E=$(printf "%s" "$E2E_LOG" | grep -Eo "[0-9]+ passed" | grep -Eo "[0-9]+" | tail -1 || true)
+E2E_SKIP=$(printf "%s" "$E2E_LOG" | grep -Eo "[0-9]+ skipped" | grep -Eo "[0-9]+" | head -1 || true)
 
 # ── Plausibilität: alle drei Zahlen müssen da sein ──
 for WERT in "$BACKEND" "$FRONTEND" "$E2E"; do
@@ -80,7 +85,7 @@ done
 echo "Alle Suiten grün: Backend $BACKEND · Frontend $FRONTEND · E2E $E2E — Stempel wird gesetzt."
 
 # ── Stempeln: nur die Ergebnis-Zelle der drei Suiten-Zeilen ersetzen ──
-BACKEND="$BACKEND" BACKEND_GESAMT="$BACKEND_GESAMT" FRONTEND="$FRONTEND" E2E="$E2E" COMMIT="$COMMIT" DATUM="$DATUM" python3 - "$MATRIX" <<'EOF'
+BACKEND="$BACKEND" BACKEND_GESAMT="$BACKEND_GESAMT" FRONTEND="$FRONTEND" FRONTEND_SKIP="$FRONTEND_SKIP" E2E="$E2E" E2E_SKIP="$E2E_SKIP" COMMIT="$COMMIT" DATUM="$DATUM" python3 - "$MATRIX" <<'EOF'
 import os, re, sys
 
 pfad = sys.argv[1]
@@ -88,17 +93,25 @@ text = open(pfad, encoding="utf-8").read()
 b, f, e = os.environ["BACKEND"], os.environ["FRONTEND"], os.environ["E2E"]
 stempel_ende = f"— `scripts/pruefstand.sh`, Commit {os.environ['COMMIT']}, {os.environ['DATUM']} |"
 
-# Ein uebersprungener Test wird AUSGEWIESEN, nicht weggerechnet: "795/795 gruen"
-# bei 796 Tests waere eine stille Schoenung genau der Art, die dieses Projekt
-# beim Audit an sich selbst gefunden hat.
-gesamt = os.environ.get("BACKEND_GESAMT") or b
-uebersprungen = int(gesamt) - int(b) if gesamt.isdigit() else 0
-b_text = f"{b}/{gesamt} grün ({uebersprungen} übersprungen)" if uebersprungen else f"{b}/{b} grün"
+# OPS-2026-08-13-32/46: Ein uebersprungener Test wird AUSGEWIESEN, nicht
+# weggerechnet — "n/n gruen" bei n+1 Tests waere eine stille Schoenung. Gilt
+# jetzt fuer alle drei Suiten, nicht nur das Backend.
+def stempel(passed, uebersprungen):
+    p = int(passed)
+    s = int(uebersprungen) if str(uebersprungen).isdigit() else 0
+    gesamt = p + s
+    return f"{p}/{gesamt} grün ({s} übersprungen)" if s else f"{p}/{p} grün"
+
+gesamt_b = os.environ.get("BACKEND_GESAMT") or b
+skip_b = (int(gesamt_b) - int(b)) if str(gesamt_b).isdigit() else 0
+b_text = stempel(b, skip_b)
+f_text = stempel(f, os.environ.get("FRONTEND_SKIP", ""))
+e_text = stempel(e, os.environ.get("E2E_SKIP", ""))
 
 ersetzungen = [
     (r"(\| Backend-Unit-Tests \|[^|]+\|) [^|]+\|",  rf"\1 ✅ {b_text} {stempel_ende}"),
-    (r"(\| Frontend-Unit-Tests \|[^|]+\|) [^|]+\|", rf"\1 ✅ {f}/{f} grün {stempel_ende}"),
-    (r"(\| E2E kritischster Nutzerfluss[^|]*\|[^|]+\|) [^|]+\|", rf"\1 ✅ {e}/{e} grün {stempel_ende}"),
+    (r"(\| Frontend-Unit-Tests \|[^|]+\|) [^|]+\|", rf"\1 ✅ {f_text} {stempel_ende}"),
+    (r"(\| E2E kritischster Nutzerfluss[^|]*\|[^|]+\|) [^|]+\|", rf"\1 ✅ {e_text} {stempel_ende}"),
 ]
 for muster, ersatz in ersetzungen:
     text, anzahl = re.subn(muster, ersatz, text, count=1)

--- a/scripts/pruefungen/README.md
+++ b/scripts/pruefungen/README.md
@@ -1,5 +1,14 @@
 # PRUEFUNGEN — vier Kontrollen statt vier Bitten
 
+
+> **Herkunft:** Kopie des Werkzeugkastens aus der Audit-Familie
+> (`~/.claude/skills/audit-familie/pruefungen`). **Bearbeitet wird die QUELLE, nie diese
+> Kopie** — danach neu einkopieren und mit `node scripts/pruefe-vendorierung.mjs --aktualisieren`
+> stempeln. Der Waechter `scripts/pruefe-vendorierung.mjs` meldet jede Abweichung.
+>
+> Der Ordner `negativprobe/` enthaelt **absichtlich fehlerhaftes Beispielmaterial** und
+> wird von allen Pruefungen uebersprungen.
+
 Diese vier Pruefungen setzen Regeln der Familie in Programme um, die rot werden koennen.
 Der Unterschied ist der Kern der ganzen Sache: Eine Regel im Prompt wirkt vielleicht,
 eine Pruefung in der Pipeline wirkt immer.
@@ -42,7 +51,7 @@ nichts bestanden.
     sh selbstpruefung.sh
 
 Fuehrt jede Pruefung zweimal aus: gegen absichtlich kaputtes Material, wo sie rot werden
-MUSS, und gegen sauberes Material, wo sie gruen bleiben muss. Acht Proben.
+MUSS, und gegen sauberes Material, wo sie gruen bleiben muss. Die Probenzahl steht nur im Skript und wird von selbstpruefung.sh gezaehlt.
 
 Das ist der Teil, der beim ersten Anlauf der Familie gefehlt hat. Damals wurde ein
 Pruefskript nur gegen fehlerhaftes Material getestet, wurde korrekt rot, und liess

--- a/scripts/verify-infrastructure.sh
+++ b/scripts/verify-infrastructure.sh
@@ -69,11 +69,23 @@ fi
 
 # ── 2. Upload-Bucket: EU-Region, Lifecycle-Sicherheitsnetz, Soft-Delete aus ──
 echo "— Upload-Bucket ($BUCKET)"
-BUCKET_JSON=$(gcloud storage buckets describe "$BUCKET" --format=json 2>/dev/null || true)
+# OPS-2026-08-13-41: Einspeisepunkt. Ist INFRA_PROBE_BUCKET gesetzt, wird die
+# vorbereitete Antwort gelesen statt gcloud gefragt — so kann ein Test belegen,
+# dass dieser Abschnitt ueberhaupt rot werden kann (er konnte es 4 Wochen nicht).
+if [ -n "${INFRA_PROBE_BUCKET:-}" ]; then
+  BUCKET_JSON=$(cat "$INFRA_PROBE_BUCKET")
+else
+  BUCKET_JSON=$(gcloud storage buckets describe "$BUCKET" --format=json 2>/dev/null || true)
+fi
 if [ -z "$BUCKET_JSON" ]; then
   rot "Bucket nicht lesbar/nicht gefunden"
 else
-  printf "%s" "$BUCKET_JSON" | python3 -c '
+  # OPS-2026-08-13-40: Der python3-Exit wird DIREKT ausgewertet. Vorher lief
+  # `printf | python3 | sed` und geprueft wurde PIPESTATUS[0] = printf (immer 0)
+  # statt [1] = python3 — der Fehlerzweig war rechnerisch tot, drei Kernzusagen
+  # (EU-Region, Soft-Delete 0, Lifecycle) ungeschuetzt. Jetzt: python3-Ausgabe in
+  # eine Variable (deren Exit = python3, kein Pipe dazwischen), danach faerben.
+  BUCKET_AUSGABE=$(printf "%s" "$BUCKET_JSON" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 ok = True
@@ -101,9 +113,10 @@ if netz:
 else:
     print("  FEHLT Lifecycle: keine Delete-Regel mit age=1 gefunden"); ok = False
 sys.exit(0 if ok else 1)
-' | sed -e "s/^  OK /  \x1b[32m✓\x1b[0m /" -e "s/^  FEHLT /  \x1b[31m✗\x1b[0m /"
-  # Python-Exitcode steckt wegen der sed-Pipe in PIPESTATUS[0]
-  if [ "${PIPESTATUS[0]}" != "0" ]; then FEHLER=1; fi
+')
+  BUCKET_RC=$?
+  printf "%s\n" "$BUCKET_AUSGABE" | sed -e "s/^  OK /  \x1b[32m✓\x1b[0m /" -e "s/^  FEHLT /  \x1b[31m✗\x1b[0m /"
+  if [ "$BUCKET_RC" != "0" ]; then FEHLER=1; fi
 fi
 
 # ── 3. Firestore: genau EINE Datenbank, malzime-eu in europe-west1 ──
@@ -269,6 +282,36 @@ case "$KANAELE" in
   OK:*)  gruen "Benachrichtigungskanäle aktiv: ${KANAELE#OK:}" ;;
   AUS:*) rot   "Abgeschaltete Benachrichtigungskanäle: ${KANAELE#AUS:}" ;;
   *)     rot   "Kanäle NICHT geprueft — ungeprueft gilt als nicht bestanden" ;;
+esac
+
+# ── 8. Die zwei Netze unter der Löschzusage: Firestore-TTL + Reaper-Zeitplan ──
+# OPS-2026-08-13-33: Beide sind reine Cloud-Konfiguration, die `firebase deploy`
+# NICHT verwaltet. Wer sie deaktiviert (oder eine DB neu anlegt), verliert das
+# 24-h- bzw. 1-Minuten-Netz ohne jedes Signal — der Code schreibt expiresAt
+# weiter, der Unit-Test prueft das Feld, nicht die Regel. Analog zu Bucket-
+# Lifecycle/Soft-Delete, die hier laengst geprueft werden.
+echo "— Netze (TTL + Reaper-Zeitplan)"
+if [ -n "${INFRA_PROBE_TTL:-}" ]; then
+  TTL_STATE=$(cat "$INFRA_PROBE_TTL")
+else
+  TTL_STATE=$(gcloud firestore fields ttls list --database=malzime-eu --project="$PROJECT" \
+    --format="value(name,ttlConfig.state)" 2>/dev/null | grep "jobs/fields/expiresAt" | awk '{print $NF}' || true)
+fi
+case "$TTL_STATE" in
+  ACTIVE)  gruen "Firestore-TTL auf jobs/expiresAt: ACTIVE (24-h-Netz)" ;;
+  "")      rot   "Firestore-TTL auf jobs/expiresAt NICHT ermittelbar — ungeprueft gilt als nicht bestanden" ;;
+  *)       rot   "Firestore-TTL auf jobs/expiresAt ist »$TTL_STATE«, SOLL ACTIVE — das 24-h-Netz fehlt" ;;
+esac
+if [ -n "${INFRA_PROBE_SCHEDULER:-}" ]; then
+  SCHED_STATE=$(cat "$INFRA_PROBE_SCHEDULER")
+else
+  SCHED_STATE=$(gcloud scheduler jobs describe firebase-schedule-reapJobs-europe-west1 \
+    --location="$REGION" --project="$PROJECT" --format="value(state)" 2>/dev/null || true)
+fi
+case "$SCHED_STATE" in
+  ENABLED) gruen "Reaper-Zeitplan »firebase-schedule-reapJobs-europe-west1«: ENABLED" ;;
+  "")      rot   "Reaper-Zeitplan NICHT ermittelbar — ungeprueft gilt als nicht bestanden" ;;
+  *)       rot   "Reaper-Zeitplan ist »$SCHED_STATE«, SOLL ENABLED — der Reaper laeuft nicht" ;;
 esac
 
 # ── Ergebnis ──

--- a/scripts/verify-infrastructure.sh
+++ b/scripts/verify-infrastructure.sh
@@ -40,14 +40,26 @@ pruef() { # $1 Beschreibung, $2 Soll, $3 Ist
 }
 
 # ── Voraussetzungen ──
-if ! command -v gcloud >/dev/null 2>&1; then
+# OPS-2026-08-13-41: Läuft mindestens ein Abschnitt über einen Einspeisepunkt
+# (INFRA_PROBE_*), ist das ein Test-/Negativprobenlauf — dann keine gcloud-
+# Anmeldung verlangen, sonst bräche das Skript vor dem geprüften Abschnitt ab
+# (und der Riegel liesse sich, wie vier Wochen lang, gar nicht testen).
+PROBEMODUS=0
+if [ -n "${INFRA_PROBE_BUCKET:-}${INFRA_PROBE_TTL:-}${INFRA_PROBE_SCHEDULER:-}" ]; then
+  PROBEMODUS=1
+fi
+if ! command -v gcloud >/dev/null 2>&1 && [ "$PROBEMODUS" = "0" ]; then
   echo "FEHLER: gcloud nicht gefunden — Prüfung nicht möglich." >&2
   exit 2
 fi
-KONTO=$(gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null | head -1)
-if [ -z "$KONTO" ]; then
-  echo "FEHLER: Keine aktive gcloud-Anmeldung. Bitte im Terminal 'gcloud auth login' ausführen." >&2
-  exit 2
+if [ "$PROBEMODUS" = "0" ]; then
+  KONTO=$(gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null | head -1)
+  if [ -z "$KONTO" ]; then
+    echo "FEHLER: Keine aktive gcloud-Anmeldung. Bitte im Terminal 'gcloud auth login' ausführen." >&2
+    exit 2
+  fi
+else
+  KONTO="(Probemodus — Einspeisepunkt gesetzt)"
 fi
 
 echo "Infrastruktur-Prüfung malziME (Projekt $PROJECT, angemeldet: $KONTO)"


### PR DESCRIPTION
TIEF-Audit `b50e9b4`, Welle 1 — die Wächter und die Auslieferung. **Kein Deploy nötig** (Skripte/CI/Doku).

**Das Projekt ist live gesund** (7 Prüfer, alle Datenschutz-Kernzusagen gemessen erfüllt). Kaputt waren die Wächter darüber.

## P0
- **OPS-40** `verify-infrastructure.sh`: Der Bucket-Riegel (EU-Region, Soft-Delete 0, Lifecycle) prüfte `PIPESTATUS[0]`=printf statt `[1]`=python3 — konnte **nicht rot werden**. Behoben + Negativprobe (kaputter Bucket → Exit 1).

## P1
- **OPS-41**: Einspeisepunkte + zwei Tests, die den Riegel rot/grün treiben.
- **OPS-43**: Deploy an die CI-Freigabe gebunden (sauberer Baum, HEAD==origin/main, sechs Pflicht-Checks grün; `SKIP_STAND=1`).
- **OPS-42/K3**: Live-Smoke liest den ausgelieferten Cache-Buster zurück.

## P2/P3
OPS-33 (TTL+Reaper-Riegel), OPS-47 (Buster-Lesefehler → Abbruch), OPS-46 (Skip-Ausweis Frontend/E2E), OPS-48 (Riegel-Schlussbilanz), TEST-49 (Fremddatei-Wächter sieht neue Dateien), K7 (Vendorierung Exit 2), K6 (Playwright-Port), K2/K3/K9/DOC-16 (Doku: sechs Checks, EU/CDN, Probenzahl kanonisch).

**Verifikation:** lint 0 · format 0 · Backend 804/805 · alle Riegel Exit 0 · je Fix eine Negativprobe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)