### PR TITLE
fix(langaudit welle 5): Alarm-Abdeckung + CHANGELOG-Parser

### DIFF
--- a/functions/src/__tests__/changelog-version-script.test.js
+++ b/functions/src/__tests__/changelog-version-script.test.js
@@ -75,6 +75,15 @@ describe("changelog-oberste-version.sh", () => {
     expect(r.aus).toBe("3.1.0-rc1");
   });
 
+  /* OPS-2026-08-13-K11: Eine Überschrift in einem Code-Zaun ist ein Beispiel,
+     keine echte oberste Version. */
+  test("Überschrift in einem Code-Zaun gewinnt NICHT gegen die echte oberste", () => {
+    const r = lauf("# Changelog\n\n```\n## [9.9.9]\n```\n\n## [3.1.0] — 2026-08-13\n\n- echt\n");
+    expect(r.aus).toBe("3.1.0");
+    expect(r.aus).not.toBe("9.9.9");
+    expect(r.code).toBe(0);
+  });
+
   test("keine auswertbare Überschrift ist ein Messfehler (2), kein 'nichts zu tun' (0)", () => {
     const r = lauf("# Changelog\n\nnur Fließtext, keine Abschnitte\n");
     expect(r.code).toBe(2);

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081301" />
+    <link rel="stylesheet" href="./styles.css?v=2026081302" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -44,7 +44,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081301" />
+    <link rel="stylesheet" href="./styles.css?v=2026081302" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/index.html
+++ b/public/index.html
@@ -82,7 +82,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081301" />
+    <link rel="stylesheet" href="./styles.css?v=2026081302" />
     <script type="application/ld+json">
 [
   {
@@ -306,15 +306,15 @@
         <p class="demo-label" data-i18n="demo.label">Kein Foto zur Hand? Probier ein Beispielbild (mit KI erstellt):</p>
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
-            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081301" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081302" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.selfie">Selfie am Stephansplatz</span>
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
-            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081301" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081302" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.cafe">Im Caf&eacute; in Salzburg</span>
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
-            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081301" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081302" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.hiker">Wanderung bei Hallstatt</span>
           </button>
         </div>
@@ -370,6 +370,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081301"></script>
+    <script type="module" src="./app.js?v=2026081302"></script>
   </body>
 </html>

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -7,9 +7,9 @@ import { setStatus, stopScanAnim } from "./ui.js";
 import { logClientError } from "./error-logger.js";
 
 const DEMO_IMAGES = {
-  selfie: "./img/demo/demo-selfie.jpg?v=2026081301",
-  cafe: "./img/demo/demo-cafe.jpg?v=2026081301",
-  hiker: "./img/demo/demo-hiker.jpg?v=2026081301",
+  selfie: "./img/demo/demo-selfie.jpg?v=2026081302",
+  cafe: "./img/demo/demo-cafe.jpg?v=2026081302",
+  hiker: "./img/demo/demo-hiker.jpg?v=2026081302",
 };
 
 export function initDemo() {

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081301" />
+    <link rel="stylesheet" href="./styles.css?v=2026081302" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081301" />
+    <link rel="stylesheet" href="./styles.css?v=2026081302" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081301"></script>
+    <script type="module" src="./js/stats.js?v=2026081302"></script>
   </body>
 </html>

--- a/scripts/changelog-oberste-version.sh
+++ b/scripts/changelog-oberste-version.sh
@@ -36,7 +36,16 @@ else
   exit 2
 fi
 
-KOPF="$(printf '%s\n' "$INHALT" | grep -m1 -oE '^## \[[^]]+\]' || true)"
+# OPS-2026-08-13-K11: Code-Zaeune (``` bzw. ~~~) ausklammern, BEVOR nach der
+# obersten Ueberschrift gesucht wird. Ein `## [x.y.z]` als Beispiel in einem
+# eingezaeunten Block wuerde sonst gegen die echte oberste Ueberschrift gewinnen
+# und Tag/Release bestimmen — dieselbe strukturblinde Denkfigur wie OPS-30, nur
+# im Parser statt im Zahlenmuster.
+OHNE_ZAEUNE="$(printf '%s\n' "$INHALT" | awk '
+  /^[[:space:]]*(```|~~~)/ { imblock = !imblock; next }
+  !imblock { print }
+')"
+KOPF="$(printf '%s\n' "$OHNE_ZAEUNE" | grep -m1 -oE '^## \[[^]]+\]' || true)"
 if [ -z "$KOPF" ]; then
   echo "FEHLER: keine Abschnitts-Ueberschrift der Form '## [...]' gefunden." >&2
   exit 2

--- a/scripts/verify-infrastructure.sh
+++ b/scripts/verify-infrastructure.sh
@@ -296,6 +296,52 @@ case "$KANAELE" in
   *)     rot   "Kanäle NICHT geprueft — ungeprueft gilt als nicht bestanden" ;;
 esac
 
+# OPS-2026-08-13-45: Deckt der Alarmfilter alle ausgelieferten Dienste ab? Der
+# Filter ist eine Positivliste (service_name=(…)); ein neuer Dienst ist stumm,
+# bis ihn jemand von Hand eintraegt. Bewusst ausgespart sind `errors`/`telemetry`
+# (Client-Diagnose, sonst Alarm-Spam — docs/ERROR-ALERTING.md), `erinnerung`
+# (vom Reaper-Waechter abgedeckt) und `ntfy` (Zustellweg, kein malziME-Dienst).
+# Jeder ANDERE Dienst, der weder im Filter noch auf dieser Ausnahmeliste steht,
+# ist rot — das erzwingt eine bewusste Entscheidung pro neuem Dienst.
+ALARM_AUSNAHMEN="errors telemetry erinnerung ntfy"
+if [ -n "${INFRA_PROBE_POLICY:-}" ]; then
+  FILTER_DIENSTE=$(cat "$INFRA_PROBE_POLICY")
+else
+  FILTER_DIENSTE=$(printf '%s' "${POLICY_JSON:-}" | python3 -c '
+import json, re, sys
+try:
+    daten = json.load(sys.stdin)
+except Exception:
+    print(""); raise SystemExit(0)
+namen = set()
+for p in (daten if isinstance(daten, list) else []):
+    for c in p.get("conditions", []):
+        f = (c.get("conditionMatchedLog") or {}).get("filter", "")
+        namen.update(re.findall(r"\"([a-z0-9-]+)\"", f))
+print(" ".join(sorted(namen)))
+' 2>/dev/null)
+fi
+if [ -n "${INFRA_PROBE_DIENSTE:-}" ]; then
+  ALLE_DIENSTE=$(cat "$INFRA_PROBE_DIENSTE")
+else
+  ALLE_DIENSTE=$(gcloud run services list --project="$PROJECT" --region="$REGION" --format="value(metadata.name)" 2>/dev/null || true)
+fi
+if [ -z "$ALLE_DIENSTE" ]; then
+  rot "Alarm-Abdeckung NICHT geprueft (Dienstliste nicht lesbar) — ungeprueft gilt als nicht bestanden"
+else
+  UNGEDECKT=""
+  for D in $ALLE_DIENSTE; do
+    case " $FILTER_DIENSTE " in *" $D "*) continue ;; esac
+    case " $ALARM_AUSNAHMEN " in *" $D "*) continue ;; esac
+    UNGEDECKT="$UNGEDECKT $D"
+  done
+  if [ -n "$UNGEDECKT" ]; then
+    rot "Dienste ohne Alarm-Abdeckung und ohne benannte Ausnahme:$UNGEDECKT — Filter erweitern oder Ausnahme begruenden"
+  else
+    gruen "Alarm-Abdeckung: jeder Dienst ist im Filter oder benannte Ausnahme"
+  fi
+fi
+
 # ── 8. Die zwei Netze unter der Löschzusage: Firestore-TTL + Reaper-Zeitplan ──
 # OPS-2026-08-13-33: Beide sind reine Cloud-Konfiguration, die `firebase deploy`
 # NICHT verwaltet. Wer sie deaktiviert (oder eine DB neu anlegt), verliert das


### PR DESCRIPTION
TIEF-Audit `b50e9b4`, Welle 5 — die restlichen Wächter (kein Functions-Deploy).

- **OPS-45** (P2): verify-infrastructure prüft jetzt, ob der Alarmfilter alle ausgelieferten Dienste abdeckt (Positivliste → neuer Dienst war stumm). Ausnahmen benannt + begründet; live grün, rot bei neuem ungedecktem Dienst.
- **K11** (P3): CHANGELOG-Parser klammert Code-Zäune aus (Beispiel-Überschrift gewinnt nicht mehr gegen die echte).

Enthält den Buster 2026081302 (Welle-4-Deploy).

**Verifikation:** lint 0 · Backend 810/811 · OPS-45 + K11 mit Negativprobe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)