### PR TITLE
fix(langaudit welle 4): Außentexte + Doku an die gemessene Wirklichkeit

### DIFF
--- a/.pruefungen/aussentext.txt
+++ b/.pruefungen/aussentext.txt
@@ -32,3 +32,6 @@ ausschlie(ss|ß)lich eine einzige Zahl|Am Live-Dokument widerlegt: Der Zaehler h
 
 # PRIV-2026-08-12-15: Es sind zwei Aufrufe an Mistral, nicht einer.
 in einem Schritt zwei fiktive Profile|Es sind zwei Aufrufe: der zweite holt die Werbe-Kategorien fuer den Beast-Modus. Beschreiben, was passiert.
+(eine einzige Zahl pro Zeitraum|a single number per time period)|Am Live-Dokument widerlegt: der Zaehler haelt Summen je Zeitraum UND die Zeitpunkte der letzten 60 Minuten. "Zaehlwerte je Zeitraum" statt "eine einzige Zahl".
+(verl(ae|ä)sst|verlassen) (nie|niemals) (den|die|das) Server|Sinnlos formuliert: GPS erreicht die Server nie, verlaesst sie also nicht. Richtig ist: GPS erreicht nie unsere Server.
+Einzige Ausnahme: ein anonymes Abhol-Ticket|Es sind mehrere sessionStorage-Werte (Ticket, Modus-Wahl, Realitaets-Check-Ticket, Absturz-Wache). Aufzaehlen statt "einzige".

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -63,8 +63,9 @@ muss die Begründung entkräften, nicht nur das Risiko benennen.
    bestätigt in der externen Review 2026-08-12 (der Reviewer zog seine
    fail-closed-Empfehlung nach Gegenrede zurück).
 2. **IP-Rate-Limit ist instanzlokal.** Das 500/10-min-Limit lebt im
-   Arbeitsspeicher jeder Function-Instanz (max. 5) — ein verteilter Angreifer
-   kann es umgehen. *Warum:* Es ist der Lärmfilter, nicht die Kostenbremse;
+   Arbeitsspeicher jeder Function-Instanz — bei `enqueue`/`jobstatus` bis zu 10
+   Instanzen (gemessen `maxScale`, 2026-08-13), effektiv also ein Mehrfaches der
+   genannten Zahl. Ein verteilter Angreifer kann es umgehen. *Warum:* Es ist der Lärmfilter, nicht die Kostenbremse;
    die echten Bremsen (Stundenlimit, Queue-Tiefe) sind global. Die Alternative —
    IP-Ableitungen in Firestore speichern — würde die Kern-Zusage „keine
    persistente IP" schwächen und träfe im Schul-WLAN ganze Klassen hinter einer

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081204" />
+    <link rel="stylesheet" href="./styles.css?v=2026081301" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -28,7 +28,7 @@
     <main id="main" class="container legal-page">
       <span class="page-eyebrow"><a href="/" class="eyebrow-home">malziME</a> &middot; Rechtliches</span>
       <h1>Datenschutz</h1>
-      <p class="legal-subtitle">Verst&auml;ndlich erkl&auml;rt &middot; Stand: 12. August 2026</p>
+      <p class="legal-subtitle">Verst&auml;ndlich erkl&auml;rt &middot; Stand: 13. August 2026</p>
       <div class="page-rule"></div>
       <div class="disclaimer disclaimer--flush">
         <p><strong>malziME</strong> ist ein Lern-Tool f&uuml;r Medienkompetenz und Datenschutz-Sensibilisierung. Die KI-Profile sind erfunden und zeigen nur, was Algorithmen behaupten k&ouml;nnten &ndash; nichts davon ist wahr oder bewiesen.</p>
@@ -62,13 +62,13 @@
             <li><strong>Kein Dateiname</strong> &ndash; ob dein Foto &bdquo;selfie_am_strand.jpg&ldquo; hei&szlig;t, erfahren wir nicht. Es wird immer als &bdquo;upload.jpg&ldquo; geschickt.</li>
             <li><strong>Keine GPS-Daten auf dem Server</strong> &ndash; GPS-Koordinaten werden im Browser ausgelesen und gehen nur an OpenStreetMap, nie an uns oder Google.</li>
             <li><strong>Kein Account</strong> &ndash; kein Login, kein Passwort, keine E-Mail-Adresse. Wir wissen nicht, wer du bist.</li>
