### PR TITLE
fix: Doku-Drift — zwei falsche Zusagen in SECURITY.md, Waechter von 4 auf 14 Fakten

### DIFF
--- a/.pruefungen/aussentext.txt
+++ b/.pruefungen/aussentext.txt
@@ -36,3 +36,11 @@ in einem Schritt zwei fiktive Profile|Es sind zwei Aufrufe: der zweite holt die 
 (verl(ae|ä)sst|verlassen) (nie|niemals) (den|die|das) Server|Sinnlos formuliert: GPS erreicht die Server nie, verlaesst sie also nicht. Richtig ist: GPS erreicht nie unsere Server.
 Einzige Ausnahme: ein anonymes Abhol-Ticket|Es sind mehrere sessionStorage-Werte (Ticket, Modus-Wahl, Realitaets-Check-Ticket, Absturz-Wache). Aufzaehlen statt "einzige".
 (des|dem|den|der|vom|beim) Inhabers?\b|Keine Zuschreibung in dritter Person. "Inhaber Christoph Krieger" (Rechtstext, ohne Artikel) bleibt erlaubt; "des/dem/den Inhabers" ist Prosa und wird neutral formuliert.
+# 2026-08-13: Die Liste prueffte nur deutsche Wendungen. In SECURITY.md stand
+# ein Jahr lang die englische Fassung genau der Zusage, die auf Deutsch
+# gesperrt ist — „GPS stays in browser". Aussentexte gibt es hier in ZWEI
+# Sprachen; die Sperrliste muss beide kennen.
+(GPS|coordinates?)[^.\n]{0,60}(stays?|remains?|never leaves?)[^.\n]{0,20}(the )?(browser|client|device)|Absolute Zusage, technisch nicht haltbar: Die Koordinaten gehen fuer die Ortsaufloesung an Nominatim. Richtig ist "GPS never reaches our servers".
+(GPS|coordinates?)[^.\n]{0,60}never (sent|transmitted) to (the |our )?server(?!s\b)|Mehrdeutig: Sie erreichen UNSERE Server nie, verlassen den Browser aber sehr wohl. "never reaches our servers" praezisieren.
+(100 ?% (secure|anonymous)|guaranteed (secure|anonymous|error-free))|Absolute Zusage ohne Nachweis, englische Fassung der deutschen Regel.
+certified Saferinternet|Es gibt keine Zertifizierung. Korrekt ist "Saferinternet trainer" ohne Zusatz.

--- a/.pruefungen/fakten.txt
+++ b/.pruefungen/fakten.txt
@@ -21,3 +21,30 @@ Stundenlimit (Analysen pro Stunde)|(\d+)\s+Analysen\s*/\s*Stunde
 IP-Rate-Limit (Requests pro 10 Minuten)|Rate.?Limit[^0-9\n]{0,20}(\d+)\s*Requests
 
 Aufbewahrung der Diagnose-Logs in Tagen|client-diagnostics[^0-9\n]{0,40}(\d+)\s*Tage
+# 2026-08-13: Von vier auf sechzehn Fakten erweitert. Vier waren zu wenig — der
+# Waechter meldete zuverlaessig "kein Drift", und das klang wie eine Aussage
+# ueber die Doku. Es war eine ueber vier Zeilen. Aufgefallen an SECURITY.md,
+# wo ein Modellname und eine GPS-Zusage jahrelang falsch standen.
+#
+# Aufgenommen wird nur, was (a) in mehreren Dokumenten steht, (b) sich aendern
+# kann und (c) EINEN gueltigen Wert hat.
+#
+# Zwei Muster wurden nach dem ersten Lauf wieder entfernt, weil sie Historie
+# als Drift meldeten — der Waechter kann beides nicht unterscheiden:
+#   - `mistral-small-(\d{4})` traf einen historischen Vergleichsbericht ueber
+#     ein Experiment mit einem aelteren Modell.
+#   - `Concurrency (\d+)` traf die Rueckbau-Anweisungen im RUNBOOK (3, 10) und
+#     ein altes Audit (80). Alle drei Werte sind an ihrer Stelle richtig.
+# Ein Waechter, der Fehlalarm schlaegt, wird abgeschaltet. Lieber zehn
+# verlaessliche Muster als zwoelf mit zwei Luegen.
+
+Region der Cloud Functions|Cloud Functions[^.\n]{0,60}\((?:2nd Gen, )?Node \d+, (europe-west\d)\)
+Aktives KI-Modell|mistral-large-(\d{4})
+Durchschnittliche Jobdauer in Sekunden|(\d+)\s*s/Job
+Maximale Warteschlangentiefe|ab (\d+) wartenden Jobs
+Hoechstalter wartender Jobs in Minuten|(\d+)(?:-min-Job-H(?:oe|ö)chstalter|\s+Minuten \(`MAX_QUEUED_AGE_MS`\))
+Karenz vor dem Aufraeumen in Minuten|(\d+)-Minuten-Karenz
+Polling-Deckel des Browsers in Minuten|(\d+)-Minuten-Polling-Deckel
+Maximale Dateigroesse in MB|max (\d+) MB
+Verarbeitungs-Durchsatz pro Stunde|~(\d+) Analysen/h
+Firestore-Datenbank|Datenbank[^.\n]{0,12}`?(malzime-[a-z]+)`?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,19 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 ### Behoben
 
 - **Die Sicherheitsrichtlinie behauptete zwei Dinge, die nicht stimmten.**
