### PR TITLE
fix: Umschalter in die Kopfzeile, zweisprachiger Hinweis mit klarer Rangfolge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,18 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
 ### Behoben
 
+- **Der Umschalter stand über der Kopfzeile statt darin, und war zu hoch.**
+  Gemessen: Das SYSTEM-AKTIV-Abzeichen ist 130 × 28 px, der Umschalter war
+  108 × 38 px und saß 42 px darüber — das sah nach zwei verschiedenen Dingen
+  aus statt nach einer Kopfzeile. Jetzt 94 × 27 px auf derselben Oberkante, am
+  anderen Rand. Tastbar bleiben es 44 × 44 px.
+
+- **Der zweisprachige Hinweis hatte zwei gleichrangige Überschriften.** Deutsch
+  und Englisch standen in gleicher Größe und Fettung untereinander und stritten
+  optisch um den Rang. Die englische Zeile ist jetzt eine zurückgenommene
+  Übersetzung — und der Dialog hat wieder genau eine Überschrift, wie es sich
+  gehört.
+
 - **Safari verliert den Fokus aus dem Dialog — und findet nicht zurück**
   (`A11Y-2026-08-13-02`). Gemessen in WebKit 26.5, der Maschine hinter Safari
   auf iPhone und iPad. Safari setzt den Fokus ohne „Vollzugriff Tastatur" gar

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit d00d7f2, 2026-08-13 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 369/369 grün — `scripts/pruefstand.sh`, Commit d00d7f2, 2026-08-13 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 66/66 grün — `scripts/pruefstand.sh`, Commit d00d7f2, 2026-08-13 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit eb3f649, 2026-08-13 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 369/369 grün — `scripts/pruefstand.sh`, Commit eb3f649, 2026-08-13 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 66/66 grün — `scripts/pruefstand.sh`, Commit eb3f649, 2026-08-13 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/public/js/sprachhinweis.js
+++ b/public/js/sprachhinweis.js
@@ -124,7 +124,11 @@ function baueHinweis() {
   titel.textContent = TEXTE.titel_de;
   kasten.setAttribute("aria-labelledby", titel.id);
 
-  const titelEn = document.createElement("h2");
+  /* Die englische Zeile ist die Übersetzung, nicht eine zweite Überschrift.
+     Als <h2> in gleicher Grösse und Fettung sahen beide aus, als stritten sie
+     um den Rang — und ein Dialog hat genau EINE Überschrift. Jetzt ein
+     zurückgenommener Absatz darunter. */
+  const titelEn = document.createElement("p");
   titelEn.className = "sw-zweitsprache";
   titelEn.lang = "en";
   titelEn.textContent = TEXTE.titel_en;

--- a/public/js/sprachumschalter.js
+++ b/public/js/sprachumschalter.js
@@ -373,11 +373,17 @@ function sageAn(text) {
 function einhaengen() {
   if (eingehaengt) return;
 
+  /* In die Kopfzeile, nicht darüber: Der Umschalter gehört auf dieselbe Höhe
+     wie das SYSTEM-AKTIV-Abzeichen, nur an den anderen Rand. `.hero` trägt
+     dafür position: relative (styles.css). Fehlt der Kopf — etwa auf einer
+     Unterseite —, bleibt es beim Anfang des Inhalts. */
+  const kopf = document.querySelector(".hero");
   const main = document.getElementById("main");
-  if (!main) return;
+  const ziel = kopf || main;
+  if (!ziel) return;
 
   umschalter = baueUmschalter();
-  main.insertBefore(umschalter, main.firstChild);
+  ziel.insertBefore(umschalter, ziel.firstChild);
 
   modalFertig = modalBauen("fertig");
   modalLaeuft = modalBauen("laeuft");

--- a/public/styles.css
+++ b/public/styles.css
@@ -225,6 +225,9 @@ body {
 /* ── Hero ── */
 
 .hero {
+  /* relative wegen des Sprachumschalters (v3.3): Er sitzt absolut am rechten
+     Rand dieser Zeile, auf Höhe des SYSTEM-AKTIV-Abzeichens. */
+  position: relative;
   margin-bottom: 32px;
 }
 
@@ -3427,10 +3430,15 @@ html[lang="en"] .rc-zitat::after {
   --sw-fuell-text: #0e1517;
 }
 
+/* Auf derselben Zeile wie das SYSTEM-AKTIV-Abzeichen, nur am anderen Rand —
+   und in derselben Höhe. Ein erster Anlauf setzte den Umschalter darüber und
+   10 px höher; das sah nach zwei verschiedenen Dingen aus statt nach einer
+   Kopfzeile. `.hero` traegt dafuer position: relative. */
 .sprachwahl {
-  display: flex;
-  justify-content: flex-end;
-  margin: 0 0 0.25rem;
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
 }
 .sprach-pille {
   position: relative;
@@ -3439,15 +3447,15 @@ html[lang="en"] .rc-zitat::after {
   background: var(--surface);
   border: 1.5px solid var(--sw-fuell);
   border-radius: 999px;
-  padding: 3px;
+  padding: 2px;
   box-shadow: var(--shadow);
 }
 .sprach-schieber {
   position: absolute;
-  top: 3px;
-  left: 3px;
-  width: calc(50% - 3px);
-  height: calc(100% - 6px);
+  top: 2px;
+  left: 2px;
+  width: calc(50% - 2px);
+  height: calc(100% - 4px);
   background: var(--sw-fuell);
   border-radius: 999px;
   transition: transform 0.28s var(--ease);
@@ -3459,15 +3467,22 @@ html[lang="en"] .rc-zitat::after {
   position: relative;
   z-index: 1;
   font-family: inherit;
-  font-weight: 500;
-  font-size: 0.82rem;
-  letter-spacing: 0.06em;
+  font-weight: 600;
+  /* Auf das Mass des SYSTEM-AKTIV-Abzeichens gebracht: 28 px hohe Pille. */
+  font-size: 0.7rem;
+  line-height: 1;
+  letter-spacing: 0.08em;
   cursor: pointer;
   border: 0;
   background: transparent;
   color: var(--sw-fuell);
   border-radius: 999px;
-  padding: 0.3rem 1rem;
+  /* Breite: 44 px je Knopf fuer den Daumen. Die Hoehe kommt ueber ::after,
+     waagrecht geht das nicht — zwei nebeneinanderliegende Knoepfe wuerden sich
+     die Flaeche streitig machen. Die Pille bleibt damit bei ~92 px und ist
+     weiterhin schmaler als das SYSTEM-AKTIV-Abzeichen (130 px). */
+  min-width: 44px;
+  padding: 0.32rem 0.5rem;
   transition: color 0.28s var(--ease);
 }
 
@@ -3665,9 +3680,11 @@ html[lang="en"] .rc-zitat::after {
 /* Zweitsprachiger Block im Hinweis der noch nicht übersetzten Seiten.
    ÜBERGANG — entfällt mit js/sprachhinweis.js, sobald die Rechtstexte auf
    Englisch vorliegen. */
-.sw-modal h2.sw-zweitsprache {
-  margin-top: 1.1rem;
-  padding-top: 1rem;
+.sw-modal .sw-zweitsprache {
+  margin-top: 0.9rem !important;
+  padding-top: 0.8rem;
   border-top: 1px solid var(--border-soft);
-  font-size: 1.1rem;
+  font-size: 0.9rem;
+  font-weight: 400;
+  color: var(--muted);
 }


### PR DESCRIPTION
Zwei Beanstandungen am ausgelieferten Stand, beide gemessen statt geschätzt.

## 1. Der Umschalter gehört IN die Kopfzeile

| | Breite × Höhe | Oberkante |
|---|---|---|
| SYSTEM AKTIV | 130 × 28 | y = 82 |
| Umschalter (vorher) | 108 × **38** | y = **40** |
| Umschalter (jetzt) | 94 × **27** | y = **82** |

Zehn Pixel zu hoch und 42 Pixel darüber — das wirkte wie zwei verschiedene Dinge statt einer Kopfzeile.

Tastbar bleiben 44 × 44 px: senkrecht über `::after`, waagrecht über `min-width`. Waagrecht ginge `::after` nicht — die beiden Knöpfe würden sich die Fläche streitig machen.

## 2. Zwei fette Zeilen streiten um den Rang

Im Hinweis auf den nur-deutschen Seiten standen deutsche und englische Zeile als zwei `<h2>` in gleicher Grösse untereinander. Die englische ist aber die **Übersetzung**, nicht eine zweite Überschrift — und ein Dialog hat genau eine. Jetzt ein zurückgenommener Absatz darunter.

## Prüfstand

| Suite | Ergebnis |
|---|---|
| Backend | 827/828 grün (1 übersprungen) |
| Frontend | 369/369 grün |
| E2E | 66/66 grün (42 Chromium + 24 WebKit) |

Ein Lauf zeigte den bekannten flackernden Realitäts-Check-Test; allein zweimal wiederholt grün, von dieser Änderung nicht berührt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)