### PR TITLE
fix: deploy.sh Stand-Bindung — Multibyte-Falle (blockierte Deploy)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -57,8 +57,8 @@ else
       exit 1
     fi
     for CHECK in $PFLICHT; do
-      if ! printf '%s\n' "$LAGE" | grep -qx "$CHECK=success"; then
-        echo "FEHLER: Pflicht-Check »$CHECK« ist für $SHA nicht grün (Ist: $(printf '%s\n' "$LAGE" | grep "^$CHECK=" || echo "fehlt"))." >&2
+      if ! printf '%s\n' "$LAGE" | grep -qx "${CHECK}=success"; then
+        echo "FEHLER: Pflicht-Check ${CHECK} ist fuer $SHA nicht grün (Ist: $(printf '%s\n' "$LAGE" | grep "^${CHECK}=" || echo "fehlt"))." >&2
         echo "        Notschalter: SKIP_STAND=1" >&2
         exit 1
       fi


### PR DESCRIPTION
Der OPS-43-Riegel aus Welle 1 brach beim ersten echten Deploy mit `CHECK: unbound variable` ab — `»$CHECK«` zieht auf macOS-bash 3.2 das erste Byte des Guillemets in den Variablennamen (bekannte Falle). Alle `$CHECK` jetzt `${CHECK}`.

Seit Welle 1 war kein Deploy möglich; die Welle-2-Functions sind noch nicht live. Dieser Fix macht den Deploy wieder möglich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)