-  Gefunden, nachdem der Betreiber die Doku als Ganzes in Zweifel gezogen hat —
-  zu Recht.
+  Aufgefallen, nachdem die Doku als Ganzes in Zweifel gezogen wurde — zu Recht.
 
   `SECURITY.md` nannte als KI-Anbieter „Large 3 + Small 4". Am Live-Log
   nachgemessen: In den letzten 30 Tagen hat ausschließlich
   `mistral-large-2512` Bilder gesehen; `mistral-small-2603` steckt nur im
   Rückfallpfad hinter einem Merkmals-Schloss und lief kein einziges Mal.
 
-  Schwerer wiegt die zweite Stelle: Dort stand **„GPS stays in browser — GPS
-  coordinates are never sent to the server"**. Das ist wörtlich die Zusage, die
-  in den eigenen Formulierungsregeln gesperrt ist — nur auf Englisch. Die
-  Koordinaten gehen für die Ortsauflösung an OpenStreetMap Nominatim; sie
-  erreichen unsere Server nie, verlassen den Browser aber sehr wohl.
+  Schwerer wiegt die zweite Stelle: Dort stand die englische Fassung genau
+  jener GPS-Zusage, die in den eigenen Formulierungsregeln gesperrt ist — sie
+  behauptete, die Koordinaten blieben im Browser. Sie gehen für die
+  Ortsauflösung an OpenStreetMap Nominatim: Sie erreichen unsere Server nie,
+  verlassen den Browser aber sehr wohl. Der Wortlaut steht bewusst nicht hier —
+  die Sperrliste würde ihn auch im Zitat beanstanden, und das ist richtig so.
 
 ### Geändert
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+### Behoben
+
+- **Die Sicherheitsrichtlinie behauptete zwei Dinge, die nicht stimmten.**
+  Gefunden, nachdem der Betreiber die Doku als Ganzes in Zweifel gezogen hat —
+  zu Recht.
+
+  `SECURITY.md` nannte als KI-Anbieter „Large 3 + Small 4". Am Live-Log
+  nachgemessen: In den letzten 30 Tagen hat ausschließlich
+  `mistral-large-2512` Bilder gesehen; `mistral-small-2603` steckt nur im
+  Rückfallpfad hinter einem Merkmals-Schloss und lief kein einziges Mal.
+
+  Schwerer wiegt die zweite Stelle: Dort stand **„GPS stays in browser — GPS
+  coordinates are never sent to the server"**. Das ist wörtlich die Zusage, die
+  in den eigenen Formulierungsregeln gesperrt ist — nur auf Englisch. Die
+  Koordinaten gehen für die Ortsauflösung an OpenStreetMap Nominatim; sie
+  erreichen unsere Server nie, verlassen den Browser aber sehr wohl.
+
+### Geändert
+
+- **Die Formulierungs-Sperrliste prüft jetzt auch Englisch.** Sie kannte nur
+  deutsche Wendungen — deshalb konnte die englische Fassung einer gesperrten
+  Zusage jahrelang unbemerkt dastehen. Vier englische Regeln ergänzt; die
+  Rückbauprobe belegt, dass sie den echten Fall fangen.
+
+- **Der Fakten-Wächter bewacht 14 statt 4 Fakten.** Vier waren zu wenig: Er
+  meldete zuverlässig „kein Drift", und das klang wie eine Aussage über die
+  Doku. Es war eine über vier Zeilen.
+
+  Beim Anlegen zeigte sich zweierlei. Zwei Muster trafen ins Leere und wären
+  stumme Wächter geblieben — repariert. Zwei weitere meldeten **Historie als
+  Drift** (ein alter Vergleichsbericht, die Rückbau-Anweisungen im RUNBOOK, wo
+  abweichende Werte richtig sind) und mussten wieder heraus. Lieber vierzehn
+  verlässliche Muster als sechzehn mit zwei Lügen.
+
 ## [3.3.0] — 2026-08-13
 
 **Der Sprachumschalter — sichtbar.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ malziME is a **workshop tool for media literacy education**. It is designed for 
 - **No permanent data storage**: In queue mode the image is briefly held in a dedicated EU storage bucket and deleted immediately after processing; job documents (including the result) are removed within ~2 hours. No profiles are stored permanently
 - **Queue worker not publicly reachable**: `processJob` runs with `invoker: private` — only Google Cloud Tasks can invoke it, authenticated via an OIDC service-account token
 - **No tracking**: No cookies, no analytics, no advertising
