### PR TITLE
feat: v3.3.0 — Sprachumschalter sichtbar, alle Seiten auf gleicher Breite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [3.3.0] — 2026-08-13
+
+**Der Sprachumschalter — sichtbar.**
+
+Nach einem Tag Vorbereitung hinter einem Merkmals-Schloss und vier Runden
+Nachbesserung am gemeinsamen Durchspielen ist der DE/EN-Umschalter für alle
+Besucher da. Die englische Fassung selbst war schon vorher erreichbar
+(`?lang=en`, Gerätesprache) — gefehlt hat das Bedienelement.
+
+Zusätzlich in diesem Zug: alle Seiten auf dieselbe Inhaltsbreite (680 px), der
+Umschalter auf einer Linie mit der Kopfzeile, und acht ernste
+Barrierefreiheits-Verstöße auf den Rechtsseiten behoben, die nie jemand gesehen
+hatte.
 
 ### Hinzugefügt
 
@@ -73,6 +85,15 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   Unterseiten, nicht durch die Änderung selbst verursacht.
 
 ### Behoben
+
+- **Alle Seiten haben dieselbe Inhaltsbreite.** Die Rechtsseiten standen auf
+  640 px, Start- und Zahlen-Seite auf 680 px — 40 px Unterschied ohne
+  dokumentierten Grund und zu wenig, um typografisch etwas zu bewirken. Jetzt
+  überall 680 px, ausgehend von der Startseite.
+
+- **Der Umschalter sitzt auf der Zeile der Rubrik.** Auf den Unterseiten stand
+  er über „malziME · Statistik" statt daneben und wirkte wie ein loses Element.
+  Rubrik und Umschalter teilen sich jetzt eine Kopfzeile, auf gleicher Mitte.
 
 - **Der Umschalter stand über der Kopfzeile statt darin, und war zu hoch.**
   Gemessen: Das SYSTEM-AKTIV-Abzeichen ist 130 × 28 px, der Umschalter war

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit eb3f649, 2026-08-13 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 369/369 grün — `scripts/pruefstand.sh`, Commit eb3f649, 2026-08-13 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 66/66 grün — `scripts/pruefstand.sh`, Commit eb3f649, 2026-08-13 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 235a794, 2026-08-13 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 369/369 grün — `scripts/pruefstand.sh`, Commit 235a794, 2026-08-13 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 66/66 grün — `scripts/pruefstand.sh`, Commit 235a794, 2026-08-13 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/e2e/sprachumschalter.test.js
+++ b/e2e/sprachumschalter.test.js
@@ -116,6 +116,11 @@ async function ruhe(page) {
         new Promise((fertig) => setTimeout(fertig, 1000)),
       ])
   );
+  /* WebKit meldet laufende CSS-Übergänge über getAnimations() NICHT — dort
+     misst axe sonst mitten im Themenwechsel und findet Schein-Kontraste an
+     Elementen, die mit der Änderung nichts zu tun haben. Der Themenwechsel
+     dauert 200 ms; 400 ms sind der sichere Abstand. */
+  await page.waitForTimeout(400);
 }
 
 async function beastAn(page) {

--- a/public/js/sprachhinweis.js
+++ b/public/js/sprachhinweis.js
@@ -62,6 +62,37 @@ function sichtbar() {
   }
 }
 
