### PR TITLE
feat: Sprachumschalter auf allen Seiten + vier Runden Nachbesserung aus dem gemeinsamen Durchspielen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,23 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
 ### Behoben
 
+- **Safari verliert den Fokus aus dem Dialog — und findet nicht zurück**
+  (`A11Y-2026-08-13-02`). Gemessen in WebKit 26.5, der Maschine hinter Safari
+  auf iPhone und iPad. Safari setzt den Fokus ohne „Vollzugriff Tastatur" gar
+  nicht erst auf Knöpfe; wer aus der Rückfrage heraustabbte, landete im Nichts
+  und kam nicht mehr hinein. `inert` und der Umbruch am Listenrand allein
+  reichen dafür nicht — es braucht ein Netz, das den Fokus zurückholt. In
+  Chromium war das Verhalten nicht zu sehen.
+
+  Zweiter WebKit-Fund: Ein Klick fokussiert dort den Knopf nicht, deshalb
+  landete auch der Rücksprung nach dem Schließen im Leeren. Der auslösende
+  Knopf wird jetzt ausdrücklich gemerkt statt über `document.activeElement`
+  erraten.
+
+  **WebKit läuft ab sofort in der Pipeline mit** — als eigener Lauf über die
+  Umschalter-Tests. Das offizielle Playwright-Abbild bringt die Maschine ohne
+  Zusatzinstallation mit.
+
 - **Nach einem Neuladen versprach der Wechsel eine unmögliche Analyse.** Die
   Seite holt das Ergebnis zurück, die Bilddatei überlebt aber kein Neuladen —
   ein File-Objekt lässt sich nicht speichern. Die Rückfrage sagte trotzdem „die

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,28 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
 ### Behoben
 
+- **Nach einem Neuladen versprach der Wechsel eine unmögliche Analyse.** Die
+  Seite holt das Ergebnis zurück, die Bilddatei überlebt aber kein Neuladen —
+  ein File-Objekt lässt sich nicht speichern. Die Rückfrage sagte trotzdem „die
+  KI schaut dein Foto noch einmal an", und der Wechsel lief stillschweigend ins
+  Leere. Jetzt wird das Profil gelöscht und man landet auf einer sauberen
+  Startseite; der gemerkte Auftrag wird dabei verworfen, sonst holt ihn der
+  nächste Seitenaufruf zurück. Vom Betreiber gefunden, nicht von den Tests —
+  die hatten das falsche Verhalten sogar festgeschrieben.
+
+- **Stehende Meldungen wechselten die Sprache nicht mit.** Eine Fehlermeldung
+  („Die KI ist gerade überlastet…") blieb wortgleich stehen, während die Seite
+  auf Englisch umschaltete. `setStatus` merkt sich jetzt den Textschlüssel, und
+  jeder Sprachwechsel schreibt die Zeile neu — der Fehlercode bleibt erhalten.
+  Gefunden bei einem systematischen Durchgang durch **alle** Zustände der
+  echten Anwendung, nicht durch die drei Zustände des Entwurfs.
+
+- **Die Rückfragen waren zu lang und sahen gleich aus.** Zwei Dialoge mit
+  demselben Titel und je rund 60 Wörtern — im Workshop liest die niemand. Die
+  Überschrift nennt jetzt die **Folge** („Dein Profil wird gelöscht."), darunter
+  steht ein Satz, und die folgenschwere Variante trägt eine eigene Farbe samt
+  Warnzeichen. Ein Test hält die Länge fest, sonst wächst sie unbemerkt zurück.
+
 - **Das Deploy-Skript schrieb in Fließtext hinein** (`OPS-2026-08-13-01`). Der
   Cache-Buster wurde mit dem Muster `?v=` plus beliebig vielen Ziffern ersetzt —
   „beliebig viele" schloss **null** ein. Damit traf die Ersetzung auch ein nacktes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,26 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   beim Beast-Modus startet jedes weitergereichte Gerät im Workshop wieder in
   der Gerätesprache.
 
+  **Auf jeder Seite.** `stats.html` ist übersetzt und bekommt denselben
+  Umschalter. Datenschutzerklärung, Impressum und Nutzungsbedingungen liegen
+  bisher nur auf Deutsch — dort steht der Schalter ebenfalls, zeigt aber immer
+  DE (er sagt aus, in welcher Sprache das dasteht, was man liest) und öffnet
+  beim Klick auf EN einen **zweisprachigen** Hinweis. Zweisprachig, weil wer
+  auf EN klickt kein Deutsch liest. Diese Übergangslösung
+  (`js/sprachhinweis.js`) verschwindet vollständig, sobald die Texte übersetzt
+  sind; ein Test macht ihre Ausnahme im i18n-Wächter ab diesem Tag zum Fehler
+  und nennt beim Namen, was zu entfernen ist.
+
+  Die drei Rechtsseiten laden weiterhin **keine** Sprachdatei und rufen **keine**
+  Schnittstelle auf — beides ist jetzt eine geprüfte Eigenschaft. Ob der
+  Schalter dort erscheint, entscheidet allein die Adresse oder eine Spur, die
+  die Startseite im selben Tab hinterlassen hat.
+
+  **Zwei Türen zum Erproben**, beide nur im eigenen Tab: `?sprachumschalter=1`
+  in der Adresse und `malziME.sprachumschalter()` in der Konsole. Die Adresse
+  ist der wichtigere Weg — auf iPhone und iPad gibt es keine Konsole, und genau
+  dort entscheidet sich, ob ein Daumen den Schalter trifft.
+
   Barrierefreiheit wurde nicht behauptet, sondern gemessen: Fokus-Käfig aus
   `inert` **plus** Umbruch am Listenrand (`inert` allein lässt den Fokus hinter
   dem letzten Knopf in die Browserleiste entkommen), Rücksprung auf den
@@ -37,6 +57,20 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   Beast-Modus, `lang`-Attribut an jedem Knopf (sonst liest ein deutscher
   Screenreader „English" deutsch vor), Ansage des vollzogenen Wechsels.
   Geprüft über die ganze Matrix: 2 Sprachen × 2 Themen, Rückfrage offen und zu.
+
+  Zur Ziel-Größe eine Korrektur am eigenen ersten Entwurf: `min-height: 44px`
+  machte aus der schlanken Pille einen 108×52-Klotz, der mit dem abgenommenen
+  Entwurf nichts mehr zu tun hatte. Die Regel meint aber die **tastbare**
+  Fläche, nicht die sichtbare — ein unsichtbares Feld über dem Knopf bringt den
+  Daumen-Treffer, das Aussehen bleibt der Entwurf (sichtbar 50×30, tastbar 44).
+  Der Test misst seither mit `elementFromPoint`, was wirklich getroffen wird,
+  statt der Kastengröße.
+
+- **Links im Fließtext der Rechtsseiten sind unterstrichen**
+  (`A11Y-2026-08-13-01`, WCAG 1.4.1). Sie waren allein an der Farbe erkennbar —
+  8 ernste axe-Verstöße, die nie jemand gesehen hat, weil die bestehende
+  axe-Prüfung nur die Startseite abdeckt. Gefunden durch die neue Prüfung der
+  Unterseiten, nicht durch die Änderung selbst verursacht.
 
 ### Behoben
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,10 +91,16 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   echten Anwendung, nicht durch die drei Zustände des Entwurfs.
 
 - **Die Rückfragen waren zu lang und sahen gleich aus.** Zwei Dialoge mit
-  demselben Titel und je rund 60 Wörtern — im Workshop liest die niemand. Die
-  Überschrift nennt jetzt die **Folge** („Dein Profil wird gelöscht."), darunter
-  steht ein Satz, und die folgenschwere Variante trägt eine eigene Farbe samt
-  Warnzeichen. Ein Test hält die Länge fest, sonst wächst sie unbemerkt zurück.
+  demselben Titel und je rund 60 Wörtern — im Workshop liest die niemand. Jetzt
+  gilt: Die Überschrift nennt das Vorhaben („Auf Englisch wechseln?"), darunter
+  steht **ein** Satz mit der Folge, und der Bestätigungsknopf heißt in allen
+  Fällen gleich. Zwei Tests halten Länge und Gleichförmigkeit fest.
+
+  Ein Zwischenstand hatte die Löschwarnung als Überschrift — vor jemandem, der
+  nur die Sprache wechseln wollte, stand damit eine Schreckmeldung ohne
+  Zusammenhang, und der Knopf hieß „Neu analysieren", obwohl nach einem
+  Neuladen gar nichts analysiert werden kann. Die Hervorhebung sitzt jetzt im
+  Folgesatz, nicht im Titel.
 
 - **Das Deploy-Skript schrieb in Fließtext hinein** (`OPS-2026-08-13-01`). Der
   Cache-Buster wurde mit dem Muster `?v=` plus beliebig vielen Ziffern ersetzt —

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 16474dd, 2026-08-13 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 369/369 grün — `scripts/pruefstand.sh`, Commit 16474dd, 2026-08-13 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 42/42 grün — `scripts/pruefstand.sh`, Commit 16474dd, 2026-08-13 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit d00d7f2, 2026-08-13 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 369/369 grün — `scripts/pruefstand.sh`, Commit d00d7f2, 2026-08-13 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 66/66 grün — `scripts/pruefstand.sh`, Commit d00d7f2, 2026-08-13 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 2501d24, 2026-08-13 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 356/356 grün — `scripts/pruefstand.sh`, Commit 2501d24, 2026-08-13 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 42/42 grün — `scripts/pruefstand.sh`, Commit 2501d24, 2026-08-13 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 09341c2, 2026-08-13 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 366/366 grün — `scripts/pruefstand.sh`, Commit 09341c2, 2026-08-13 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 42/42 grün — `scripts/pruefstand.sh`, Commit 09341c2, 2026-08-13 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 09341c2, 2026-08-13 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 366/366 grün — `scripts/pruefstand.sh`, Commit 09341c2, 2026-08-13 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 42/42 grün — `scripts/pruefstand.sh`, Commit 09341c2, 2026-08-13 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 16474dd, 2026-08-13 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 369/369 grün — `scripts/pruefstand.sh`, Commit 16474dd, 2026-08-13 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 42/42 grün — `scripts/pruefstand.sh`, Commit 16474dd, 2026-08-13 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 9c65351, 2026-08-13 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 349/349 grün — `scripts/pruefstand.sh`, Commit 9c65351, 2026-08-13 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 30/30 grün — `scripts/pruefstand.sh`, Commit 9c65351, 2026-08-13 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 2501d24, 2026-08-13 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 356/356 grün — `scripts/pruefstand.sh`, Commit 2501d24, 2026-08-13 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 42/42 grün — `scripts/pruefstand.sh`, Commit 2501d24, 2026-08-13 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/e2e/sprachumschalter-unterseiten.test.js
+++ b/e2e/sprachumschalter-unterseiten.test.js
@@ -56,13 +56,15 @@ test.describe("Nur-deutsche Seiten: Hinweis statt Wechsel", () => {
     await expect(hinweis).toBeVisible();
 
     /* Wer auf EN klickt, liest kein Deutsch — die Erklärung muss ihn erreichen. */
-    await expect(hinweis).toContainText("noch nicht auf Englisch");
-    await expect(hinweis).toContainText("not available in English yet");
+    await expect(hinweis).toContainText("nur auf Deutsch");
+    await expect(hinweis).toContainText("German only");
 
-    /* Und beide Blöcke sind als ihre Sprache ausgezeichnet, sonst spricht ein
-       Screenreader den englischen Satz deutsch aus. */
-    await expect(hinweis.locator('[lang="de"]').first()).toBeVisible();
-    await expect(hinweis.locator('[lang="en"]').first()).toBeVisible();
+    /* Beide Zeilen sind als ihre Sprache ausgezeichnet, sonst spricht ein
+       Screenreader den englischen Satz deutsch aus. Und es bleibt bei je EINER
+       Zeile — längere Hinweise liest im Workshop niemand. */
+    await expect(hinweis.locator('[lang="de"]')).toHaveCount(1);
+    await expect(hinweis.locator('[lang="en"]')).toHaveCount(1);
+    expect((await hinweis.innerText()).split("\n").filter(Boolean).length).toBeLessThanOrEqual(4);
 
     await page.click(".sw-knopf--bleiben");
     await expect(page.locator(".sw-grund.sichtbar")).toHaveCount(0);

--- a/e2e/sprachumschalter-unterseiten.test.js
+++ b/e2e/sprachumschalter-unterseiten.test.js
@@ -1,0 +1,165 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+/* Der Sprachumschalter auf den Unterseiten.
+ *
+ * Zwei verschiedene Dinge werden geprüft:
+ *
+ * - `stats.html` ist übersetzt und bekommt den ECHTEN Umschalter
+ *   (js/sprachumschalter.js). Dort wird wirklich umgeschaltet.
+ * - Datenschutz, Impressum und Nutzungsbedingungen liegen nur auf Deutsch. Sie
+ *   bekommen die ÜBERGANGSLÖSUNG (js/sprachhinweis.js): denselben Schalter,
+ *   aber ein zweisprachiger Hinweis statt eines Wechsels. Verschwindet, sobald
+ *   die Texte übersetzt sind.
+ *
+ * Diese drei Seiten laden sonst kein JavaScript und rufen keine Schnittstelle
+ * auf. Das muss so bleiben — geprüft wird es unten ausdrücklich. */
+
+const NUR_DEUTSCH = ["/datenschutz.html", "/impressum.html", "/nutzungsbedingungen.html"];
+
+async function ruhe(page) {
+  await page.evaluate(
+    () =>
+      new Promise((fertig) => requestAnimationFrame(() => requestAnimationFrame(fertig)))
+  );
+}
+
+test.describe("Nur-deutsche Seiten: Hinweis statt Wechsel", () => {
+  test.use({ locale: "en-US" });
+
+  for (const seite of NUR_DEUTSCH) {
+    test(`${seite}: ohne Tür kein Schalter, mit Tür einer`, async ({ page }) => {
+      await page.goto(seite);
+      await ruhe(page);
+      await expect(page.locator(".sprach-pille")).toHaveCount(0);
+
+      /* Positivkontrolle: Die Null oben wäre auch dann erfüllt, wenn der
+         Schalter überhaupt nicht mehr gebaut werden könnte. */
+      await page.goto(`${seite}?sprachumschalter=1`);
+      await expect(page.locator(".sprach-pille")).toBeVisible();
+    });
+  }
+
+  test("der Schalter steht auf DE — auch bei englischem Browser", async ({ page }) => {
+    /* Er sagt aus, in welcher Sprache das dasteht, was man liest. Auf einer
+       deutschen Seite EN anzuzeigen wäre gelogen. */
+    await page.goto("/datenschutz.html?sprachumschalter=1");
+    await expect(page.locator('.sprach-knopf[data-lang="de"]')).toHaveClass(/aktiv/);
+    await expect(page.locator('.sprach-knopf[data-lang="en"]')).not.toHaveClass(/aktiv/);
+  });
+
+  test("EN öffnet einen zweisprachigen Hinweis und ändert nichts", async ({ page }) => {
+    await page.goto("/datenschutz.html?sprachumschalter=1");
+    await page.click('.sprach-knopf[data-lang="en"]');
+
+    const hinweis = page.locator('.sw-grund[data-modal="unuebersetzt"]');
+    await expect(hinweis).toBeVisible();
+
+    /* Wer auf EN klickt, liest kein Deutsch — die Erklärung muss ihn erreichen. */
+    await expect(hinweis).toContainText("noch nicht auf Englisch");
+    await expect(hinweis).toContainText("not available in English yet");
+
+    /* Und beide Blöcke sind als ihre Sprache ausgezeichnet, sonst spricht ein
+       Screenreader den englischen Satz deutsch aus. */
+    await expect(hinweis.locator('[lang="de"]').first()).toBeVisible();
+    await expect(hinweis.locator('[lang="en"]').first()).toBeVisible();
+
+    await page.click(".sw-knopf--bleiben");
+    await expect(page.locator(".sw-grund.sichtbar")).toHaveCount(0);
+    await expect(page.locator("html")).toHaveAttribute("lang", "de");
+    await expect(page.locator('.sprach-knopf[data-lang="de"]')).toHaveClass(/aktiv/);
+  });
+
+  test("Escape schließt, der Fokus kehrt auf den Schalter zurück", async ({ page }) => {
+    await page.goto("/datenschutz.html?sprachumschalter=1");
+    const en = page.locator('.sprach-knopf[data-lang="en"]');
+    await en.focus();
+    await en.click();
+    await expect(page.locator('.sw-grund[data-modal="unuebersetzt"]')).toBeVisible();
+
+    for (let i = 0; i < 6; i++) {
+      await page.keyboard.press("Tab");
+      const drin = await page.evaluate(() => !!document.activeElement.closest(".sw-modal"));
+      expect(drin, `Fokus nach ${i + 1} Tab-Schritten ausserhalb`).toBe(true);
+    }
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".sw-grund.sichtbar")).toHaveCount(0);
+    expect(await page.evaluate(() => document.activeElement.dataset.lang)).toBe("en");
+  });
+
+  test("keine Schnittstellen-Aufrufe von einer Rechtsseite", async ({ page }) => {
+    /* Diese Seiten sollen still bleiben. Der Umschalter darf daran nichts
+       ändern — er entscheidet allein an der Adresse und am Tab-Speicher. */
+    const rufe = [];
+    page.on("request", (r) => {
+      const u = new URL(r.url());
+      if (u.pathname.startsWith("/api/")) rufe.push(u.pathname);
+    });
+    await page.goto("/datenschutz.html?sprachumschalter=1");
+    await page.click('.sprach-knopf[data-lang="en"]');
+    await ruhe(page);
+    expect(rufe).toEqual([]);
+  });
+
+  test("axe: Seite mit offenem Hinweis ohne ernste Verstöße", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/datenschutz.html?sprachumschalter=1");
+    await page.click('.sprach-knopf[data-lang="en"]');
+    await expect(page.locator(".sw-grund.sichtbar")).toHaveCount(1);
+    await page.evaluate(
+      () =>
+        Promise.race([
+          Promise.all(document.getAnimations().map((a) => a.finished.catch(() => {}))),
+          new Promise((f) => setTimeout(f, 1000)),
+        ])
+    );
+    const funde = (await new AxeBuilder({ page }).analyze()).violations;
+    const ernst = funde.filter((v) => v.impact === "serious" || v.impact === "critical");
+    expect(
+      ernst.map((v) => ({ regel: v.id, elemente: v.nodes.map((n) => n.target.join(" ")) })),
+      "Ernste A11y-Verstöße: Rechtsseite mit Hinweis"
+    ).toEqual([]);
+  });
+});
+
+test.describe("Spur aus dem Tab", () => {
+  test("wer den Schalter auf der Startseite gesehen hat, sieht ihn auch auf der Rechtsseite", async ({
+    page,
+  }) => {
+    await page.route("**/api/stats", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          current: { count: 1, limit: 500, limitActive: false },
+          sprachumschalter: true,
+        }),
+      })
+    );
+    await page.goto("/");
+    await expect(page.locator(".sprach-pille")).toBeVisible();
+
+    /* Ohne Adress-Anhängsel — die Spur im Tab genügt. */
+    await page.goto("/datenschutz.html");
+    await expect(page.locator(".sprach-pille")).toBeVisible();
+  });
+});
+
+test.describe("Zahlen-Seite: echter Wechsel", () => {
+  /* Sonst startet der Testbrowser (en-US) die Seite bereits englisch und die
+     Richtung des Wechsels stimmt nicht mehr. */
+  test.use({ locale: "de-AT" });
+
+  test("stats.html schaltet wirklich um, ohne Rückfrage", async ({ page }) => {
+    await page.goto("/stats.html?sprachumschalter=1");
+    await expect(page.locator(".sprach-pille")).toBeVisible();
+    await expect(page.locator("h1")).toContainText("Zahlen");
+
+    await page.click('.sprach-knopf[data-lang="en"]');
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
+    await expect(page.locator("h1")).toContainText("numbers");
+    /* Hier steht nichts auf dem Spiel — es darf keine Rückfrage kommen. */
+    await expect(page.locator(".sw-grund.sichtbar")).toHaveCount(0);
+  });
+});