-- **GPS stays in browser**: GPS coordinates are never sent to the server
+- **GPS never reaches our servers**: Coordinates are read in the browser and used there for the map. Reverse geocoding goes directly from the browser to OpenStreetMap Nominatim — the coordinates leave the browser, but never touch malziME infrastructure
 - **Content Security Policy**: Strict whitelist (self + OpenStreetMap tiles + Nominatim)
 - **HSTS with preload**
 - **Rate limiting**: Per-IP request limits
@@ -50,9 +50,9 @@ malziME relies on external AI providers as data processors (Art. 28 GDPR). See [
 
 | Vendor | Role | Data Region |
 |--------|------|-------------|
-| Mistral AI SAS (Paris, FR) | Sole AI provider (Large 3 + Small 4) | EU by default |
+| Mistral AI SAS (Paris, FR) | Sole AI provider — `mistral-large-2512` handles every live analysis | EU by default |
 
-Mistral is the only AI provider since v1.6.0 — no Google AI in the pipeline. Mistral is contractually bound to not use uploaded images for training on the paid tier we use. See [Mistral DPA](https://legal.mistral.ai/terms/data-processing-addendum). (Google remains an infrastructure processor for Firebase Hosting / Cloud Functions / Firestore — see [datenschutz.html](public/datenschutz.html).)
+Mistral is the only AI provider since v1.6.0 — no Google AI in the pipeline. Since v2.2 a single call to `mistral-large-2512` produces both profiles; `mistral-small-2603` exists only in the fallback pipeline behind a feature flag and has not processed an image in production for over a month (checked against the live logs on 2026-08-13). Mistral is contractually bound to not use uploaded images for training on the paid tier we use. See [Mistral DPA](https://legal.mistral.ai/terms/data-processing-addendum). (Google remains an infrastructure processor for Firebase Hosting / Cloud Functions / Firestore — see [datenschutz.html](public/datenschutz.html).)
 
 ## Secrets management
 
@@ -60,5 +60,5 @@ All production secrets are stored in Google Cloud Secret Manager and bound to Cl
 
 Required secrets:
 - `ADMIN_SECRET` — Bearer token for admin endpoints (Boost, Reset, Maintenance)
-- `MISTRAL_API_KEY` — Mistral AI API key (Scale tier)
+- `MISTRAL_API_KEY` — Mistral AI API key (paid tier)
 - `NTFY_URL`, `NTFY_TOPIC` — optional, for limit-reached push notifications

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081305" />
+    <link rel="stylesheet" href="./styles.css?v=2026081306" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -177,6 +177,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081305"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081306"></script>
   </body>
 </html>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -44,7 +44,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081305" />
+    <link rel="stylesheet" href="./styles.css?v=2026081306" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -116,6 +116,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081305"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081306"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -82,7 +82,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081305" />
+    <link rel="stylesheet" href="./styles.css?v=2026081306" />
     <script type="application/ld+json">
 [
   {
@@ -306,15 +306,15 @@
         <p class="demo-label" data-i18n="demo.label">Kein Foto zur Hand? Probier ein Beispielbild (mit KI erstellt):</p>
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
-            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081305" data-i18n-src="demo.src.selfie" data-i18n-alt="demo.alt.selfie" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081306" data-i18n-src="demo.src.selfie" data-i18n-alt="demo.alt.selfie" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.selfie">Selfie am Stephansplatz</span>
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
-            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081305" data-i18n-src="demo.src.cafe" data-i18n-alt="demo.alt.cafe" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081306" data-i18n-src="demo.src.cafe" data-i18n-alt="demo.alt.cafe" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.cafe">Im Caf&eacute; in Salzburg</span>
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
-            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081305" data-i18n-src="demo.src.hiker" data-i18n-alt="demo.alt.hiker" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081306" data-i18n-src="demo.src.hiker" data-i18n-alt="demo.alt.hiker" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.hiker">Wanderung bei Hallstatt</span>
           </button>
         </div>
@@ -370,6 +370,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081305"></script>
+    <script type="module" src="./app.js?v=2026081306"></script>
   </body>
 </html>

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -14,7 +14,7 @@ import { logClientError } from "./error-logger.js";
    ausgeschrieben — und wurde vom Deploy prompt selbst überschrieben, weil das
    Muster null Ziffern erlaubte. Beides ist behoben; der Satz nennt das Muster
    trotzdem nicht mehr wörtlich. */
-const DEMO_BUSTER = "?v=2026081305";
+const DEMO_BUSTER = "?v=2026081306";
 
 /* 2026-08-13: Die KI-Kennzeichnung ist in die Pixel gebrannt (Pflicht seit
    08/2026 — ein CSS-Etikett verschwindet, sobald jemand das Bild speichert).

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081305" />
+    <link rel="stylesheet" href="./styles.css?v=2026081306" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -181,6 +181,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081305"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081306"></script>
   </body>
 </html>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081305" />
+    <link rel="stylesheet" href="./styles.css?v=2026081306" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081305"></script>
+    <script type="module" src="./js/stats.js?v=2026081306"></script>
   </body>
 </html>


### PR DESCRIPTION
Die Doku wurde als Ganzes in Zweifel gezogen. Die Prüfung gibt dem Zweifel recht.

## 1. Zwei falsche Behauptungen in SECURITY.md

**„Sole AI provider (Large 3 + Small 4)"** — am Live-Log nachgemessen zeigt sich in 30 Tagen ausschließlich `mistral-large-2512`, Schritt `mistral-single-large`. `mistral-small-2603` steckt seit v2.2 nur im Rückfallpfad hinter einem Flag und hat kein einziges Bild gesehen.

**„GPS stays in browser — GPS coordinates are never sent to the server"** — wörtlich die Zusage, die in den eigenen Formulierungsregeln **gesperrt** ist. Die Koordinaten gehen für die Ortsauflösung an Nominatim (`public/js/geocoding.js:15`): Sie erreichen unsere Server nie, verlassen den Browser aber sehr wohl.

Warum das durchkam: **Die Sperrliste kannte nur deutsche Wendungen.**

## 2. Die Sperrliste prüft jetzt auch Englisch

Vier englische Regeln ergänzt. Rückbauprobe: Mit der alten Formulierung schlägt die Prüfung an `SECURITY.md:37` an, zweimal.

## 3. Der Fakten-Wächter bewacht 14 statt 4 Fakten

Vier waren zu wenig — er meldete zuverlässig „kein Drift", und das klang wie eine Aussage über die Doku statt über vier Zeilen.

Beim Anlegen zeigte sich dreierlei, alles nachgemessen:

| Beobachtung | Folge |
|---|---|
| Zwei Muster trafen **ins Leere** (Umlaut anders, Formulierung anders als vermutet) | repariert — wären stumme Wächter geblieben |
| Zwei Muster meldeten **Historie als Drift** (alter Vergleichsbericht; Rückbau-Anweisungen im RUNBOOK, wo abweichende Werte richtig sind) | wieder entfernt, mit Begründung in der Datei |
| Ein Muster mit zwei Klammergruppen wurde vom Wächter **still verworfen** (14 zu 13, sonst keine Meldung) | auf eine Gruppe gebracht; Schwäche in `LEHREN.md` der Familie vermerkt |

Positivkontrollen: jedes neue Muster einmal absichtlich verletzt — der Wächter meldet den Drift und wird danach wieder grün.

## Nicht geändert

`docs/ARCHITECTURE.md` war bereits korrekt; es unterscheidet ausdrücklich zwischen aktivem Pfad und Rückfall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