+/* Wohin der Umschalter gehört, je nach Seitenaufbau:
+
+   - Startseite: in die Kopfzeile mit dem SYSTEM-AKTIV-Abzeichen (`.hero`).
+   - Unterseiten: auf dieselbe Zeile wie die Rubrik oben („malziME · Statistik",
+     „malziME · Rechtliches"). Dafür kommen Rubrik und Umschalter in eine
+     gemeinsame Zeile — vorher stand er darüber, was nach einem losen Element
+     aussah statt nach einer Kopfzeile (Nutzer-Ansage 2026-08-13).
+   - Sonst: an den Anfang des Inhalts. */
+function umschalterEinsetzen(el) {
+  /* Die Rubrik zuerst: Sie ist, wo vorhanden, die oberste Zeile — auch auf der
+     Zahlen-Seite, die zusaetzlich einen Hero-Block hat. Erst wenn es keine
+     gibt (Startseite), kommt die Kopfzeile mit dem Abzeichen. */
+  const rubrik = document.querySelector(".page-eyebrow");
+  if (rubrik && rubrik.parentNode) {
+    const zeile = document.createElement("div");
+    zeile.className = "seiten-kopfzeile";
+    rubrik.parentNode.insertBefore(zeile, rubrik);
+    zeile.append(rubrik, el);
+    return true;
+  }
+  const hero = document.querySelector(".hero");
+  if (hero) {
+    hero.insertBefore(el, hero.firstChild);
+    return true;
+  }
+  const main = document.getElementById("main");
+  if (!main) return false;
+  main.insertBefore(el, main.firstChild);
+  return true;
+}
+
 function knopf(code, aktiv) {
   const b = document.createElement("button");
   b.type = "button";
@@ -150,7 +181,6 @@ function baueHinweis() {
 function start() {
   if (!sichtbar()) return;
 
-  const ziel = document.getElementById("main") || document.querySelector("main") || document.body;
   const { grund, ok, schliessen } = baueHinweis();
   let ausloeser = null;
   /* Eigener Zustand statt `grund.hidden`: Das Verbergen passiert erst nach dem
@@ -206,7 +236,7 @@ function start() {
   }
 
   const umschalter = baueUmschalter(oeffnen);
-  ziel.insertBefore(umschalter, ziel.firstChild);
+  if (!umschalterEinsetzen(umschalter)) return;
   document.body.appendChild(grund);
 
   ok.addEventListener("click", schliessenTun);

--- a/public/js/sprachumschalter.js
+++ b/public/js/sprachumschalter.js
@@ -88,6 +88,37 @@ function lage() {
   return laeuftEtwas ? "laeuft" : "fertig";
 }
 
+/* Wohin der Umschalter gehört, je nach Seitenaufbau:
+
+   - Startseite: in die Kopfzeile mit dem SYSTEM-AKTIV-Abzeichen (`.hero`).
+   - Unterseiten: auf dieselbe Zeile wie die Rubrik oben („malziME · Statistik",
+     „malziME · Rechtliches"). Dafür kommen Rubrik und Umschalter in eine
+     gemeinsame Zeile — vorher stand er darüber, was nach einem losen Element
+     aussah statt nach einer Kopfzeile (Nutzer-Ansage 2026-08-13).
+   - Sonst: an den Anfang des Inhalts. */
+function umschalterEinsetzen(el) {
+  /* Die Rubrik zuerst: Sie ist, wo vorhanden, die oberste Zeile — auch auf der
+     Zahlen-Seite, die zusaetzlich einen Hero-Block hat. Erst wenn es keine
+     gibt (Startseite), kommt die Kopfzeile mit dem Abzeichen. */
+  const rubrik = document.querySelector(".page-eyebrow");
+  if (rubrik && rubrik.parentNode) {
+    const zeile = document.createElement("div");
+    zeile.className = "seiten-kopfzeile";
+    rubrik.parentNode.insertBefore(zeile, rubrik);
+    zeile.append(rubrik, el);
+    return true;
+  }
+  const hero = document.querySelector(".hero");
+  if (hero) {
+    hero.insertBefore(el, hero.firstChild);
+    return true;
+  }
+  const main = document.getElementById("main");
+  if (!main) return false;
+  main.insertBefore(el, main.firstChild);
+  return true;
+}
+
 /* ── Bausteine ──────────────────────────────────────────────────────────── */
 
 function knopf(code) {
@@ -373,17 +404,11 @@ function sageAn(text) {
 function einhaengen() {
   if (eingehaengt) return;
 
-  /* In die Kopfzeile, nicht darüber: Der Umschalter gehört auf dieselbe Höhe
-     wie das SYSTEM-AKTIV-Abzeichen, nur an den anderen Rand. `.hero` trägt
-     dafür position: relative (styles.css). Fehlt der Kopf — etwa auf einer
-     Unterseite —, bleibt es beim Anfang des Inhalts. */
-  const kopf = document.querySelector(".hero");
-  const main = document.getElementById("main");
-  const ziel = kopf || main;
-  if (!ziel) return;
-
   umschalter = baueUmschalter();
-  ziel.insertBefore(umschalter, ziel.firstChild);
+  if (!umschalterEinsetzen(umschalter)) {
+    umschalter = null;
+    return;
+  }
 
   modalFertig = modalBauen("fertig");
   modalLaeuft = modalBauen("laeuft");

--- a/public/styles.css
+++ b/public/styles.css
@@ -2012,8 +2012,11 @@ html[data-has-result] {
 
 /* ── Rechtsseiten ── */
 
+/* Dieselbe Inhaltsbreite wie Start- und Zahlen-Seite. Bis 2026-08-13 standen
+   hier 640 px — 40 px schmaler als der Rest, ohne dokumentierten Grund und zu
+   wenig, um typografisch etwas zu bewirken. */
 .legal-page {
-  max-width: 640px;
+  max-width: 680px;
   padding-bottom: 40px;
 }
 
@@ -3687,4 +3690,22 @@ html[lang="en"] .rc-zitat::after {
   font-size: 0.9rem;
   font-weight: 400;
   color: var(--muted);
+}
+
+/* Kopfzeile der Unterseiten: Rubrik links, Sprachumschalter rechts, auf einer
+   Linie. Vorher stand er darüber und wirkte wie ein loses Element. */
+.seiten-kopfzeile {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.seiten-kopfzeile .sprachwahl {
+  position: static;
+  flex: 0 0 auto;
+}
+/* Der eigene Abstand der Rubrik wandert an die Zeile — sonst sitzt die Rubrik
+   um ihren unteren Rand versetzt neben der Pille statt auf gleicher Mitte. */
+.seiten-kopfzeile .page-eyebrow {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
Der Umschalter geht scharf. Dazu die letzten drei Beanstandungen aus dem gemeinsamen Durchspielen.

## 1. Alle Seiten auf dieselbe Inhaltsbreite

Gemessen: Rechtsseiten 640 px, Start- und Zahlen-Seite 680 px. Der Unterschied stand ohne Begründung im Stylesheet und ist zu klein, um typografisch etwas zu bewirken. Jetzt überall 680 px, ausgehend von der Startseite.

## 2. Der Umschalter auf der Zeile der Rubrik

Auf den Unterseiten stand er über „malziME · Statistik" statt daneben. Rubrik und Umschalter teilen sich jetzt eine Kopfzeile, auf gleicher Mitte. Die Rubrik hat Vorrang vor dem Hero-Block — die Zahlen-Seite hat beides, und oben steht dort die Rubrik.

Nachgemessen (1280 px):

| Seite | Inhalt | Bezug-Mitte | Pille-Mitte |
|---|---|---|---|
| Startseite | 640 px | y54 | y54 |
| Datenschutz | 640 px | y54 | y54 |
| Zahlen | 640 px | y54 | y54 |

## 3. Ein Messfehler im eigenen Prüfmittel

Der axe-Lauf fand in WebKit 16 Schein-Kontraste an fremden Elementen: **WebKit meldet laufende CSS-Übergänge über `getAnimations()` nicht**, also mass axe mitten im Themenwechsel. Die Ruhephase wartet jetzt zusätzlich eine feste Zeit ab. Dieselbe Fehlerklasse wie am Vormittag in Chromium, nur über einen anderen Weg.

## Prüfstand

| Suite | Ergebnis |
|---|---|
| Backend | 827/828 grün (1 übersprungen) |
| Frontend | 369/369 grün |
| E2E | 66/66 grün (42 Chromium + 24 WebKit) |

## Danach

Das Merkmal `useSprachumschalter` wird nach dem Deploy in Firestore umgelegt — ohne Deploy, in Sekunden zurückzunehmen (RUNBOOK-Hebel 2a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)