-            <li><strong>Kein Tracking</strong> &ndash; kein Cookie, kein localStorage, keine Analyse-Tools. Einzige Ausnahme: ein anonymes <strong>Abhol-Ticket</strong> (eine Zufallsnummer im sessionStorage deines Tabs), damit dein Ergebnis ein versehentliches Neuladen der Seite &uuml;berlebt. Es enth&auml;lt keine pers&ouml;nlichen Daten, taugt nicht zum Wiedererkennen und l&ouml;scht sich von selbst, sobald du den Tab schlie&szlig;t. Danach vergisst dein Browser uns genauso schnell wie wir ihn.</li>
+            <li><strong>Kein Tracking</strong> &ndash; kein Cookie, kein localStorage, keine Analyse-Tools. Im <strong>sessionStorage deines Tabs</strong> merkt sich die Seite ein paar technische Dinge: das anonyme Abhol-Ticket (damit dein Ergebnis ein versehentliches Neuladen &uuml;berlebt), deine Modus-Wahl (seri&ouml;s/Beast), das Ticket f&uuml;r den Realit&auml;ts-Check und eine kleine Absturz-Wache. Keiner dieser Werte enth&auml;lt pers&ouml;nliche Daten, keiner taugt zum Wiedererkennen, und alle l&ouml;schen sich von selbst, sobald du den Tab schlie&szlig;t. Danach vergisst dein Browser uns genauso schnell wie wir ihn.</li>
             <li><strong>Keine IP-Adresse dauerhaft</strong> &ndash; der Missbrauchsschutz merkt sich deine IP f&uuml;r maximal 10&nbsp;Minuten im Arbeitsspeicher, dann ist sie weg.</li>
           </ul>
         </div>
-        <p>Der <a href="/stats" tabindex="0">Analyse-Z&auml;hler</a> speichert ausschlie&szlig;lich Zahlen: die Summen je Zeitraum (Tag, Woche, Monat, gesamt) und &ndash; damit das Stundenlimit rollen kann &ndash; die Zeitpunkte der Analysen der letzten 60&nbsp;Minuten. Keine IP-Adressen, keine Bildinhalte, keine Nutzerprofile. Der Z&auml;hler dient dem Kostenschutz und der transparenten Nutzungsstatistik.</p>
-        <p>Unsere Anwendungs-Logs enthalten nur eine zuf&auml;llige Anfrage-ID, den Status und technische Verarbeitungsschritte (Schritt-Name, Antwortl&auml;nge, Token-Counts) &ndash; keine Bildinhalte, keine Profile, keine IP-Adressen. Die Cloud-Functions-Infrastruktur (Google) protokolliert bei Fehlern technische Daten (IP, Zeitstempel, Statuscode) &ndash; Routine-Logs haben wir ausgeschlossen, diese Fehler-Logs werden nach 1&nbsp;Tag gel&ouml;scht. Vollst&auml;ndig anonyme Diagnose-Daten ohne Personenbezug (z.&nbsp;B. Fehler-Typ, Dauer, grobe Browser-/Betriebssystem-Klasse wie &bdquo;Safari 17 / iOS&ldquo; statt des vollen User-Agents, Bildschirm-Gr&ouml;&szlig;enklasse (klein/mittel/gro&szlig;) statt exakter Aufl&ouml;sung, Netzwerk-Klasse und -Geschwindigkeit, Datensparmodus, Spracheinstellung, Anzahl der Prozessorkerne, Arbeitsspeicher-Klasse, Pixeldichte und die aufgerufene Seite ohne Suchparameter &ndash; keine IP-Adressen, keine Bilder, keine Dateinamen) bewahren wir bis zu 30&nbsp;Tage auf, um seltene Ger&auml;tefehler &uuml;ber mehrere Workshops hinweg erkennen und beheben zu k&ouml;nnen. Eine anonymisierte Fehlerzusammenfassung ohne personenbezogene Daten (nur Fehlermeldung und H&auml;ufigkeit) bleibt zur Fehlerbehebung bestehen &ndash; eine k&uuml;rzere Aufbewahrung ist technisch nicht m&ouml;glich.</p>
-        <p>Beim freiwilligen Realit&auml;ts-Check z&auml;hlen wir ausschlie&szlig;lich anonym, wie oft die Einsch&auml;tzungen der KI als getroffen oder daneben bewertet wurden &mdash; ohne Foto, ohne Profil und ohne Verbindung zu deiner Analyse.</p>
+        <p>Der <a href="/stats" tabindex="0">Analyse-Z&auml;hler</a> speichert nur Z&auml;hlwerte: die Summen je Zeitraum (Tag, Woche, Monat, Jahr, gesamt) &ndash; jeweils mit dem zugeh&ouml;rigen Datumsschl&uuml;ssel, damit der Z&auml;hler beim Tageswechsel korrekt weiterz&auml;hlt &ndash; und, damit das Stundenlimit rollen kann, die Zeitpunkte der Analysen der letzten 60&nbsp;Minuten. Keine IP-Adressen, keine Bildinhalte, keine Nutzerprofile. Der Z&auml;hler dient dem Kostenschutz und der transparenten Nutzungsstatistik.</p>
+        <p>Unsere Anwendungs-Logs enthalten nur eine zuf&auml;llige Anfrage-ID, den Status und technische Verarbeitungsschritte (Schritt-Name, Antwortl&auml;nge, Token-Counts) &ndash; keine Bildinhalte, keine Profile, keine IP-Adressen. Die serverseitigen Anfrage-Protokolle der Infrastruktur (Google) &ndash; die einzige Stelle, an der eine IP-Adresse anfiele &ndash; sind vollst&auml;ndig ausgeschlossen und werden gar nicht erst gespeichert. Die verbleibenden Programm-Logs ohne Personenbezug l&ouml;schen sich nach 1&nbsp;Tag. Vollst&auml;ndig anonyme Diagnose-Daten ohne Personenbezug (z.&nbsp;B. Fehler-Typ, Dauer, grobe Browser-/Betriebssystem-Klasse wie &bdquo;Safari 17 / iOS&ldquo; statt des vollen User-Agents, Bildschirm-Gr&ouml;&szlig;enklasse (klein/mittel/gro&szlig;) statt exakter Aufl&ouml;sung, Netzwerk-Klasse und -Geschwindigkeit, Datensparmodus, Spracheinstellung, Anzahl der Prozessorkerne, Arbeitsspeicher-Klasse, Pixeldichte, eine grobe Motivklasse des Bildes (Mensch, Tier oder gemischt &ndash; nicht das Bild selbst) und die aufgerufene Seite ohne Suchparameter &ndash; keine IP-Adressen, keine Bilder, keine Dateinamen) bewahren wir bis zu 30&nbsp;Tage auf, um seltene Ger&auml;tefehler &uuml;ber mehrere Workshops hinweg erkennen und beheben zu k&ouml;nnen. Eine anonymisierte Fehlerzusammenfassung ohne personenbezogene Daten (nur Fehlermeldung und H&auml;ufigkeit) bleibt zur Fehlerbehebung bestehen &ndash; eine k&uuml;rzere Aufbewahrung ist technisch nicht m&ouml;glich.</p>
+        <p>Beim freiwilligen Realit&auml;ts-Check halten wir je Bewertung einen anonymen Datensatz fest (welche Einsch&auml;tzungen der KI du als getroffen oder daneben markiert hast) und z&auml;hlen daraus zusammen, wie gut die KI im Schnitt lag &mdash; ohne Foto, ohne Profil und ohne jede Verbindung zu deiner Analyse. Diese Datens&auml;tze tragen keine Kennung und bleiben bis zu 30&nbsp;Tage erhalten.</p>
       </section>
       <!-- Wer ist beteiligt? -->
       <section class="legal-section">