--- a/e2e/sprachumschalter.test.js
+++ b/e2e/sprachumschalter.test.js
@@ -260,7 +260,7 @@ test("Profil fertig: Rückfrage in der AKTUELLEN Sprache, Abbrechen ändert nich
   await page.click('.sprach-knopf[data-lang="en"]');
   const modal = page.locator('.sw-grund[data-modal="fertig"]');
   await expect(modal).toBeVisible();
-  await expect(modal.locator(".sw-knopf--bleiben")).toHaveText("Profil behalten");
+  await expect(modal.locator(".sw-knopf--bleiben")).toHaveText("Abbrechen");
 
   await modal.locator(".sw-schliessen").click();
   await expect(page.locator("html")).toHaveAttribute("lang", "de");
@@ -269,7 +269,7 @@ test("Profil fertig: Rückfrage in der AKTUELLEN Sprache, Abbrechen ändert nich
   /* Der am Prototyp gemeldete Fehler: Der zweite Versuch kam auf Englisch,
      obwohl nie gewechselt worden war. */
   await page.click('.sprach-knopf[data-lang="en"]');
-  await expect(modal.locator(".sw-knopf--bleiben")).toHaveText("Profil behalten");
+  await expect(modal.locator(".sw-knopf--bleiben")).toHaveText("Abbrechen");
 });
 
 test("Analyse läuft: bestätigen startet dieselbe Datei neu", async ({ page }) => {
@@ -456,7 +456,7 @@ test.describe("Startsprache folgt dem Gerät", () => {
     await profilErzeugen(page);
     await page.click('.sprach-knopf[data-lang="de"]');
     await expect(page.locator('.sw-grund[data-modal="fertig"] .sw-knopf--bleiben')).toHaveText(
-      "Keep my profile"
+      "Cancel"
     );
   });
 });

--- a/e2e/sprachumschalter.test.js
+++ b/e2e/sprachumschalter.test.js
@@ -194,6 +194,31 @@ test("Positivkontrolle: mit Flag entsteht er sehr wohl", async ({ page }) => {
   await expect(page.locator(".sw-grund")).toHaveCount(2);
 });
 
+test("Adress-Tür blendet ihn auch ohne Flag ein — ohne Konsole, auch am Handy", async ({
+  page,
+}) => {
+  /* Der wichtigere der beiden Wege: Auf iPhone und iPad gibt es keine Konsole,
+     und Chrome sperrt am Rechner das Einfügen in die Konsole. */
+  await seiteVorbereiten(page, { merkmal: false });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/?sprachumschalter=1");
+  await expect(page.locator(".sprach-pille")).toBeVisible();
+
+  /* Und die Daumen-Größe stimmt auch auf diesem Weg. */
+  const f = await trefferflaeche(page, '.sprach-knopf[data-lang="en"]');
+  expect(f.breite).toBeGreaterThanOrEqual(44);
+  expect(f.hoehe).toBeGreaterThanOrEqual(44);
+});
+
+test("ein Tippfehler in der Adresse blendet nichts ein", async ({ page }) => {
+  await seiteVorbereiten(page, { merkmal: false });
+  const antwort = page.waitForResponse("**/api/stats");
+  await page.goto("/?sprachumschalter=0");
+  await antwort;
+  await settle(page);
+  await expect(page.locator(".sprach-pille")).toHaveCount(0);
+});
+
 test("Konsolen-Tür blendet ihn auch ohne Flag ein", async ({ page }) => {
   await seiteVorbereiten(page, { merkmal: false });
   const antwort = page.waitForResponse("**/api/stats");
@@ -302,27 +327,66 @@ test("Fokus bleibt in der Rückfrage und kehrt danach zurück", async ({ page })
   expect(zurueck).toBe("en");
 });
 
-test("Ziel-Größen erreichen 44 px", async ({ page }) => {
+/** Misst, was ein Daumen WIRKLICH trifft — nicht, was man sieht.
+    Getastet wird mit elementFromPoint vom Mittelpunkt nach aussen; damit zaehlt
+    die unsichtbare Erweiterung ueber ::after mit, die genau dafuer da ist. */
+async function trefferflaeche(page, waehler) {
+  return page.evaluate((w) => {
+    const el = document.querySelector(w);
+    const r = el.getBoundingClientRect();
+    const mx = r.left + r.width / 2;
+    const my = r.top + r.height / 2;
+    const trifft = (x, y) => {
+      const t = document.elementFromPoint(x, y);
+      return !!t && (t === el || el.contains(t));
+    };
+    let oben = 0;
+    while (oben < 60 && trifft(mx, my - oben - 1)) oben++;
+    let unten = 0;
+    while (unten < 60 && trifft(mx, my + unten + 1)) unten++;
+    let links = 0;
+    while (links < 80 && trifft(mx - links - 1, my)) links++;
+    let rechts = 0;
+    while (rechts < 80 && trifft(mx + rechts + 1, my)) rechts++;
+    /* +1 fuer den Mittelpunkt selbst: Gezaehlt werden die Punkte NEBEN ihm,
+       die Flaeche umfasst ihn aber mit. Ohne das misst man 43 statt 44 und
+       verwirft eine korrekte Umsetzung. */
+    return { breite: links + rechts + 1, hoehe: oben + unten + 1 };
+  }, waehler);
+}
+
+test("Ziel-Größen erreichen 44 px — tastbar, ohne dass der Schalter aufgeblasen wird", async ({
+  page,
+}) => {
   await seiteVorbereiten(page);
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
   await warteAufSchalter(page);
   await profilErzeugen(page);
 
+  /* Nach dem Erzeugen des Profils steht die Seite gescrollt; der Umschalter
+     liegt dann ausserhalb des Sichtfelds und elementFromPoint greift ins
+     Leere. Im Einzellauf fiel das nie auf, unter Last (sieben E2E-Dateien
+     gleichzeitig) schon — ein Messfehler, kein Mangel am Schalter. */
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await expect(page.locator(".sprach-pille")).toBeInViewport();
+
   for (const waehler of ['.sprach-knopf[data-lang="de"]', '.sprach-knopf[data-lang="en"]']) {
-    const k = await page.locator(waehler).boundingBox();
-    expect(Math.round(k.width), `Breite ${waehler}`).toBeGreaterThanOrEqual(44);
-    expect(Math.round(k.height), `Höhe ${waehler}`).toBeGreaterThanOrEqual(44);
+    const f = await trefferflaeche(page, waehler);
+    expect(f.breite, `tastbare Breite ${waehler}`).toBeGreaterThanOrEqual(44);
+    expect(f.hoehe, `tastbare Höhe ${waehler}`).toBeGreaterThanOrEqual(44);
   }
 
+  /* Und die SICHTBARE Pille bleibt schlank wie der abgenommene Entwurf.
+     Der erste Anlauf blies sie auf 108×52 auf — vom Nutzer sofort bemerkt. */
+  const pille = await page.locator(".sprach-pille").boundingBox();
+  expect(Math.round(pille.height), "sichtbare Höhe der Pille").toBeLessThanOrEqual(40);
+
   await page.click('.sprach-knopf[data-lang="en"]');
-  /* Erst messen, wenn die Rückfrage ihre Endgröße hat: Bis die Klasse
-     `sichtbar` gesetzt ist, steht sie auf scale(0.985) — 44 px wären dann
-     43,3 und der Test schlüge grundlos fehl. */
   await expect(page.locator('.sw-grund[data-modal="fertig"].sichtbar')).toBeVisible();
-  const x = await page.locator('.sw-grund[data-modal="fertig"] .sw-schliessen').boundingBox();
-  expect(Math.round(x.width)).toBeGreaterThanOrEqual(44);
-  expect(Math.round(x.height)).toBeGreaterThanOrEqual(44);
+  const x = await trefferflaeche(page, '.sw-grund[data-modal="fertig"] .sw-schliessen');
+  expect(x.breite, "tastbare Breite des X").toBeGreaterThanOrEqual(44);
+  expect(x.hoehe, "tastbare Höhe des X").toBeGreaterThanOrEqual(44);
 });
 
 test("Kontrast der gefüllten Flächen reicht in hell UND dunkel", async ({ page }) => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,8 @@ export default [
         navigator: "readonly",
         screen: "readonly",
         sessionStorage: "readonly",
+        localStorage: "readonly",
+        MutationObserver: "readonly",
         fetch: "readonly",
         console: "readonly",
         setTimeout: "readonly",
@@ -100,10 +102,13 @@ export default [
         afterAll: "readonly",
         vi: "readonly",
         sessionStorage: "readonly",
+        localStorage: "readonly",
+        MutationObserver: "readonly",
         /* Für den Test des Modus-Speichers: `localStorage` als Gegenprobe
            (die Wahl darf dort NICHT landen), `Storage` zum Nachstellen eines
            defekten Speichers wie im privaten Safari-Modus. */
         localStorage: "readonly",
+        MutationObserver: "readonly",
         Storage: "readonly",
       },
     },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,7 +7,21 @@ export default defineConfig({
     baseURL: "http://localhost:8081",
     headless: true,
   },
-  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+  projects: [
+    { name: "chromium", use: { browserName: "chromium" } },
+    /* WebKit ist die Maschine hinter Safari auf iPhone und iPad — dort laufen
+       die Workshops. Am 2026-08-13 hat genau dieser Lauf einen Fehler gezeigt,
+       den Chromium nicht zeigte: Safari setzt den Fokus ohne „Vollzugriff
+       Tastatur" nicht auf Knoepfe; wer den Dialog per Tab verliess, kam nicht
+       mehr zurueck. Nur die Umschalter-Tests, damit die Pipeline nicht
+       unnoetig waechst — das offizielle Playwright-Abbild bringt WebKit ohne
+       Zusatzinstallation mit. */
+    {
+      name: "webkit-sprachumschalter",
+      use: { browserName: "webkit", viewport: { width: 390, height: 844 } },
+      testMatch: /sprachumschalter.*\.test\.js/,
+    },
+  ],
   webServer: {
     command: "python3 -m http.server 8081 --directory public",
     port: 8081,

--- a/public/__tests__/i18n-guardian.test.js
+++ b/public/__tests__/i18n-guardian.test.js
@@ -219,10 +219,10 @@ describe("i18n Guardian", () => {
          eines: Sobald eine der drei Rechtsseiten Übersetzungs-Marker trägt,
          ist die Übergangslösung überflüssig — dann müssen js/sprachhinweis.js,
          seine Einbindung im HTML und dieser Eintrag weg. */
-      const wurzel = path.join(__dirname, "../..");
+      /* PUBLIC_DIR zeigt bereits auf public/ — siehe oben. */
       const rechtsseiten = ["datenschutz.html", "impressum.html", "nutzungsbedingungen.html"];
       const uebersetzt = rechtsseiten.filter((datei) => {
-        const p = path.join(wurzel, "public", datei);
+        const p = path.join(PUBLIC_DIR, datei);
         return fs.existsSync(p) && fs.readFileSync(p, "utf8").includes("data-i18n");
       });
 

--- a/public/__tests__/i18n-guardian.test.js
+++ b/public/__tests__/i18n-guardian.test.js
@@ -188,7 +188,18 @@ describe("i18n Guardian", () => {
      * As phases complete, files get REMOVED from this list.
      * The guardian then ensures they stay clean forever.
      */
-    const ALLOWLIST = [];
+    const ALLOWLIST = [
+      /* ÜBERGANG (2026-08-13): js/sprachhinweis.js trägt den zweisprachigen
+         Hinweis auf den noch nicht übersetzten Rechtsseiten. Die Texte stehen
+         dort bewusst fest im Code: Diese Seiten laden KEINE Sprachdatei und
+         rufen keine Schnittstelle auf — das ist eine geprüfte Eigenschaft
+         (e2e/sprachumschalter-unterseiten.test.js). Sie dafür zu öffnen wäre
+         der schlechtere Tausch.
+
+         Der Eintrag löst sich selbst auf: Der Test direkt darunter macht ihn
+         zum Fehler, sobald die Rechtsseiten übersetzt sind. */
+      "js/sprachhinweis.js",
+    ];
 
     it("non-allowlisted JS files have no hardcoded German", () => {
       const violations = [];
@@ -201,6 +212,27 @@ describe("i18n Guardian", () => {
         }
       }
       expect(violations).toEqual([]);
+    });
+
+    it("die Übergangs-Ausnahme verschwindet, sobald die Rechtsseiten übersetzt sind", () => {
+      /* Eine Ausnahme ohne Ablaufdatum wird zur Dauerlösung. Diese hier hat
+         eines: Sobald eine der drei Rechtsseiten Übersetzungs-Marker trägt,
+         ist die Übergangslösung überflüssig — dann müssen js/sprachhinweis.js,
+         seine Einbindung im HTML und dieser Eintrag weg. */
+      const wurzel = path.join(__dirname, "../..");
+      const rechtsseiten = ["datenschutz.html", "impressum.html", "nutzungsbedingungen.html"];
+      const uebersetzt = rechtsseiten.filter((datei) => {
+        const p = path.join(wurzel, "public", datei);
+        return fs.existsSync(p) && fs.readFileSync(p, "utf8").includes("data-i18n");
+      });
+
+      if (uebersetzt.length === 0) return; // Übergang gilt noch
+
+      expect(
+        ALLOWLIST.includes("js/sprachhinweis.js"),
+        `${uebersetzt.join(", ")} ist übersetzt — die Übergangslösung js/sprachhinweis.js ` +
+          "und dieser Allowlist-Eintrag gehören jetzt entfernt"
+      ).toBe(false);
     });
 
     it("allowlist contains only files that need it (hygiene)", () => {

--- a/public/__tests__/sprachumschalter.test.js
+++ b/public/__tests__/sprachumschalter.test.js
@@ -8,6 +8,11 @@ import { setupDOM } from "./setup.js";
 let aktuelleSprache = "de";
 let ladenScheitert = false;
 
+let statusNeuGeschrieben = 0;
+vi.mock("../js/ui.js", () => ({
+  statusNeuSchreiben: () => statusNeuGeschrieben++,
+}));
+
 vi.mock("../js/i18n.js", () => ({
   t: (key) => key,
   getLanguage: () => aktuelleSprache,
@@ -116,21 +121,27 @@ describe("Sprachumschalter — wann gefragt wird", () => {
 
   it("laufende Analyse: Rückfrage statt Wechsel", () => {
     state.isAnalyzing = true;
+    state.lastFile = { name: "a.jpg" };
     langKnopf("en").click();
     expect(sichtbaresModal().dataset.modal).toBe("laeuft");
     expect(aktuelleSprache).toBe("de");
   });
 
-  it("fertiges Profil: Rückfrage mit Verlust-Hinweis", () => {
+  it("fertiges Profil: die Rückfrage ist als die folgenschwere erkennbar", () => {
     state.lastData = { profileText: "x" };
+    state.lastFile = { name: "a.jpg" };
     langKnopf("en").click();
     const modal = sichtbaresModal();
     expect(modal.dataset.modal).toBe("fertig");
-    expect(modal.querySelector(".sw-hinweis")).not.toBeNull();
+    /* Beide Rückfragen sahen gleich aus, deshalb las sie niemand. Die
+       löschende trägt jetzt eine eigene Markierung. */
+    expect(modal.querySelector(".sw-modal--fertig")).not.toBeNull();
+    expect(modal.querySelector(".sw-modal--laeuft")).toBeNull();
   });
 
   it("laufender Upload zählt wie eine laufende Analyse", () => {
     state.uploadLaeuft = true;
+    state.lastFile = { name: "a.jpg" };
     langKnopf("en").click();
     expect(sichtbaresModal().dataset.modal).toBe("laeuft");
   });
@@ -154,6 +165,7 @@ describe("Sprachumschalter — wann gefragt wird", () => {
 
   it("Klick auf die bereits eingestellte Sprache tut nichts", () => {
     state.lastData = { profileText: "x" };
+    state.lastFile = { name: "a.jpg" };
     langKnopf("de").click();
     expect(sichtbaresModal()).toBeNull();
     expect(aktuelleSprache).toBe("de");
@@ -212,12 +224,19 @@ describe("Sprachumschalter — Bestätigen", () => {
     expect(analysiert).toEqual([{ name: "foto.jpg" }]);
   });
 
-  it("ohne Bild wird nichts neu gestartet", async () => {
-    state.lastFile = null;
-    langKnopf("en").click();
-    sichtbaresModal().querySelector(".sw-knopf--wechseln").click();
-    await vi.waitFor(() => expect(aktuelleSprache).toBe("en"));
-    expect(analysiert).toHaveLength(0);
+  it("Rückfragen bleiben kurz — höchstens ein Satz Text", () => {
+    /* Nutzer-Ansage 2026-08-13: „Das lässt sich niemals jemand durch." Ein
+       Grenzwert im Test hält das fest, sonst wächst der Text unbemerkt wieder. */
+    for (const art of ["fertig", "laeuft"]) {
+      state.lastFile = { name: "a.jpg" };
+      state.isAnalyzing = art === "laeuft";
+      state.lastData = art === "fertig" ? { profileText: "x" } : null;
+      langKnopf("en").click();
+      const modal = sichtbaresModal();
+      const absaetze = modal.querySelectorAll(".sw-modal p");
+      expect(absaetze.length, `${art}: Anzahl Absätze`).toBeLessThanOrEqual(1);
+      modal.querySelector(".sw-knopf--bleiben").click();
+    }
   });
 
   it("scheitert das Laden der Sprachdatei, bleibt alles beim Alten", async () => {
@@ -259,6 +278,7 @@ describe("Sprachumschalter — Barrierefreiheit", () => {
 
   it("der Dialog ist als solcher ausgewiesen und beschriftet", () => {
     state.lastData = { profileText: "x" };
+    state.lastFile = { name: "a.jpg" };
     langKnopf("en").click();
     const kasten = sichtbaresModal().querySelector(".sw-modal");
     expect(kasten.getAttribute("role")).toBe("dialog");
@@ -269,6 +289,7 @@ describe("Sprachumschalter — Barrierefreiheit", () => {
 
   it("während der Rückfrage ist alles andere stillgelegt", () => {
     state.lastData = { profileText: "x" };
+    state.lastFile = { name: "a.jpg" };
     langKnopf("en").click();
     const offen = sichtbaresModal();
     const andere = Array.from(document.body.children).filter((el) => el !== offen);
@@ -278,6 +299,7 @@ describe("Sprachumschalter — Barrierefreiheit", () => {
 
   it("nach dem Schließen ist die Stilllegung restlos zurückgenommen", () => {
     state.lastData = { profileText: "x" };
+    state.lastFile = { name: "a.jpg" };
     langKnopf("en").click();
     sichtbaresModal().querySelector(".sw-knopf--bleiben").click();
     Array.from(document.body.children).forEach((el) => {
@@ -287,6 +309,7 @@ describe("Sprachumschalter — Barrierefreiheit", () => {
 
   it("der Fokus landet im Dialog und kehrt danach auf den Schalter zurück", () => {
     state.lastData = { profileText: "x" };
+    state.lastFile = { name: "a.jpg" };
     const ausloeser = langKnopf("en");
     ausloeser.focus();
     ausloeser.click();
@@ -313,11 +336,64 @@ describe("Sprachumschalter — Tür über die Adresse", () => {
     window.history.replaceState({}, "", suche || "/");
   }
 
-  afterEach(() => adresse("/"));
+  afterEach(() => {
+    adresse("/");
+    try {
+      localStorage.removeItem("malzime-tuer-sprachumschalter");
+    } catch {
+      /* jsdom ohne Speicher */
+    }
+  });
 
   it("?sprachumschalter=1 blendet ihn ein, ohne Merkmal und ohne Konsole", () => {
     adresse("/?sprachumschalter=1");
     initSprachumschalter({ analysiere: () => {} });
+    expect(pille()).not.toBeNull();
+  });
+
+  it("die Tür bleibt offen — auch ohne Anhängsel und in einem neuen Tab", () => {
+    /* Der eigentliche Grund für den geräteweiten Speicher: Die Rechtsseiten
+       öffnen mit target="_blank" rel="noopener" (index.html:348), und ein so
+       geöffneter Tab bekommt einen LEEREN sessionStorage. Die erste Fassung
+       legte die Spur dort ab — sie kam nie an. */
+    adresse("/?sprachumschalter=1");
+    initSprachumschalter({ analysiere: () => {} });
+    expect(pille()).not.toBeNull();
+
+    zeigeSprachumschalter(false);
+    baueSeite();
+    adresse("/");
+    initSprachumschalter({ analysiere: () => {} });
+    expect(pille()).toBeNull(); // aushängen schliesst die Tür ausdrücklich
+  });
+
+  it("?sprachumschalter=0 schliesst die Tür wieder", () => {
+    adresse("/?sprachumschalter=1");
+    initSprachumschalter({ analysiere: () => {} });
+    expect(pille()).not.toBeNull();
+
+    baueSeite();
+    adresse("/?sprachumschalter=0");
+    initSprachumschalter({ analysiere: () => {} });
+    expect(pille()).toBeNull();
+  });
+
+  it("einmal geöffnet, gilt sie auch beim nächsten Aufruf ohne Anhängsel", async () => {
+    adresse("/?sprachumschalter=1");
+    initSprachumschalter({ analysiere: () => {} });
+    expect(pille()).not.toBeNull();
+
+    /* Ein echter neuer Seitenaufruf: frisches Modul, frisches DOM, kein
+       Anhängsel mehr in der Adresse. Ohne vi.resetModules() glaubt das Modul,
+       es sei noch eingehängt, und der Test bewiese nichts. */
+    vi.resetModules();
+    baueSeite();
+    adresse("/datenschutz");
+    const frisch = await import("../js/sprachumschalter.js");
+    frisch.initSprachumschalter({ analysiere: () => {} });
+
+    /* Der Schalter muss da sein — sonst ist er beim ersten Klick in die
+       Fußleiste wieder weg, und genau das war der gemeldete Fehler. */
     expect(pille()).not.toBeNull();
   });
 
@@ -338,5 +414,87 @@ describe("Sprachumschalter — Tür über die Adresse", () => {
     adresse("/?lang=en&sprachumschalter=1");
     initSprachumschalter({ analysiere: () => {} });
     expect(pille()).not.toBeNull();
+  });
+});
+
+describe("Sprachumschalter — nach einem Neuladen ist das Bild weg", () => {
+  /* Vom Nutzer gefunden und dreimal nachgebessert:
+     1. Die Rückfrage versprach eine Analyse, die nicht stattfinden konnte.
+     2. Ein eigener Dialog verhandelte über etwas Unmögliches.
+     3. Ohne Dialog blieb ein Profil in der alten Sprache stehen.
+     Richtig ist: Das Profil wird gelöscht, man landet auf einer sauberen
+     Startseite — dieselbe Rückfrage wie sonst, nur ein anderer Satz. */
+  let zurueckgesetzt;
+
+  beforeEach(() => {
+    zurueckgesetzt = 0;
+    initSprachumschalter({
+      analysiere: (datei) => analysiert.push(datei),
+      zuruecksetze: () => zurueckgesetzt++,
+    });
+    zeigeSprachumschalter(true);
+    document.getElementById("facts").innerHTML = '<div class="cat-card"></div>';
+    state.lastData = { profileText: "x" };
+    state.lastFile = null;
+  });
+
+  it("es kommt die Löschen-Rückfrage, nicht die mit dem Neuanalyse-Versprechen", () => {
+    langKnopf("en").click();
+    const modal = sichtbaresModal();
+    expect(modal.dataset.modal).toBe("fertig");
+    expect(modal.querySelector("p").dataset.swKey).toBe("sprache.fertig.textOhneBild");
+  });
+
+  it("mit Bild steht dort der andere Satz", () => {
+    state.lastFile = { name: "a.jpg" };
+    langKnopf("en").click();
+    expect(sichtbaresModal().querySelector("p").dataset.swKey).toBe("sprache.fertig.text");
+  });
+
+  it("bestätigen setzt zurück, statt eine unmögliche Analyse zu starten", async () => {
+    langKnopf("en").click();
+    sichtbaresModal().querySelector(".sw-knopf--wechseln").click();
+    await vi.waitFor(() => expect(zurueckgesetzt).toBe(1));
+    expect(analysiert).toHaveLength(0);
+  });
+
+  it("abbrechen setzt nichts zurück", () => {
+    langKnopf("en").click();
+    sichtbaresModal().querySelector(".sw-knopf--bleiben").click();
+    expect(zurueckgesetzt).toBe(0);
+    expect(aktuelleSprache).toBe("de");
+  });
+
+  it("mit Bild wird analysiert und NICHT zurückgesetzt", async () => {
+    state.lastFile = { name: "foto.jpg" };
+    langKnopf("en").click();
+    sichtbaresModal().querySelector(".sw-knopf--wechseln").click();
+    await vi.waitFor(() => expect(analysiert).toHaveLength(1));
+    expect(zurueckgesetzt).toBe(0);
+  });
+});
+
+describe("Sprachumschalter — stehende Meldungen wechseln mit", () => {
+  /* Gefunden beim Durchgang durch alle Zustände der echten Anwendung
+     (2026-08-13): Nach einem Fehlschlag stand die Fehlermeldung weiter auf
+     Deutsch, während die Seite auf Englisch umschaltete. Eine einmal gesetzte
+     Zeichenkette, die niemand mehr anfasst. */
+  beforeEach(() => {
+    statusNeuGeschrieben = 0;
+    zeigeSprachumschalter(true);
+  });
+
+  it("jeder Wechsel schreibt die Statuszeile neu", async () => {
+    langKnopf("en").click();
+    await vi.waitFor(() => expect(aktuelleSprache).toBe("en"));
+    expect(statusNeuGeschrieben).toBe(1);
+  });
+
+  it("ein abgebrochener Wechsel schreibt nichts neu", () => {
+    state.lastData = { profileText: "x" };
+    state.lastFile = { name: "a.jpg" };
+    langKnopf("en").click();
+    sichtbaresModal().querySelector(".sw-knopf--bleiben").click();
+    expect(statusNeuGeschrieben).toBe(0);
   });
 });

--- a/public/__tests__/sprachumschalter.test.js
+++ b/public/__tests__/sprachumschalter.test.js
@@ -442,13 +442,13 @@ describe("Sprachumschalter — nach einem Neuladen ist das Bild weg", () => {
     langKnopf("en").click();
     const modal = sichtbaresModal();
     expect(modal.dataset.modal).toBe("fertig");
-    expect(modal.querySelector("p").dataset.swKey).toBe("sprache.fertig.textOhneBild");
+    expect(modal.querySelector("p").dataset.swKeyHtml).toBe("sprache.fertig.textOhneBild");
   });
 
   it("mit Bild steht dort der andere Satz", () => {
     state.lastFile = { name: "a.jpg" };
     langKnopf("en").click();
-    expect(sichtbaresModal().querySelector("p").dataset.swKey).toBe("sprache.fertig.text");
+    expect(sichtbaresModal().querySelector("p").dataset.swKeyHtml).toBe("sprache.fertig.text");
   });
 
   it("bestätigen setzt zurück, statt eine unmögliche Analyse zu starten", async () => {
@@ -496,5 +496,30 @@ describe("Sprachumschalter — stehende Meldungen wechseln mit", () => {
     langKnopf("en").click();
     sichtbaresModal().querySelector(".sw-knopf--bleiben").click();
     expect(statusNeuGeschrieben).toBe(0);
+  });
+});
+
+describe("Sprachumschalter — die Rückfrage handelt vom Sprachwechsel", () => {
+  /* Ein Anlauf setzte die Löschwarnung als Überschrift. Vor jemandem, der nur
+     die Sprache wechseln wollte, stand damit eine Schreckmeldung ohne
+     Zusammenhang — und der Bestätigungsknopf hiess „Neu analysieren", obwohl
+     nach einem Neuladen gar nichts analysiert werden kann. */
+  const faelle = [
+    ["fertig, Bild da", { lastData: { profileText: "x" }, lastFile: { name: "a.jpg" } }],
+    ["fertig, Bild weg", { lastData: { profileText: "x" }, lastFile: null }],
+    ["Analyse läuft", { isAnalyzing: true, lastFile: { name: "a.jpg" } }],
+  ];
+
+  it.each(faelle)("%s: Überschrift und Knöpfe sind dieselben", (_name, zustand) => {
+    zeigeSprachumschalter(true);
+    Object.assign(state, zustand);
+    langKnopf("en").click();
+    const modal = sichtbaresModal();
+    expect(modal).not.toBeNull();
+    expect(modal.querySelector("h2").dataset.swKey).toMatch(/^sprache\.(fertig|laeuft)\.titel$/);
+    /* Immer derselbe Bestätigungstext — der Nutzer bestätigt den
+       SPRACHWECHSEL, nicht wechselnde Nebenwirkungen. */
+    expect(modal.querySelector(".sw-knopf--wechseln").dataset.swKey).toMatch(/^sprache\.(fertig|laeuft)\.wechseln$/);
+    expect(modal.querySelector(".sw-knopf--bleiben").dataset.swKey).toMatch(/^sprache\.(fertig|laeuft)\.bleiben$/);
   });
 });

--- a/public/__tests__/sprachumschalter.test.js
+++ b/public/__tests__/sprachumschalter.test.js
@@ -304,3 +304,39 @@ describe("Sprachumschalter — Barrierefreiheit", () => {
     });
   });
 });
+
+describe("Sprachumschalter — Tür über die Adresse", () => {
+  /* jsdom laesst window.location nicht ohne Weiteres umschreiben; die Adresse
+     wird deshalb ueber history.replaceState gesetzt — genau das liest
+     URLSearchParams. */
+  function adresse(suche) {
+    window.history.replaceState({}, "", suche || "/");
+  }
+
+  afterEach(() => adresse("/"));
+
+  it("?sprachumschalter=1 blendet ihn ein, ohne Merkmal und ohne Konsole", () => {
+    adresse("/?sprachumschalter=1");
+    initSprachumschalter({ analysiere: () => {} });
+    expect(pille()).not.toBeNull();
+  });
+
+  it.each([
+    ["0", "/?sprachumschalter=0"],
+    ["false", "/?sprachumschalter=false"],
+    ["leer", "/?sprachumschalter="],
+    ["ganz ohne", "/"],
+  ])("der Wert %s blendet ihn NICHT ein", (_name, suche) => {
+    /* Streng, damit ein Tippfehler in einem herumgereichten Link kein
+         Bedienelement vor ein Workshop-Publikum stellt. */
+    adresse(suche);
+    initSprachumschalter({ analysiere: () => {} });
+    expect(pille()).toBeNull();
+  });
+
+  it("die Adresse verträgt sich mit ?lang=en", () => {
+    adresse("/?lang=en&sprachumschalter=1");
+    initSprachumschalter({ analysiere: () => {} });
+    expect(pille()).not.toBeNull();
+  });
+});

--- a/public/app.js
+++ b/public/app.js
@@ -17,7 +17,7 @@ import { enthuellungAbkuerzen, modusWechsel } from "./js/live-anzeige.js";
 import * as realitaetsCheck from "./js/realitaets-check.js";
 import { merkeModus, gemerkterModus } from "./js/modus-speicher.js";
 import { initAbsturzWache, merkePhase } from "./js/absturz-wache.js";
-import { initSprachumschalter, zeigeSprachumschalter } from "./js/sprachumschalter.js";
+import { initSprachumschalter, merkmalUebernehmen } from "./js/sprachumschalter.js";
 
 /* ── Absturz-Wache: als ALLERERSTES, vor jedem await ──
    Startet die Seite mehrfach binnen einer Minute, meldet sie das einmalig und
@@ -68,8 +68,9 @@ state.statsReady = fetch("/api/stats", { signal: statsAbort.signal })
     }
     /* v3.3: Sprachumschalter nur bauen, wenn das Merkmal an ist. Steht es aus
        oder war die Antwort nicht lesbar, entsteht kein Element — kein toter
-       Schalter, den jemand vergeblich anklickt. */
-    if (data?.sprachumschalter === true) zeigeSprachumschalter(true);
+       Schalter, den jemand vergeblich anklickt. Auch bei `false` aufrufen:
+       Nur so erfahren die Unterseiten, dass das Merkmal wieder aus ist. */
+    merkmalUebernehmen(data?.sprachumschalter === true);
   })
   .catch(() => {})
   .finally(() => clearTimeout(statsTimer));
@@ -77,7 +78,17 @@ state.statsReady = fetch("/api/stats", { signal: statsAbort.signal })
 /* v3.3: Sprachumschalter anmelden — bedingungslos, damit die Konsolen-Tuer
    `malziME.sprachumschalter()` auch dann offensteht, wenn /api/stats nicht
    antwortet. Gebaut wird erst auf Zuruf (Merkmals-Schloss oder Konsole). */
-initSprachumschalter({ analysiere: handleNewFile });
+initSprachumschalter({
+  analysiere: handleNewFile,
+  /* Nach einem Neuladen liegt zwar ein Ergebnis vor, die Bilddatei aber nicht
+     mehr. Wer dann die Sprache wechselt, soll nicht ein Profil in der alten
+     Sprache behalten — er landet auf einer sauberen Startseite. Den gemerkten
+     Auftrag vorher verwerfen, sonst holt ihn der nächste Seitenaufruf zurück. */
+  zuruecksetze: () => {
+    clearStoredJobId();
+    window.location.reload();
+  },
+});
 
 /* Maintenance-Modal: Seite neu laden */
 elements.maintenanceReload.addEventListener("click", () => location.reload());

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -174,5 +174,9 @@
         <a href="/stats" tabindex="0">Stats</a>
       </div>
     </footer>
+    <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
+         Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
+         sobald sie übersetzt ist. -->
+    <script type="module" src="./js/sprachhinweis.js?v=2026081303"></script>
   </body>
 </html>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -113,5 +113,9 @@
         <a href="/stats" tabindex="0">Stats</a>
       </div>
     </footer>
+    <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
+         Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
+         sobald sie übersetzt ist. -->
+    <script type="module" src="./js/sprachhinweis.js?v=2026081303"></script>
   </body>
 </html>

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -504,7 +504,7 @@ async function renderQueueResult(data, myId, traceId, timings) {
   if (!data) {
     /* Nie halben Live-Text stehen lassen — Karte weg, normale Fehlermeldung. */
     liveAnzeige.abbrechen();
-    setStatus(t("error.queueFailed"), traceId);
+    setStatus(t("error.queueFailed"), traceId, "error.queueFailed");
     return;
   }
   /* Client-seitige Daten injizieren — GPS/dateTimeOriginal erreichen nie unsere
@@ -623,14 +623,14 @@ async function analyzeImageQueued() {
   const file = state.lastFile || elements.fileInput.files[0];
   if (!file) {
     stopScanAnim();
-    setStatus(t("error.noFile"));
+    setStatus(t("error.noFile"), undefined, "error.noFile");
     state.isAnalyzing = false;
     state.uploadLaeuft = false;
     return;
   }
   if (file.size > 25 * 1024 * 1024) {
     stopScanAnim();
-    setStatus(t("error.fileTooLarge"));
+    setStatus(t("error.fileTooLarge"), undefined, "error.fileTooLarge");
     state.isAnalyzing = false;
     state.uploadLaeuft = false;
     return;
@@ -695,22 +695,22 @@ async function analyzeImageQueued() {
       }
       if (enqueueResp.status === 429 && parsed && parsed.blocked === "limit") {
         showLimitBanner(parsed.retryAfterSeconds || 600);
-        setStatus(t("error.rateLimit"), traceId);
+        setStatus(t("error.rateLimit"), traceId, "error.rateLimit");
       } else if (enqueueResp.status === 429 && parsed && parsed.blocked === "queueFull") {
         /* UX-2026-08-13-FE-02: Die volle Warteschlange ist im Workshop-Burst der
            ERWARTETE Fall, nicht ein Serverfehler. Vorher fiel er in den else-Zweig
            mit "Wir haben es dreimal probiert" — auf dem enqueue-Weg wird aber
            nichts wiederholt (ein einziger fetch). Eigener Text + die vom Server
            mitgelieferte Wartezeit. */
-        setStatus(t("error.queueFull"), traceId);
+        setStatus(t("error.queueFull"), traceId, "error.queueFull");
       } else if (enqueueResp.status === 503 && parsed && parsed.maintenance) {
         showMaintenanceModal(parsed.message);
       } else if (enqueueResp.status === 413) {
-        setStatus(t("error.imageTooLarge"), traceId);
+        setStatus(t("error.imageTooLarge"), traceId, "error.imageTooLarge");
       } else if (enqueueResp.status === 400) {
-        setStatus(t("error.invalidFormat"), traceId);
+        setStatus(t("error.invalidFormat"), traceId, "error.invalidFormat");
       } else {
-        setStatus(t("error.serverBusy"), traceId);
+        setStatus(t("error.serverBusy"), traceId, "error.serverBusy");
       }
       logClientError(new Error(`enqueue HTTP ${enqueueResp.status}`), {
         phase: "queue-enqueue",
@@ -727,7 +727,7 @@ async function analyzeImageQueued() {
     const jobId = enqueueData && enqueueData.jobId;
     if (!jobId) {
       stopScanAnim();
-      setStatus(t("error.queueFailed"), traceId);
+      setStatus(t("error.queueFailed"), traceId, "error.queueFailed");
       return;
     }
     /* PRIV-003: Abhol-Ticket vom Server merken + bei jedem Poll mitschicken. */
@@ -752,7 +752,7 @@ async function analyzeImageQueued() {
       /* v3.0: nie halben Live-Text stehen lassen — Karte samt Text weg. */
       liveAnzeige.abbrechen();
       clearStoredJobId();
-      setStatus(t("error.queueAbandoned"), traceId);
+      setStatus(t("error.queueAbandoned"), traceId, "error.queueAbandoned");
       return;
     }
     if (outcome.error) {
@@ -794,16 +794,16 @@ async function analyzeImageQueued() {
     let phase;
     if (err.message === "read_failed") {
       phase = "image-read";
-      setStatus(t("error.readFailed"), traceId);
+      setStatus(t("error.readFailed"), traceId, "error.readFailed");
     } else if (err.message === "image_decode_failed") {
       phase = "image-decode";
-      setStatus(t("error.decodeFailed"), traceId);
+      setStatus(t("error.decodeFailed"), traceId, "error.decodeFailed");
     } else if (!navigator.onLine) {
       phase = "offline";
-      setStatus(t("error.offline"), traceId);
+      setStatus(t("error.offline"), traceId, "error.offline");
     } else {
       phase = "queue-network";
-      setStatus(t("error.networkError"), traceId);
+      setStatus(t("error.networkError"), traceId, "error.networkError");
     }
     logClientError(err, {
       phase,

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -83,7 +83,7 @@ async function loadDemoImage(url, name) {
        Demo-Fotos sind ausgerechnet der Rückfallweg für Workshops. Jetzt Meldung,
        Animation stoppen, Fehler protokollieren. */
     stopScanAnim(true);
-    setStatus(t("error.networkError"));
+    setStatus(t("error.networkError"), undefined, "error.networkError");
     logClientError(err, { phase: "demo-image-load", demo: name });
   }
 }

--- a/public/js/sprachhinweis.js
+++ b/public/js/sprachhinweis.js
@@ -1,0 +1,208 @@
+/* ── Sprachumschalter auf den noch nicht übersetzten Seiten ────────────────
+ *
+ * ÜBERGANGSLÖSUNG. Sie verschwindet vollständig, sobald Datenschutzerklärung,
+ * Impressum und Nutzungsbedingungen auf Englisch vorliegen: dann bekommen
+ * diese Seiten den echten Umschalter aus js/sprachumschalter.js, und diese
+ * Datei samt ihrer beiden Zeilen im HTML wird gelöscht.
+ *
+ * Warum es sie überhaupt gibt: Der Umschalter gehört auf JEDE Seite. Fehlte er
+ * hier, sähe es aus wie ein Fehler — man käme von der englischen Startseite und
+ * hätte plötzlich kein Bedienelement mehr.
+ *
+ * Zwei bewusste Festlegungen:
+ *
+ * 1. Der Schalter steht hier IMMER auf DE, auch bei englischem Browser und
+ *    auch, wenn im Tab vorher Englisch gewählt wurde. Er sagt aus, in welcher
+ *    Sprache das dasteht, was man gerade liest — und das ist Deutsch. EN
+ *    anzuzeigen wäre schlicht falsch.
+ *
+ * 2. Der Hinweis ist ZWEISPRACHIG. Wer auf EN klickt, liest kein Deutsch; eine
+ *    rein deutsche Erklärung wäre genau die falsche. Zwei kurze Zeilen
+ *    untereinander sind auch deshalb richtig, weil so keine Sprachlogik
+ *    entsteht, die später zurückgebaut werden müsste.
+ *
+ * Diese Seiten laden sonst KEIN JavaScript und rufen keine Schnittstelle auf.
+ * Das bleibt so: Ob der Umschalter erscheint, entscheidet allein die Adresse
+ * (`?sprachumschalter=1`) oder eine Spur, die die Startseite im selben Tab
+ * hinterlassen hat. Kein Netzweg, kein Merkmals-Abruf auf einer Rechtsseite.
+ */
+
+const SPUR = "malzime-sprachumschalter";
+const KREUZ_ZEICHEN = "×";
+
+const TEXTE = {
+  titel_de: "Diese Seite gibt es noch nicht auf Englisch.",
+  titel_en: "This page is not available in English yet.",
+  text_de: "Sie wird gerade übersetzt. Die Startseite und die Analyse sind schon auf Englisch.",
+  text_en: "It is being translated. The start page and the analysis are already in English.",
+  knopf: "OK",
+  schliessen_de: "Schließen",
+  schliessen_en: "Close",
+};
+
+function sichtbar() {
+  try {
+    if (new URLSearchParams(window.location.search).get("sprachumschalter") === "1") return true;
+    return sessionStorage.getItem(SPUR) === "1";
+  } catch (_err) {
+    return false;
+  }
+}
+
+function knopf(code, aktiv) {
+  const b = document.createElement("button");
+  b.type = "button";
+  b.className = "sprach-knopf" + (aktiv ? " aktiv" : "");
+  b.dataset.lang = code;
+  b.textContent = code.toUpperCase();
+  b.lang = code;
+  b.setAttribute("aria-pressed", String(aktiv));
+  b.setAttribute("aria-label", code === "de" ? "Deutsch" : "English");
+  return b;
+}
+
+function baueUmschalter(beiKlick) {
+  const huelle = document.createElement("div");
+  huelle.className = "sprachwahl";
+
+  const pille = document.createElement("div");
+  pille.className = "sprach-pille";
+  pille.setAttribute("role", "group");
+  pille.setAttribute("aria-label", "Sprache wählen / Choose language");
+
+  const schieber = document.createElement("span");
+  schieber.className = "sprach-schieber";
+  schieber.setAttribute("aria-hidden", "true");
+  pille.appendChild(schieber);
+
+  /* DE ist hier immer der aktive Stand — siehe Festlegung 1 oben. */
+  pille.appendChild(knopf("de", true));
+  const en = knopf("en", false);
+  en.addEventListener("click", beiKlick);
+  pille.appendChild(en);
+
+  huelle.appendChild(pille);
+  return huelle;
+}
+
+function baueHinweis() {
+  const grund = document.createElement("div");
+  grund.className = "sw-grund";
+  grund.dataset.modal = "unuebersetzt";
+  grund.hidden = true;
+
+  const kasten = document.createElement("div");
+  kasten.className = "sw-modal";
+  kasten.setAttribute("role", "dialog");
+  kasten.setAttribute("aria-modal", "true");
+
+  const schliessen = document.createElement("button");
+  schliessen.type = "button";
+  schliessen.className = "sw-schliessen";
+  schliessen.setAttribute("aria-label", `${TEXTE.schliessen_de} / ${TEXTE.schliessen_en}`);
+  const kreuz = document.createElement("span");
+  kreuz.setAttribute("aria-hidden", "true");
+  kreuz.textContent = KREUZ_ZEICHEN;
+  schliessen.appendChild(kreuz);
+
+  const titel = document.createElement("h2");
+  titel.id = "sw-titel-unuebersetzt";
+  titel.lang = "de";
+  titel.textContent = TEXTE.titel_de;
+  kasten.setAttribute("aria-labelledby", titel.id);
+
+  const textDe = document.createElement("p");
+  textDe.lang = "de";
+  textDe.textContent = TEXTE.text_de;
+
+  const titelEn = document.createElement("h2");
+  titelEn.className = "sw-zweitsprache";
+  titelEn.lang = "en";
+  titelEn.textContent = TEXTE.titel_en;
+
+  const textEn = document.createElement("p");
+  textEn.lang = "en";
+  textEn.textContent = TEXTE.text_en;
+
+  const knoepfe = document.createElement("div");
+  knoepfe.className = "sw-knoepfe";
+  const ok = document.createElement("button");
+  ok.type = "button";
+  ok.className = "sw-knopf sw-knopf--bleiben";
+  ok.textContent = TEXTE.knopf;
+  knoepfe.appendChild(ok);
+
+  kasten.append(schliessen, titel, textDe, titelEn, textEn, knoepfe);
+  grund.appendChild(kasten);
+
+  return { grund, ok, schliessen };
+}
+
+function start() {
+  if (!sichtbar()) return;
+
+  const ziel = document.getElementById("main") || document.querySelector("main") || document.body;
+  const { grund, ok, schliessen } = baueHinweis();
+  let ausloeser = null;
+
+  function stillegen(an) {
+    Array.prototype.forEach.call(document.body.children, (kind) => {
+      if (kind === grund) return;
+      if (an) kind.setAttribute("inert", "");
+      else kind.removeAttribute("inert");
+    });
+  }
+
+  function oeffnen() {
+    ausloeser = document.activeElement;
+    grund.hidden = false;
+    stillegen(true);
+    const dieser = grund;
+    requestAnimationFrame(() => dieser.classList.add("sichtbar"));
+    ok.focus();
+  }
+
+  function schliessenTun() {
+    if (grund.hidden) return;
+    stillegen(false);
+    grund.classList.remove("sichtbar");
+    setTimeout(() => {
+      grund.hidden = true;
+    }, 200);
+    if (ausloeser && typeof ausloeser.focus === "function") ausloeser.focus();
+    ausloeser = null;
+  }
+
+  const umschalter = baueUmschalter(oeffnen);
+  ziel.insertBefore(umschalter, ziel.firstChild);
+  document.body.appendChild(grund);
+
+  ok.addEventListener("click", schliessenTun);
+  schliessen.addEventListener("click", schliessenTun);
+  grund.addEventListener("click", (e) => {
+    if (e.target === grund) schliessenTun();
+  });
+
+  /* Fokus-Fänger: `inert` hält ihn aus der Umgebung heraus, aber hinter dem
+     letzten Knopf verließe er das Dokument in die Browserleiste. */
+  document.addEventListener("keydown", (e) => {
+    if (grund.hidden) return;
+    if (e.key === "Escape") {
+      schliessenTun();
+      return;
+    }
+    if (e.key !== "Tab") return;
+    const ziele = Array.from(grund.querySelectorAll("button"));
+    const erster = ziele[0];
+    const letzter = ziele[ziele.length - 1];
+    if (e.shiftKey && document.activeElement === erster) {
+      e.preventDefault();
+      letzter.focus();
+    } else if (!e.shiftKey && document.activeElement === letzter) {
+      e.preventDefault();
+      erster.focus();
+    }
+  });
+}
+
+start();

--- a/public/js/sprachhinweis.js
+++ b/public/js/sprachhinweis.js
@@ -27,25 +27,38 @@
  * hinterlassen hat. Kein Netzweg, kein Merkmals-Abruf auf einer Rechtsseite.
  */
 
-const SPUR = "malzime-sprachumschalter";
+const TUER = "malzime-tuer-sprachumschalter";
+const MERKMAL = "malzime-umschalter-aktiv";
 const KREUZ_ZEICHEN = "×";
 
+/* Je EIN Satz pro Sprache. Alles darüber hinaus liest im Workshop niemand
+   (Nutzer-Ansage 2026-08-13). */
 const TEXTE = {
-  titel_de: "Diese Seite gibt es noch nicht auf Englisch.",
-  titel_en: "This page is not available in English yet.",
-  text_de: "Sie wird gerade übersetzt. Die Startseite und die Analyse sind schon auf Englisch.",
-  text_en: "It is being translated. The start page and the analysis are already in English.",
+  titel_de: "Diese Seite gibt es nur auf Deutsch.",
+  titel_en: "This page is German only.",
   knopf: "OK",
   schliessen_de: "Schließen",
   schliessen_en: "Close",
 };
 
+/* Dieselbe Tür wie auf der Startseite (js/sprachumschalter.js). Sie liegt im
+   localStorage, weil diese Seiten mit target="_blank" rel="noopener" geöffnet
+   werden: Ein so geöffneter Tab bekommt einen leeren sessionStorage, eine
+   Spur von dort wäre hier nie angekommen. */
 function sichtbar() {
+  let wert = null;
   try {
-    if (new URLSearchParams(window.location.search).get("sprachumschalter") === "1") return true;
-    return sessionStorage.getItem(SPUR) === "1";
+    wert = new URLSearchParams(window.location.search).get("sprachumschalter");
   } catch (_err) {
-    return false;
+    /* kaputte Adresse */
+  }
+  try {
+    if (wert === "1") localStorage.setItem(TUER, "1");
+    if (wert === "0") localStorage.removeItem(TUER);
+    return localStorage.getItem(TUER) === "1" || localStorage.getItem(MERKMAL) === "1";
+  } catch (_err) {
+    /* Privater Modus: dann gilt nur die Angabe in der Adresse. */
+    return wert === "1";
   }
 }
 
@@ -111,18 +124,10 @@ function baueHinweis() {
   titel.textContent = TEXTE.titel_de;
   kasten.setAttribute("aria-labelledby", titel.id);
 
-  const textDe = document.createElement("p");
-  textDe.lang = "de";
-  textDe.textContent = TEXTE.text_de;
-
   const titelEn = document.createElement("h2");
   titelEn.className = "sw-zweitsprache";
   titelEn.lang = "en";
   titelEn.textContent = TEXTE.titel_en;
-
-  const textEn = document.createElement("p");
-  textEn.lang = "en";
-  textEn.textContent = TEXTE.text_en;
 
   const knoepfe = document.createElement("div");
   knoepfe.className = "sw-knoepfe";
@@ -132,7 +137,7 @@ function baueHinweis() {
   ok.textContent = TEXTE.knopf;
   knoepfe.appendChild(ok);
 
-  kasten.append(schliessen, titel, textDe, titelEn, textEn, knoepfe);
+  kasten.append(schliessen, titel, titelEn, knoepfe);
   grund.appendChild(kasten);
 
   return { grund, ok, schliessen };

--- a/public/js/sprachhinweis.js
+++ b/public/js/sprachhinweis.js
@@ -158,17 +158,32 @@ function start() {
     });
   }
 
-  function oeffnen() {
-    ausloeser = document.activeElement;
+  /* Letztes Netz, wie beim echten Umschalter: In Safari tabbt man ohne
+     „Vollzugriff Tastatur" nicht auf Knöpfe — der Fokus landet dann im Nichts
+     und kommt nicht zurück. Am 2026-08-13 im WebKit-Lauf gemessen. */
+  function fokusZurueckholen() {
+    setTimeout(() => {
+      if (grund.hidden || grund.contains(document.activeElement)) return;
+      const erster = grund.querySelector("button");
+      if (erster) erster.focus();
+    }, 0);
+  }
+
+  function oeffnen(e) {
+    /* Den auslösenden Knopf merken, nicht document.activeElement — in WebKit
+       fokussiert ein Klick den Knopf nicht. */
+    ausloeser = (e && e.currentTarget) || document.activeElement;
     grund.hidden = false;
     stillegen(true);
     const dieser = grund;
     requestAnimationFrame(() => dieser.classList.add("sichtbar"));
+    grund.addEventListener("focusout", fokusZurueckholen);
     ok.focus();
   }
 
   function schliessenTun() {
     if (grund.hidden) return;
+    grund.removeEventListener("focusout", fokusZurueckholen);
     stillegen(false);
     grund.classList.remove("sichtbar");
     setTimeout(() => {

--- a/public/js/sprachhinweis.js
+++ b/public/js/sprachhinweis.js
@@ -149,6 +149,12 @@ function start() {
   const ziel = document.getElementById("main") || document.querySelector("main") || document.body;
   const { grund, ok, schliessen } = baueHinweis();
   let ausloeser = null;
+  /* Eigener Zustand statt `grund.hidden`: Das Verbergen passiert erst nach dem
+     Ausblenden (200 ms). In dieser Lücke feuerte ein noch offener Zeitgeber des
+     Fokus-Netzes und zog den Fokus in den schliessenden Dialog zurück — der
+     Rücksprung auf den Umschalter fiel damit aus. In der CI aufgeschlagen,
+     lokal nie. */
+  let offen = false;
 
   function stillegen(an) {
     Array.prototype.forEach.call(document.body.children, (kind) => {
@@ -163,7 +169,7 @@ function start() {
      und kommt nicht zurück. Am 2026-08-13 im WebKit-Lauf gemessen. */
   function fokusZurueckholen() {
     setTimeout(() => {
-      if (grund.hidden || grund.contains(document.activeElement)) return;
+      if (!offen || grund.contains(document.activeElement)) return;
       const erster = grund.querySelector("button");
       if (erster) erster.focus();
     }, 0);
@@ -173,6 +179,7 @@ function start() {
     /* Den auslösenden Knopf merken, nicht document.activeElement — in WebKit
        fokussiert ein Klick den Knopf nicht. */
     ausloeser = (e && e.currentTarget) || document.activeElement;
+    offen = true;
     grund.hidden = false;
     stillegen(true);
     const dieser = grund;
@@ -182,7 +189,8 @@ function start() {
   }
 
   function schliessenTun() {
-    if (grund.hidden) return;
+    if (!offen) return;
+    offen = false;
     grund.removeEventListener("focusout", fokusZurueckholen);
     stillegen(false);
     grund.classList.remove("sichtbar");
@@ -206,7 +214,7 @@ function start() {
   /* Fokus-Fänger: `inert` hält ihn aus der Umgebung heraus, aber hinter dem
      letzten Knopf verließe er das Dokument in die Browserleiste. */
   document.addEventListener("keydown", (e) => {
-    if (grund.hidden) return;
+    if (!offen) return;
     if (e.key === "Escape") {
       schliessenTun();
       return;

--- a/public/js/sprachumschalter.js
+++ b/public/js/sprachumschalter.js
@@ -4,14 +4,18 @@
  * ist. Ist es aus, entsteht kein einziges Element — ein sichtbarer, toter
  * Schalter wäre schlimmer als gar keiner (Nutzer-Ansage 2026-08-13).
  *
- * Zum Erproben gibt es eine Tür über die Konsole:
+ * Zum Erproben gibt es zwei Türen. Beide wirken nur im eigenen Tab und
+ * überleben kein Neuladen — damit lässt sich die fertige Bedienung auf der
+ * ECHTEN Seite durchspielen, ohne dass ein Workshop-Publikum etwas sieht.
  *
- *     malziME.sprachumschalter()        blendet ihn im eigenen Tab ein
- *     malziME.sprachumschalter(false)   nimmt ihn wieder weg
+ * 1. In der Adresse:  ?sprachumschalter=1
  *
- * Sie wirkt nur in diesem Tab und überlebt kein Neuladen. Damit lässt sich
- * die fertige Bedienung auf der ECHTEN Seite durchspielen, ohne dass ein
- * Workshop-Publikum etwas davon sieht.
+ *    Der wichtigere Weg. Auf iPhone und iPad gibt es keine Konsole, und genau
+ *    dort muss der Umschalter erprobt werden: Daumen-Größe und Rückfrage auf
+ *    kleinem Schirm sind die kritischen Punkte. Chrome sperrt am Rechner
+ *    obendrein das Einfügen in die Konsole.
+ *
+ * 2. In der Konsole:  malziME.sprachumschalter()   /   (false) zum Entfernen
  *
  * Der Wechsel selbst ist bewusst einfach gehalten: Es gibt keinen Weg, einem
  * laufenden Auftrag nachträglich eine andere Sprache zu geben. Stattdessen
@@ -30,6 +34,11 @@ import { state } from "./state.js";
    müssten die Locale-Texte einen Platzhalter bekommen. */
 const SPRACHEN = ["de", "en"];
 const SPEICHER_SCHLUESSEL = "malzime-sprache";
+/* Spur für die noch nicht übersetzten Seiten: Sie laden bewusst kein
+   /api/stats (eine Rechtsseite soll keinen Netzweg aufmachen) und erfahren so
+   im selben Tab, ob der Umschalter überhaupt gezeigt werden soll.
+   Übergangslösung — entfällt mit js/sprachhinweis.js. */
+const SPUR_SCHLUESSEL = "malzime-sprachumschalter";
 
 /* Das Schliess-Kreuz ist ein Zeichen, kein Text: Es wird nie uebersetzt und
    Screenreadern gar nicht vorgelesen — deren Beschriftung kommt aus dem
@@ -328,6 +337,11 @@ function einhaengen() {
   document.addEventListener("keydown", aufTaste);
 
   eingehaengt = true;
+  try {
+    sessionStorage.setItem(SPUR_SCHLUESSEL, "1");
+  } catch (_err) {
+    /* Privater Modus — dann zeigen die Unterseiten den Schalter eben nicht. */
+  }
   beschriften();
 }
 
@@ -335,6 +349,11 @@ function aushaengen() {
   if (!eingehaengt) return;
   modalSchliessen();
   document.removeEventListener("keydown", aufTaste);
+  try {
+    sessionStorage.removeItem(SPUR_SCHLUESSEL);
+  } catch (_err) {
+    /* siehe oben */
+  }
   [umschalter, modalFertig, modalLaeuft, ansage].forEach((el) => el && el.remove());
   umschalter = modalFertig = modalLaeuft = ansage = null;
   eingehaengt = false;
@@ -386,6 +405,16 @@ export function initSprachumschalter({ analysiere } = {}) {
     zeigeSprachumschalter(an);
     return an ? "Sprachumschalter eingeblendet (nur in diesem Tab)." : "Sprachumschalter entfernt.";
   };
+
+  /* Tür über die Adresse. Bewusst streng: nur genau "1" oeffnet. Ein
+     versehentliches ?sprachumschalter=0 oder =false darf nichts einblenden. */
+  try {
+    if (new URLSearchParams(window.location.search).get("sprachumschalter") === "1") {
+      einhaengen();
+    }
+  } catch (_err) {
+    /* Kaputte Adresse — dann eben keine Tür. */
+  }
 }
 
 /**

--- a/public/js/sprachumschalter.js
+++ b/public/js/sprachumschalter.js
@@ -117,7 +117,7 @@ function baueUmschalter() {
 
   SPRACHEN.forEach((code) => {
     const b = knopf(code);
-    b.addEventListener("click", () => geklickt(code));
+    b.addEventListener("click", () => geklickt(code, b));
     pille.appendChild(b);
   });
 
@@ -242,7 +242,7 @@ function umgebungStillegen(an) {
   });
 }
 
-function modalOeffnen(art, ziel, ohneBild) {
+function modalOeffnen(art, ziel, ohneBild, ausloeser) {
   zielSprache = ziel;
   /* Ein Satz, zwei Fälle: Mit Bild folgt eine neue Analyse, ohne Bild eine
      leere Startseite. Überschrift und Knöpfe bleiben gleich — der Nutzer
@@ -252,7 +252,11 @@ function modalOeffnen(art, ziel, ohneBild) {
     text.dataset.swKeyHtml = ohneBild ? "sprache.fertig.textOhneBild" : "sprache.fertig.text";
     text.innerHTML = t(text.dataset.swKeyHtml);
   }
-  fokusVorher = document.activeElement;
+  /* Den ausloesenden Knopf merken, NICHT document.activeElement: In WebKit
+     (Safari) bekommt ein Knopf beim Klicken keinen Fokus — der Rücksprung
+     landete dort im Leeren statt auf dem Umschalter. Am 2026-08-13 im
+     WebKit-Lauf gemessen. */
+  fokusVorher = ausloeser || document.activeElement;
   offen = art === "fertig" ? modalFertig : modalLaeuft;
   offen.hidden = false;
   umgebungStillegen(true);
@@ -262,12 +266,14 @@ function modalOeffnen(art, ziel, ohneBild) {
   requestAnimationFrame(() => dieser.classList.add("sichtbar"));
   const ruhig = offen.querySelector(".sw-knopf--bleiben");
   if (ruhig) ruhig.focus();
+  offen.addEventListener("focusout", fokusZurueckholen);
 }
 
 function modalSchliessen() {
   if (!offen) return;
   const el = offen;
   umgebungStillegen(false);
+  offen.removeEventListener("focusout", fokusZurueckholen);
   offen = null;
   zielSprache = null;
   el.classList.remove("sichtbar");
@@ -319,7 +325,7 @@ async function wechseln(ziel, neuStarten) {
   if (typeof zuruecksetzen === "function") zuruecksetzen();
 }
 
-function geklickt(ziel) {
+function geklickt(ziel, knopfEl) {
   if (ziel === getLanguage()) return;
 
   /* Steht nichts auf dem Spiel, sofort umschalten. Das ist genau der leere
@@ -346,7 +352,7 @@ function geklickt(ziel) {
      Profil wird gelöscht." stimmt in beiden Fällen. Nur der eine Satz darunter
      unterscheidet sich: einmal folgt eine neue Analyse, einmal eine leere
      Startseite. */
-  modalOeffnen(jetzt === "laeuft" ? "laeuft" : "fertig", ziel, jetzt === "ohnebild");
+  modalOeffnen(jetzt === "laeuft" ? "laeuft" : "fertig", ziel, jetzt === "ohnebild", knopfEl);
 }
 
 /* ── Ansage für Screenreader ────────────────────────────────────────────── */
@@ -396,6 +402,20 @@ function aushaengen() {
   [umschalter, modalFertig, modalLaeuft, ansage].forEach((el) => el && el.remove());
   umschalter = modalFertig = modalLaeuft = ansage = null;
   eingehaengt = false;
+}
+
+/* Letztes Netz: Verliert der Fokus die Rückfrage trotzdem (in Safari tabbt man
+   ohne „Vollzugriff Tastatur" gar nicht auf Knöpfe — der Fokus landet dann im
+   Nichts und kommt nicht zurück), wird er zurückgeholt. In WebKit 26.5
+   gemessen; Chromium zeigte das Verhalten nicht. */
+function fokusZurueckholen() {
+  /* Erst im naechsten Durchlauf pruefen: Beim Verlassen steht der neue
+     Fokus noch nicht fest. */
+  setTimeout(() => {
+    if (!offen || offen.contains(document.activeElement)) return;
+    const erster = offen.querySelector("button");
+    if (erster) erster.focus();
+  }, 0);
 }
 
 /* Fokus-Fänger. `inert` allein genügt nicht: Es verhindert, dass der Fokus in

--- a/public/js/sprachumschalter.js
+++ b/public/js/sprachumschalter.js
@@ -156,7 +156,8 @@ function modalBauen(art) {
   kasten.setAttribute("aria-labelledby", titel.id);
 
   const text = document.createElement("p");
-  text.dataset.swKey = `sprache.${art}.text`;
+  /* Der Folgesatz hebt die Folge hervor (<strong>), deshalb der HTML-Weg. */
+  text.dataset.swKeyHtml = `sprache.${art}.text`;
 
   kasten.append(schliessen, titel, text);
 
@@ -243,10 +244,13 @@ function umgebungStillegen(an) {
 
 function modalOeffnen(art, ziel, ohneBild) {
   zielSprache = ziel;
-  const text = art === "fertig" ? modalFertig.querySelector("[data-sw-key]:not(h2)") : null;
+  /* Ein Satz, zwei Fälle: Mit Bild folgt eine neue Analyse, ohne Bild eine
+     leere Startseite. Überschrift und Knöpfe bleiben gleich — der Nutzer
+     wollte die Sprache wechseln, nicht über eine Löschung verhandeln. */
+  const text = art === "fertig" ? modalFertig.querySelector("[data-sw-key-html]") : null;
   if (text) {
-    text.dataset.swKey = ohneBild ? "sprache.fertig.textOhneBild" : "sprache.fertig.text";
-    text.textContent = t(text.dataset.swKey);
+    text.dataset.swKeyHtml = ohneBild ? "sprache.fertig.textOhneBild" : "sprache.fertig.text";
+    text.innerHTML = t(text.dataset.swKeyHtml);
   }
   fokusVorher = document.activeElement;
   offen = art === "fertig" ? modalFertig : modalLaeuft;

--- a/public/js/sprachumschalter.js
+++ b/public/js/sprachumschalter.js
@@ -28,17 +28,34 @@
 
 import { t, getLanguage, setLanguage } from "./i18n.js";
 import { state } from "./state.js";
+import { statusNeuSchreiben } from "./ui.js";
 
 /* Die Texte sprechen von „der anderen Sprache", ohne sie zu benennen —
    solange es genau zwei gibt, ist das eindeutig. Käme eine dritte dazu,
    müssten die Locale-Texte einen Platzhalter bekommen. */
 const SPRACHEN = ["de", "en"];
 const SPEICHER_SCHLUESSEL = "malzime-sprache";
-/* Spur für die noch nicht übersetzten Seiten: Sie laden bewusst kein
-   /api/stats (eine Rechtsseite soll keinen Netzweg aufmachen) und erfahren so
-   im selben Tab, ob der Umschalter überhaupt gezeigt werden soll.
-   Übergangslösung — entfällt mit js/sprachhinweis.js. */
-const SPUR_SCHLUESSEL = "malzime-sprachumschalter";
+/* Spur der Erprobungs-Tür. Sie liegt im localStorage, NICHT im
+   sessionStorage: Die Rechtsseiten öffnen mit target="_blank" rel="noopener"
+   (index.html:348), und ein so geöffneter Tab bekommt einen leeren
+   sessionStorage. Die Spur wäre dort nie angekommen — genau daran ist die
+   erste Fassung gescheitert.
+
+   Bewusst geräteweit und dauerhaft: Es ist eine Tür zum Erproben, keine
+   Nutzer-Einstellung. Zu bekommen nur über ?sprachumschalter=1, wieder los
+   über ?sprachumschalter=0 oder malziME.sprachumschalter(false). Der
+   Normalbetrieb hängt weiterhin allein am Merkmals-Schloss. */
+const TUER_SCHLUESSEL = "malzime-tuer-sprachumschalter";
+
+/* Zweite Spur, die den Stand des Merkmals spiegelt. Die Rechtsseiten rufen
+   bewusst kein /api/stats auf (eine Rechtsseite soll keinen Netzweg aufmachen)
+   und erfahren nur so, dass der Umschalter im Betrieb an ist. Wird bei JEDEM
+   Aufruf der Startseite neu geschrieben oder geloescht, damit ein Abschalten
+   des Merkmals ankommt.
+
+   Getrennt von der Tuer, weil sonst das ausgeschaltete Merkmal beim naechsten
+   Seitenaufruf die Erprobung wieder zusperren wuerde. */
+const MERKMAL_SCHLUESSEL = "malzime-umschalter-aktiv";
 
 /* Das Schliess-Kreuz ist ein Zeichen, kein Text: Es wird nie uebersetzt und
    Screenreadern gar nicht vorgelesen — deren Beschriftung kommt aus dem
@@ -51,14 +68,24 @@ let modalFertig = null;
 let modalLaeuft = null;
 let ansage = null;
 let neuAnalysieren = null;
+let zuruecksetzen = null;
 
 /* ── Lage bestimmen ─────────────────────────────────────────────────────── */
 
-/** "leer" | "laeuft" | "fertig" — woran hängt gerade etwas? */
+/**
+ * "leer" | "laeuft" | "fertig" | "ohnebild"
+ *
+ * `ohnebild` ist der Fall nach einem Neuladen: Die Seite holt das Ergebnis
+ * zurück (js/api.js, resumeQueueJob), die Bilddatei aber überlebt kein
+ * Neuladen — ein File-Objekt lässt sich nicht speichern. Eine neue Analyse ist
+ * dann unmöglich, und eine Rückfrage, die sie verspricht, wäre eine Lüge: Der
+ * Wechsel liefe ins Leere und niemand wüsste warum.
+ */
 function lage() {
-  if (state.isAnalyzing || state.uploadLaeuft) return "laeuft";
-  if (state.lastData) return "fertig";
-  return "leer";
+  const laeuftEtwas = state.isAnalyzing || state.uploadLaeuft;
+  if (!laeuftEtwas && !state.lastData) return "leer";
+  if (!state.lastFile) return "ohnebild";
+  return laeuftEtwas ? "laeuft" : "fertig";
 }
 
 /* ── Bausteine ──────────────────────────────────────────────────────────── */
@@ -98,14 +125,18 @@ function baueUmschalter() {
   return huelle;
 }
 
-function modalBauen(art, mitHinweis) {
+function modalBauen(art) {
   const grund = document.createElement("div");
   grund.className = "sw-grund";
   grund.dataset.modal = art;
   grund.hidden = true;
 
   const kasten = document.createElement("div");
-  kasten.className = "sw-modal";
+  /* Die Art steht als Klasse dran, damit sich die beiden Rückfragen auf einen
+     Blick unterscheiden: Die eine löscht etwas (rostrot, Warnzeichen), die
+     andere kostet nur Wartezeit (ruhig). Vorher sahen sie gleich aus — der
+     Nutzer hat sie deshalb gar nicht erst gelesen. */
+  kasten.className = `sw-modal sw-modal--${art}`;
   kasten.setAttribute("role", "dialog");
   kasten.setAttribute("aria-modal", "true");
   kasten.id = `sw-modal-${art}`;
@@ -128,13 +159,6 @@ function modalBauen(art, mitHinweis) {
   text.dataset.swKey = `sprache.${art}.text`;
 
   kasten.append(schliessen, titel, text);
-
-  if (mitHinweis) {
-    const hinweis = document.createElement("p");
-    hinweis.className = "sw-hinweis";
-    hinweis.dataset.swKeyHtml = `sprache.${art}.hinweis`;
-    kasten.appendChild(hinweis);
-  }
 
   const knoepfe = document.createElement("div");
   knoepfe.className = "sw-knoepfe";
@@ -217,8 +241,13 @@ function umgebungStillegen(an) {
   });
 }
 
-function modalOeffnen(art, ziel) {
+function modalOeffnen(art, ziel, ohneBild) {
   zielSprache = ziel;
+  const text = art === "fertig" ? modalFertig.querySelector("[data-sw-key]:not(h2)") : null;
+  if (text) {
+    text.dataset.swKey = ohneBild ? "sprache.fertig.textOhneBild" : "sprache.fertig.text";
+    text.textContent = t(text.dataset.swKey);
+  }
   fokusVorher = document.activeElement;
   offen = art === "fertig" ? modalFertig : modalLaeuft;
   offen.hidden = false;
@@ -267,14 +296,23 @@ async function wechseln(ziel, neuStarten) {
   }
 
   beschriften();
+  /* Eine stehende Fehlermeldung gehört mitgewechselt — sonst steht sie auf
+     Deutsch unter einer englischen Seite. */
+  statusNeuSchreiben();
   sageAn(t("sprache.gewechselt"));
 
-  /* Die Analyse läuft immer in der Sprache, die beim Absenden eingestellt war
-     — Oberflächen- und Auftragssprache können deshalb nach einem Wechsel gar
-     nicht auseinanderlaufen. */
-  if (neuStarten && state.lastFile && typeof neuAnalysieren === "function") {
+  if (!neuStarten) return;
+
+  if (state.lastFile && typeof neuAnalysieren === "function") {
     neuAnalysieren(state.lastFile);
+    return;
   }
+
+  /* Kein Bild mehr da (nach einem Neuladen). Das vorliegende Profil in der
+     alten Sprache stehen zu lassen und mit einer Zeile zu entschuldigen wäre
+     der schlechtere Weg — es gehört weg, und man landet auf einer sauberen
+     Startseite. Genau das hat der Nutzer verlangt. */
+  if (typeof zuruecksetzen === "function") zuruecksetzen();
 }
 
 function geklickt(ziel) {
@@ -290,6 +328,8 @@ function geklickt(ziel) {
      nachgezogen werden — ein Test hat das nachgewiesen. Toter Code, der
      Sicherheit vortäuscht, ist schlimmer als keiner. */
   const jetzt = lage();
+
+  /* Nur auf der leeren Seite steht nichts auf dem Spiel. */
   if (jetzt === "leer") {
     wechseln(ziel, false);
     return;
@@ -298,7 +338,11 @@ function geklickt(ziel) {
   /* Sonst erst fragen. Die Oberfläche bleibt bis zur Entscheidung unverändert,
      damit „Abbrechen" wirklich nichts hinterlässt — auch die Rückfrage selbst
      erscheint deshalb in der AKTUELLEN Sprache. */
-  modalOeffnen(jetzt === "fertig" ? "fertig" : "laeuft", ziel);
+  /* "ohnebild" nutzt dieselbe Rückfrage wie "fertig" — die Überschrift „Dein
+     Profil wird gelöscht." stimmt in beiden Fällen. Nur der eine Satz darunter
+     unterscheidet sich: einmal folgt eine neue Analyse, einmal eine leere
+     Startseite. */
+  modalOeffnen(jetzt === "laeuft" ? "laeuft" : "fertig", ziel, jetzt === "ohnebild");
 }
 
 /* ── Ansage für Screenreader ────────────────────────────────────────────── */
@@ -325,8 +369,8 @@ function einhaengen() {
   umschalter = baueUmschalter();
   main.insertBefore(umschalter, main.firstChild);
 
-  modalFertig = modalBauen("fertig", true);
-  modalLaeuft = modalBauen("laeuft", false);
+  modalFertig = modalBauen("fertig");
+  modalLaeuft = modalBauen("laeuft");
   document.body.append(modalFertig, modalLaeuft);
 
   ansage = document.createElement("div");
@@ -337,11 +381,6 @@ function einhaengen() {
   document.addEventListener("keydown", aufTaste);
 
   eingehaengt = true;
-  try {
-    sessionStorage.setItem(SPUR_SCHLUESSEL, "1");
-  } catch (_err) {
-    /* Privater Modus — dann zeigen die Unterseiten den Schalter eben nicht. */
-  }
   beschriften();
 }
 
@@ -349,11 +388,7 @@ function aushaengen() {
   if (!eingehaengt) return;
   modalSchliessen();
   document.removeEventListener("keydown", aufTaste);
-  try {
-    sessionStorage.removeItem(SPUR_SCHLUESSEL);
-  } catch (_err) {
-    /* siehe oben */
-  }
+  tuer(false);
   [umschalter, modalFertig, modalLaeuft, ansage].forEach((el) => el && el.remove());
   umschalter = modalFertig = modalLaeuft = ansage = null;
   eingehaengt = false;
@@ -397,23 +432,51 @@ function aufTaste(e) {
  * @param {object} opts
  * @param {Function} opts.analysiere  Callback, der eine Datei neu analysiert.
  */
-export function initSprachumschalter({ analysiere } = {}) {
+export function initSprachumschalter({ analysiere, zuruecksetze } = {}) {
   neuAnalysieren = analysiere || null;
+  zuruecksetzen = zuruecksetze || null;
 
   window.malziME = window.malziME || {};
   window.malziME.sprachumschalter = (an = true) => {
+    tuer(an);
     zeigeSprachumschalter(an);
-    return an ? "Sprachumschalter eingeblendet (nur in diesem Tab)." : "Sprachumschalter entfernt.";
+    return an ? "Sprachumschalter eingeblendet — gilt jetzt auch auf den Unterseiten." : "Sprachumschalter entfernt.";
   };
 
-  /* Tür über die Adresse. Bewusst streng: nur genau "1" oeffnet. Ein
-     versehentliches ?sprachumschalter=0 oder =false darf nichts einblenden. */
+  /* Tür über die Adresse. Bewusst streng: nur genau "1" öffnet, nur genau "0"
+     schliesst. Alles andere lässt den Zustand, wie er ist. */
+  const wunsch = adressWunsch();
+  if (wunsch === true) tuer(true);
+  if (wunsch === false) tuer(false);
+  if (tuerOffen()) einhaengen();
+}
+
+/** "1" → true, "0" → false, sonst null (keine Angabe). */
+function adressWunsch() {
   try {
-    if (new URLSearchParams(window.location.search).get("sprachumschalter") === "1") {
-      einhaengen();
-    }
+    const wert = new URLSearchParams(window.location.search).get("sprachumschalter");
+    if (wert === "1") return true;
+    if (wert === "0") return false;
   } catch (_err) {
-    /* Kaputte Adresse — dann eben keine Tür. */
+    /* Kaputte Adresse — dann eben keine Angabe. */
+  }
+  return null;
+}
+
+function tuerOffen() {
+  try {
+    return localStorage.getItem(TUER_SCHLUESSEL) === "1";
+  } catch (_err) {
+    return false;
+  }
+}
+
+function tuer(auf) {
+  try {
+    if (auf) localStorage.setItem(TUER_SCHLUESSEL, "1");
+    else localStorage.removeItem(TUER_SCHLUESSEL);
+  } catch (_err) {
+    /* Privater Modus — dann gilt die Tür nur für diesen Seitenaufruf. */
   }
 }
 
@@ -426,6 +489,22 @@ export function initSprachumschalter({ analysiere } = {}) {
 export function zeigeSprachumschalter(an) {
   if (an) einhaengen();
   else aushaengen();
+}
+
+/**
+ * Übernimmt den Stand des Merkmals-Schlosses: baut den Umschalter und
+ * hinterlässt die Spur für die Unterseiten. Ruft app.js auf, sobald die
+ * Antwort von /api/stats da ist — mit `false` genauso wie mit `true`, damit
+ * ein Abschalten ankommt.
+ */
+export function merkmalUebernehmen(an) {
+  try {
+    if (an) localStorage.setItem(MERKMAL_SCHLUESSEL, "1");
+    else localStorage.removeItem(MERKMAL_SCHLUESSEL);
+  } catch (_err) {
+    /* Privater Modus — dann sehen die Unterseiten den Schalter nicht. */
+  }
+  if (an) einhaengen();
 }
 
 /** Nur für Tests: aktueller Einbauzustand. */

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -1,6 +1,7 @@
 /* ── Stats-Seite: Lädt /api/stats und befüllt die Anzeige ── */
 
 import { initI18n, t, getLanguage, applyTranslations } from "./i18n.js";
+import { initSprachumschalter, zeigeSprachumschalter } from "./sprachumschalter.js";
 
 /* Projekt-Start: 5. Februar 2026 */
 const PROJECT_START = new Date("2026-02-05");
@@ -46,6 +47,10 @@ async function loadStats() {
     const res = await fetch("/api/stats");
     if (!res.ok) throw new Error(res.status);
     const data = await res.json();
+
+    /* v3.3: Merkmals-Schloss des Sprachumschalters — dieselbe Antwort, die
+       ohnehin geholt wird. Aus oder unlesbar ⇒ kein Bedienelement. */
+    if (data.sprachumschalter === true) zeigeSprachumschalter(true);
 
     /* Zahlen einsetzen — hourlyTotal ist die echte Anzahl (unabhängig von Resets) */
     el.liveCount.textContent = fmt(data.current.hourlyTotal);
@@ -117,6 +122,14 @@ function startCountdown(seconds, el) {
 async function init() {
   await initI18n();
   applyTranslations();
+
+  /* v3.3: Diese Seite ist übersetzt, also bekommt sie den echten Umschalter.
+     Ohne Neuanalyse-Rückruf — hier steht nichts auf dem Spiel, ein Wechsel
+     zeichnet die Zahlen einfach neu. Gezeigt wird er nach denselben Regeln wie
+     auf der Startseite: Merkmals-Schloss aus /api/stats, dazu die beiden
+     Erprobungs-Türen (Adresse und Konsole). */
+  initSprachumschalter({});
+
   await loadStats();
 }
 

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -1,7 +1,7 @@
 /* ── Stats-Seite: Lädt /api/stats und befüllt die Anzeige ── */
 
 import { initI18n, t, getLanguage, applyTranslations } from "./i18n.js";
-import { initSprachumschalter, zeigeSprachumschalter } from "./sprachumschalter.js";
+import { initSprachumschalter, merkmalUebernehmen } from "./sprachumschalter.js";
 
 /* Projekt-Start: 5. Februar 2026 */
 const PROJECT_START = new Date("2026-02-05");
@@ -50,7 +50,7 @@ async function loadStats() {
 
     /* v3.3: Merkmals-Schloss des Sprachumschalters — dieselbe Antwort, die
        ohnehin geholt wird. Aus oder unlesbar ⇒ kein Bedienelement. */
-    if (data.sprachumschalter === true) zeigeSprachumschalter(true);
+    merkmalUebernehmen(data.sprachumschalter === true);
 
     /* Zahlen einsetzen — hourlyTotal ist die echte Anzahl (unabhängig von Resets) */
     el.liveCount.textContent = fmt(data.current.hourlyTotal);

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -1,16 +1,47 @@
 import { elements } from "./dom.js";
 import { t } from "./i18n.js";
 
+/**
+ * Schreibt eine gemerkte Statusmeldung in der aktuellen Sprache neu.
+ * Ruft der Sprachumschalter nach jedem Wechsel auf.
+ */
+export function statusNeuSchreiben() {
+  const schluessel = elements.status.dataset.i18nKey;
+  if (!schluessel) return;
+  setStatus(t(schluessel), elements.status.dataset.traceId || undefined, schluessel);
+}
+
 /* ── Scan-Animation ── */
 
 let scanInterval = null;
 
-export function setStatus(text, traceId) {
+/**
+ * Setzt die Statuszeile.
+ *
+ * @param {string} text     Fertiger Text.
+ * @param {string} [traceId]
+ * @param {string} [schluessel] i18n-Schlüssel des Textes. Wird er mitgegeben,
+ *   merkt sich die Zeile ihn und kann bei einem Sprachwechsel neu geschrieben
+ *   werden (statusNeuSchreiben). Ohne ihn bleibt die Meldung stehen, wie sie
+ *   ist — genau das war der Fehler: Nach einem Wechsel auf Englisch stand die
+ *   Fehlermeldung weiter auf Deutsch (gefunden 2026-08-13 beim Durchgang durch
+ *   alle Zustände der echten Anwendung).
+ */
+export function setStatus(text, traceId, schluessel) {
   if (!text) {
     elements.status.textContent = "";
     elements.status.classList.remove("visible");
     elements.status.removeAttribute("role");
+    delete elements.status.dataset.i18nKey;
+    delete elements.status.dataset.traceId;
     return;
+  }
+  if (schluessel) {
+    elements.status.dataset.i18nKey = schluessel;
+    if (traceId) elements.status.dataset.traceId = traceId;
+  } else {
+    delete elements.status.dataset.i18nKey;
+    delete elements.status.dataset.traceId;
   }
   if (traceId) {
     /* Bei Fehlern wird die Trace-ID dezent als zweite Zeile angehaengt,

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -238,13 +238,13 @@
   "sprache.name.en": "English",
   "sprache.schliessen": "Schließen",
   "sprache.gewechselt": "Sprache auf Deutsch umgestellt.",
-  "sprache.fertig.titel": "Sprache wechseln?",
-  "sprache.fertig.text": "Dein Profil ist auf Deutsch entstanden. Übersetzen wäre die faule Lösung. Für ein englisches Profil sieht sich die KI dein Foto noch einmal an und urteilt von vorne.",
-  "sprache.fertig.hinweis": "<strong>Dabei kommt nie dasselbe Profil heraus.</strong> Die KI rät jedes Mal neu — der zweite Durchlauf kann dich ganz anders beschreiben. Genau das ist der Lerneffekt, aber dein jetziges Ergebnis ist dann weg.",
-  "sprache.fertig.bleiben": "Profil behalten",
+  "sprache.fertig.titel": "Dein Profil wird gelöscht.",
+  "sprache.fertig.text": "Die KI schaut dein Foto noch einmal an und schreibt alles neu — auf Englisch.",
+  "sprache.fertig.bleiben": "Abbrechen",
   "sprache.fertig.wechseln": "Neu analysieren",
-  "sprache.laeuft.titel": "Sprache wechseln?",
-  "sprache.laeuft.text": "Dein Foto ist noch in Arbeit. Beim Wechsel beginnt die Analyse auf Englisch von vorn — dein Foto bleibt dasselbe, du musst nichts noch einmal auswählen.",
-  "sprache.laeuft.bleiben": "Bei Deutsch bleiben",
-  "sprache.laeuft.wechseln": "Auf Englisch wechseln"
+  "sprache.laeuft.titel": "Die Analyse beginnt von vorn.",
+  "sprache.laeuft.text": "Auf Englisch. Dein Foto bleibt, du musst nichts neu auswählen.",
+  "sprache.laeuft.bleiben": "Abbrechen",
+  "sprache.laeuft.wechseln": "Neu starten",
+  "sprache.fertig.textOhneBild": "Du landest wieder auf der Startseite und kannst ein neues Foto auswählen."
 }

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -238,13 +238,13 @@
   "sprache.name.en": "English",
   "sprache.schliessen": "Schließen",
   "sprache.gewechselt": "Sprache auf Deutsch umgestellt.",
-  "sprache.fertig.titel": "Dein Profil wird gelöscht.",
-  "sprache.fertig.text": "Die KI schaut dein Foto noch einmal an und schreibt alles neu — auf Englisch.",
+  "sprache.fertig.titel": "Auf Englisch wechseln?",
+  "sprache.fertig.text": "<strong>Dein jetziges Profil wird gelöscht.</strong> Die KI schaut dein Foto noch einmal an und schreibt alles neu.",
   "sprache.fertig.bleiben": "Abbrechen",
-  "sprache.fertig.wechseln": "Neu analysieren",
-  "sprache.laeuft.titel": "Die Analyse beginnt von vorn.",
-  "sprache.laeuft.text": "Auf Englisch. Dein Foto bleibt, du musst nichts neu auswählen.",
+  "sprache.fertig.wechseln": "Auf Englisch wechseln",
+  "sprache.laeuft.titel": "Auf Englisch wechseln?",
+  "sprache.laeuft.text": "Die Analyse beginnt von vorn — dein Foto bleibt, du musst es nicht noch einmal hochladen.",
   "sprache.laeuft.bleiben": "Abbrechen",
-  "sprache.laeuft.wechseln": "Neu starten",
-  "sprache.fertig.textOhneBild": "Du landest wieder auf der Startseite und kannst ein neues Foto auswählen."
+  "sprache.laeuft.wechseln": "Auf Englisch wechseln",
+  "sprache.fertig.textOhneBild": "<strong>Dein jetziges Profil wird gelöscht.</strong> Für ein englisches müsstest du dein Foto noch einmal hochladen."
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -238,13 +238,13 @@
   "sprache.name.en": "English",
   "sprache.schliessen": "Close",
   "sprache.gewechselt": "Language switched to English.",
-  "sprache.fertig.titel": "Switch language?",
-  "sprache.fertig.text": "Your profile was created in English. Translating would be the lazy way out. For a German profile the AI takes another look at your photo and judges from scratch.",
-  "sprache.fertig.hinweis": "<strong>And it never comes out the same.</strong> The AI guesses anew every time — the second run may describe you quite differently. That is exactly the lesson here, but your current result will be gone.",
-  "sprache.fertig.bleiben": "Keep my profile",
+  "sprache.fertig.titel": "Your profile will be deleted.",
+  "sprache.fertig.text": "The AI looks at your photo again and writes everything from scratch — in German.",
+  "sprache.fertig.bleiben": "Cancel",
   "sprache.fertig.wechseln": "Analyse again",
-  "sprache.laeuft.titel": "Switch language?",
-  "sprache.laeuft.text": "Your photo is still being processed. Switching restarts the analysis in German — your photo stays the same, you do not have to choose anything again.",
-  "sprache.laeuft.bleiben": "Stay in English",
-  "sprache.laeuft.wechseln": "Switch to German"
+  "sprache.laeuft.titel": "The analysis starts over.",
+  "sprache.laeuft.text": "In German. Your photo stays, you do not have to pick it again.",
+  "sprache.laeuft.bleiben": "Cancel",
+  "sprache.laeuft.wechseln": "Restart",
+  "sprache.fertig.textOhneBild": "You will be back on the start page and can pick a new photo."
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -238,13 +238,13 @@
   "sprache.name.en": "English",
   "sprache.schliessen": "Close",
   "sprache.gewechselt": "Language switched to English.",
-  "sprache.fertig.titel": "Your profile will be deleted.",
-  "sprache.fertig.text": "The AI looks at your photo again and writes everything from scratch — in German.",
+  "sprache.fertig.titel": "Switch to German?",
+  "sprache.fertig.text": "<strong>Your current profile will be deleted.</strong> The AI looks at your photo again and writes everything from scratch.",
   "sprache.fertig.bleiben": "Cancel",
-  "sprache.fertig.wechseln": "Analyse again",
-  "sprache.laeuft.titel": "The analysis starts over.",
-  "sprache.laeuft.text": "In German. Your photo stays, you do not have to pick it again.",
+  "sprache.fertig.wechseln": "Switch to German",
+  "sprache.laeuft.titel": "Switch to German?",
+  "sprache.laeuft.text": "The analysis starts over — your photo stays, you do not have to upload it again.",
   "sprache.laeuft.bleiben": "Cancel",
-  "sprache.laeuft.wechseln": "Restart",
-  "sprache.fertig.textOhneBild": "You will be back on the start page and can pick a new photo."
+  "sprache.laeuft.wechseln": "Switch to German",
+  "sprache.fertig.textOhneBild": "<strong>Your current profile will be deleted.</strong> For a German one you would have to upload your photo again."
 }

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -178,5 +178,9 @@
         <a href="/stats" tabindex="0">Stats</a>
       </div>
     </footer>
+    <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
+         Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
+         sobald sie übersetzt ist. -->
+    <script type="module" src="./js/sprachhinweis.js?v=2026081303"></script>
   </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -3575,20 +3575,25 @@ html[lang="en"] .rc-zitat::after {
   margin: 0 2.5rem 0.7rem 0;
   line-height: 1.25;
 }
+
+/* Die zwei Rückfragen müssen auf einen Blick unterscheidbar sein — sonst liest
+   sie niemand zu Ende. Die eine LÖSCHT etwas: rostrote Überschrift mit
+   Warnzeichen. Die andere kostet nur Wartezeit: ruhig wie der Rest.
+   (Nutzer-Ansage 2026-08-13: „Selbst ich habe es nicht gelesen, weil es gleich
+   ausschaut wie die anderen.") */
+.sw-modal--fertig h2 {
+  color: var(--rust-text);
+}
+.sw-modal--fertig h2::before {
+  content: "⚠";
+  margin-right: 0.45rem;
+  font-weight: 400;
+}
 .sw-modal p {
   color: var(--text);
   font-size: 0.95rem;
   margin: 0;
 }
-.sw-hinweis {
-  margin-top: 0.85rem !important;
-  padding: 0.8rem 0.9rem;
-  background: var(--tint-rust);
-  border-left: 3px solid var(--rust-text);
-  border-radius: 8px;
-  font-size: 0.9rem;
-}
-
 .sw-knoepfe {
   display: flex;
   gap: 0.6rem;

--- a/public/styles.css
+++ b/public/styles.css
@@ -3577,17 +3577,14 @@ html[lang="en"] .rc-zitat::after {
 }
 
 /* Die zwei Rückfragen müssen auf einen Blick unterscheidbar sein — sonst liest
-   sie niemand zu Ende. Die eine LÖSCHT etwas: rostrote Überschrift mit
-   Warnzeichen. Die andere kostet nur Wartezeit: ruhig wie der Rest.
-   (Nutzer-Ansage 2026-08-13: „Selbst ich habe es nicht gelesen, weil es gleich
-   ausschaut wie die anderen.") */
-.sw-modal--fertig h2 {
+   sie niemand zu Ende (Nutzer-Ansage 2026-08-13). Die Unterscheidung sitzt
+   aber im FOLGESATZ, nicht in der Überschrift: Ein erster Anlauf setzte die
+   Löschwarnung als Titel, und damit stand vor jemandem, der nur die Sprache
+   wechseln wollte, plötzlich eine Schreckmeldung ohne Zusammenhang. Die
+   Überschrift nennt jetzt wieder das Vorhaben, der hervorgehobene Halbsatz die
+   Folge. */
+.sw-modal p strong {
   color: var(--rust-text);
-}
-.sw-modal--fertig h2::before {
-  content: "⚠";
-  margin-right: 0.45rem;
-  font-weight: 400;
 }
 .sw-modal p {
   color: var(--text);

--- a/public/styles.css
+++ b/public/styles.css
@@ -2084,13 +2084,19 @@ html[data-has-result] {
   margin-bottom: 0;
 }
 
+/* A11Y-2026-08-13-01 (WCAG 1.4.1): Links im Fliesstext waren allein an der
+   Farbe erkennbar — axe meldete 8 ernste Verstoesse (link-in-text-block) auf
+   den Rechtsseiten. Sie waren nie gemessen worden: Die bestehende
+   axe-Pruefung deckt nur die Startseite ab. Unterstrichen ist die Loesung,
+   die ohne Farbsehen funktioniert. */
 .legal-block a {
   color: var(--teal-text);
-  text-decoration: none;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
 }
 
 .legal-block a:hover {
-  text-decoration: underline;
+  text-decoration-thickness: 2px;
 }
 
 .legal-section p {
@@ -2102,11 +2108,12 @@ html[data-has-result] {
 
 .legal-section a {
   color: var(--teal-text);
-  text-decoration: none;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
 }
 
 .legal-section a:hover {
-  text-decoration: underline;
+  text-decoration-thickness: 2px;
 }
 
 .legal-list {
@@ -3460,12 +3467,25 @@ html[lang="en"] .rc-zitat::after {
   background: transparent;
   color: var(--sw-fuell);
   border-radius: 999px;
-  /* WCAG 2.5.5: 44x44 als Ziel-Groesse. Am Prototyp gemessen waren es
-     49x28 — auf dem Handy zu wenig fuer einen Daumen. */
-  min-width: 44px;
-  min-height: 44px;
-  padding: 0 1rem;
+  padding: 0.3rem 1rem;
   transition: color 0.28s var(--ease);
+}
+
+/* Ziel-Groesse 44 px, ohne die Pille aufzublasen.
+   Erster Anlauf war `min-height: 44px` — das machte aus 49x28 ganze 50x44 und
+   aus der schlanken Pille einen 108x52-Klotz, der mit dem abgenommenen
+   Entwurf nichts mehr zu tun hatte. Die Regel meint aber die TASTBARE Flaeche,
+   nicht die sichtbare: Ein unsichtbares Feld ueber dem Knopf bringt den
+   Daumen-Treffer, das Aussehen bleibt der Entwurf. Nur senkrecht ausgedehnt —
+   waagrecht wuerden sich die beiden Knoepfe gegenseitig ins Gehege kommen. */
+.sprach-knopf::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 44px;
+  transform: translateY(-50%);
 }
 .sprach-knopf.aktiv {
   color: var(--sw-fuell-text);
@@ -3515,10 +3535,11 @@ html[lang="en"] .rc-zitat::after {
 
 .sw-schliessen {
   position: absolute;
-  top: 0.4rem;
-  right: 0.45rem;
-  width: 44px;
-  height: 44px;
+  top: 0.55rem;
+  right: 0.6rem;
+  /* Sichtbar 32 px wie im abgenommenen Entwurf, tastbar 44 px ueber ::after. */
+  width: 2rem;
+  height: 2rem;
   display: grid;
   place-items: center;
   font-size: 1.5rem;
@@ -3532,6 +3553,11 @@ html[lang="en"] .rc-zitat::after {
   transition:
     background 0.15s var(--ease),
     color 0.15s var(--ease);
+}
+.sw-schliessen::after {
+  content: "";
+  position: absolute;
+  inset: -6px;
 }
 .sw-schliessen:hover {
   background: var(--hover);
@@ -3632,4 +3658,14 @@ html[lang="en"] .rc-zitat::after {
   .sw-schliessen {
     transition: none;
   }
+}
+
+/* Zweitsprachiger Block im Hinweis der noch nicht übersetzten Seiten.
+   ÜBERGANG — entfällt mit js/sprachhinweis.js, sobald die Rechtstexte auf
+   Englisch vorliegen. */
+.sw-modal h2.sw-zweitsprache {
+  margin-top: 1.1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-soft);
+  font-size: 1.1rem;
 }


### PR DESCRIPTION
Stufe 2 des vereinbarten Vorgehens: gemeinsam durchgespielt, vier Runden nachgebessert. Das Merkmal bleibt **aus** — für Besucher ändert sich genau eine Sache, siehe unten.

## Was der Betreiber gefunden hat

**1. Nach einem Neuladen ist die Bilddatei weg.** Die Seite holt das Ergebnis zurück, ein File-Objekt überlebt aber kein Neuladen. Die Rückfrage versprach trotzdem eine neue Analyse, und der Wechsel lief stillschweigend ins Leere.

Dreimal nachgebessert, bis es stimmte: erst ein eigener Dialog (der über etwas Unmögliches verhandelte), dann gar keiner (dann blieb ein Profil in der falschen Sprache stehen), schliesslich das Richtige — das Profil wird gelöscht, man landet auf einer sauberen Startseite, der gemerkte Auftrag wird verworfen.

**2. Die Rückfragen waren zu lang und sahen gleich aus.** Zwei Dialoge, gleicher Titel, je rund 60 Wörter. Im Workshop liest die niemand. Jetzt nennt die Überschrift das Vorhaben, darunter steht **ein** Satz, und der Bestätigungsknopf heisst in allen Fällen gleich.

**3. Der Schalter gehört auf jede Seite.** `stats.html` ist übersetzt und bekommt den echten Umschalter. Die drei Rechtsseiten liegen nur auf Deutsch — dort steht der Schalter ebenfalls, zeigt immer DE und öffnet einen **zweisprachigen** Hinweis. Diese Übergangslösung verschwindet, sobald die Texte übersetzt sind; ein Test macht ihre Ausnahme ab diesem Tag zum Fehler.

**4. Der Schalter war zu gross.** `min-height: 44px` blies die Pille auf 108×52 auf. Die Regel meint die **tastbare** Fläche, nicht die sichtbare: jetzt sichtbar 50×30 wie im abgenommenen Entwurf, tastbar 44.

## Was der systematische Durchgang zusätzlich fand

Acht Zustände der echten Anwendung einzeln durchgemessen — nicht die drei des Entwurfs:

- **Fehlermeldungen wechselten die Sprache nicht mit.** „Die KI ist gerade überlastet…" blieb deutsch unter einer englischen Seite. `setStatus` merkt sich jetzt den Textschlüssel (15 Aufrufstellen), der Fehlercode bleibt erhalten.
- Im Wartungsmodus liegt der Schalter hinter dem Dialog und ist nicht erreichbar. Über das Merkmals-Schloss entsteht er dort ohnehin nicht — aktenkundig.

## Was der WebKit-Lauf fand

Playwright bringt die Maschine hinter Safari mit. Zwei Fehler, die Chromium nicht zeigt:

- **Der Fokus verlässt den Dialog und findet nicht zurück.** Safari setzt den Fokus ohne „Vollzugriff Tastatur" gar nicht auf Knöpfe; wer heraustabbte, landete im Nichts. `inert` und der Umbruch am Listenrand reichen dafür nicht.
- **Der Rücksprung landete im Leeren**, weil ein Klick in Safari den Knopf nicht fokussiert.

**WebKit läuft ab jetzt in der Pipeline mit** — eigener Lauf über die Umschalter-Tests, ohne Zusatzinstallation.

Nachgemessen, was ein Screenreader vorliest:

```
group "Sprache wählen"
  button "Deutsch" [gedrückt]: DE
  button "English": EN
dialog "Auf Englisch wechseln?"
  button "Schließen" · heading · Text · button "Abbrechen" · button "Auf Englisch wechseln"
```

## Und ein Fehler, den ich selbst eingebaut hatte

Beim Verschieben der Test-Tür in den geräteweiten Speicher erfuhren die Rechtsseiten nichts mehr vom Merkmals-Schloss. Live geschaltet hätten sie den Umschalter **nicht** gezeigt. Ein E2E-Test hat es gefangen.

## Für Besucher sichtbar

Genau eine Sache: Links im Fließtext der Rechtsseiten sind **unterstrichen** statt nur eingefärbt (`A11Y-2026-08-13-01`, WCAG 1.4.1). Das behebt acht ernste axe-Verstöße, die nie jemand gesehen hat, weil die bestehende axe-Prüfung nur die Startseite abdeckt.

## Prüfstand

| Suite | Ergebnis |
|---|---|
| Backend | 827/828 grün (1 übersprungen) |
| Frontend | 369/369 grün |
| E2E | 66/66 grün — 42 Chromium + 24 WebKit |

Lint, Format, aussentext, test-blind, selbstpruefung, Fremddateien, Vendorierung — sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)