@@ -95,7 +95,7 @@
               </tr>
               <tr>
                 <td>Cloud Firestore</td>
-                <td>Anonymer Analyse-Z&auml;hler (nur Gesamtzahl pro Zeitraum), Maintenance-Flag und die kurzlebige Warteschlangen-Verwaltung (Status + fertiges Profil ohne Personenbezug, L&ouml;schung wenige Minuten nach der Abholung, nie abgeholte sp&auml;testens nach rund 2&nbsp;Stunden). Keine Accounts, keine IP-Adressen.</td>
+                <td>Anonymer Analyse-Z&auml;hler (Z&auml;hlwerte je Zeitraum, keine Einzelvorg&auml;nge), Maintenance-Flag und die kurzlebige Warteschlangen-Verwaltung (Status + fertiges Profil ohne Personenbezug, L&ouml;schung wenige Minuten nach der Abholung, nie abgeholte sp&auml;testens nach rund 2&nbsp;Stunden). Keine Accounts, keine IP-Adressen.</td>
                 <td>Google Ireland Ltd., EU (europe-west1)</td>
               </tr>
               <tr>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -44,7 +44,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081204" />
+    <link rel="stylesheet" href="./styles.css?v=2026081301" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -82,7 +82,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081204" />
+    <link rel="stylesheet" href="./styles.css?v=2026081301" />
     <script type="application/ld+json">
 [
   {
@@ -306,15 +306,15 @@
         <p class="demo-label" data-i18n="demo.label">Kein Foto zur Hand? Probier ein Beispielbild (mit KI erstellt):</p>
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
-            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081204" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081301" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.selfie">Selfie am Stephansplatz</span>
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
-            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081204" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081301" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.cafe">Im Caf&eacute; in Salzburg</span>
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
-            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081204" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081301" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.hiker">Wanderung bei Hallstatt</span>
           </button>
         </div>
@@ -370,6 +370,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081204"></script>
+    <script type="module" src="./app.js?v=2026081301"></script>
   </body>
 </html>

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -7,9 +7,9 @@ import { setStatus, stopScanAnim } from "./ui.js";
 import { logClientError } from "./error-logger.js";
 
 const DEMO_IMAGES = {
-  selfie: "./img/demo/demo-selfie.jpg?v=2026081204",
-  cafe: "./img/demo/demo-cafe.jpg?v=2026081204",
-  hiker: "./img/demo/demo-hiker.jpg?v=2026081204",
+  selfie: "./img/demo/demo-selfie.jpg?v=2026081301",
+  cafe: "./img/demo/demo-cafe.jpg?v=2026081301",
+  hiker: "./img/demo/demo-hiker.jpg?v=2026081301",
 };
 
 export function initDemo() {

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -181,7 +181,7 @@
   "stats.countdownSeconds": "Wieder verfügbar in {{seconds}} Sekunden",
   "stats.countdownDone": "Analyse wird wieder freigeschaltet…",
   "stats.infoCountTitle": "Was wird gezählt?",
-  "stats.infoCountText": "Nur die Anzahl der Analysen — eine einzige Zahl pro Zeitraum. Keine Bilder, keine IP-Adressen, keine Nutzerprofile.",
+  "stats.infoCountText": "Nur Zählwerte je Zeitraum — keine Einzelvorgänge. Keine Bilder, keine IP-Adressen, keine Nutzerprofile.",
   "stats.infoLimitTitle": "Warum ein Limit?",
   "stats.infoLimitText": "Jede Analyse kostet Geld (KI + Bilderkennung). Das Stundenlimit schützt das Projekt vor unerwarteten Kosten.",
   "stats.infoFundingTitle": "Eigenfinanziert — für alle kostenlos",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -181,7 +181,7 @@
   "stats.countdownSeconds": "Available again in {{seconds}} seconds",
   "stats.countdownDone": "Unlocking analysis…",
   "stats.infoCountTitle": "What is being counted?",
-  "stats.infoCountText": "Only the number of analyses — a single number per time period. No images, no IP addresses, no user profiles.",
+  "stats.infoCountText": "Only counts per time period — no individual events. No images, no IP addresses, no user profiles.",
   "stats.infoLimitTitle": "Why a limit?",
   "stats.infoLimitText": "Each analysis costs money (AI + image recognition). The hourly limit protects the project from unexpected costs.",
   "stats.infoFundingTitle": "Self-funded — free for everyone",

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081204" />
+    <link rel="stylesheet" href="./styles.css?v=2026081301" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081204" />
+    <link rel="stylesheet" href="./styles.css?v=2026081301" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -100,7 +100,7 @@
         <div class="stats-info">
           <svg class="stats-info__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M12 15v-3m0-3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
           <h2 class="stats-info__title" data-i18n="stats.infoCountTitle">Was wird gez&auml;hlt?</h2>
-          <p class="stats-info__text" data-i18n="stats.infoCountText">Nur die Anzahl der Analysen &mdash; eine einzige Zahl pro Zeitraum. Keine Bilder, keine IP-Adressen, keine Nutzerprofile.</p>
+          <p class="stats-info__text" data-i18n="stats.infoCountText">Nur Z&auml;hlwerte je Zeitraum &mdash; keine Einzelvorg&auml;nge. Keine Bilder, keine IP-Adressen, keine Nutzerprofile.</p>
         </div>
 
         <div class="stats-info">
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081204"></script>
+    <script type="module" src="./js/stats.js?v=2026081301"></script>
   </body>
 </html>


### PR DESCRIPTION
TIEF-Audit `b50e9b4`, Welle 4 — Außentexte/Doku (Hosting).

Formulierungen, die die Prüfer an ihrem Belegort als widerlegt fanden:
- **K-1/PRIV-13** (P2): /stats + Datenschutz + Locales »eine einzige Zahl« → »Zählwerte je Zeitraum«.
- **K-6/PRIV-FE-04** (P2): »Einzige Ausnahme: Abhol-Ticket« → vier sessionStorage-Verwendungen aufgezählt.
- **K-3/K-4/K-5** (P3): Jahr-Zähler, Realitäts-Check-Datensätze, Motivklasse ehrlich beschrieben.
- **DOC-H** (P3): IP-Fehler-Logs, die es nicht mehr gibt, richtiggestellt.
- **DOC-G** (P3): SECURITY-MODEL »max. 5« → maxScale 10.

Drei neue Sperrlisten-Regeln verhindern den Rückfall.

**Verifikation:** aussentext 11/0 · Frontend 316/316 · Locale-Parität. Enthält den Buster 2026081301 (Welle-3-Deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)