### PR TITLE
feat: scripts/vor-dem-push.sh — die Pipeline in sechs Sekunden vorweggenommen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
 ## [Unveröffentlicht]
 
+### Hinzugefügt
+
+- **`scripts/vor-dem-push.sh` — die Pipeline in wenigen Sekunden vorweggenommen.**
+  Am 13. August gingen drei Pipeline-Läufe rot; zwei davon waren reine
+  Nachlässigkeit (Format nicht gelaufen, die vendorierte Kopie statt der Quelle
+  bearbeitet). Beide hätte dieses Skript gefangen. Es fährt genau die billigen
+  Prüfungen der drei Jobs `test-frontend`, `test-backend` und `pruefungen` ab
+  und nennt bei jedem Mangel den Job, der ohne ihn rot würde.
+
+  Nachgemessen: **13 Prüfungen in 6 bis 7 Sekunden.** Ein roter Pipeline-Lauf
+  kostet dagegen Push, dreieinhalb Minuten Warten, Protokoll lesen, beheben und
+  dasselbe noch einmal.
+
+  Die langen Suiten fehlen bewusst — sie laufen lokal so lang wie in der
+  Pipeline, weil GitHub sie auf mehrere Maschinen verteilt. Dafür bleibt
+  `scripts/pruefstand.sh` der Lauf vor einem Release.
+
+  **Der Wächter dazu ist wichtiger als das Skript:** `vor-dem-push-script.test.js`
+  liest die Workflow-Datei und das Skript und meldet jeden Pipeline-Schritt, den
+  das Skript nicht kennt. Ohne ihn würde es beim ersten neuen CI-Schritt zur
+  Beruhigungspille — „alles grün" für etwas, das es nicht mehr prüft. Jede
+  bewusste Auslassung braucht eine Begründung, auch das prüft ein Test.
+
 ### Behoben
 
 - **Die Sicherheitsrichtlinie behauptete zwei Dinge, die nicht stimmten.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,14 +24,23 @@ Detaillierte Anleitung: [`docs/SETUP.md`](docs/SETUP.md)
 
 1. Fork das Repo und erstelle einen Feature-Branch (`git checkout -b feature/mein-feature`)
 2. Aenderungen machen
-3. Tests laufen lassen:
-   - Backend: `cd functions && npm test`
-   - Frontend: `npm run test:frontend`
-4. Lint + Format pruefen:
-   - Backend: `cd functions && npm run lint && npm run format:check`
-   - Frontend: `npm run lint:frontend && npm run format:frontend:check`
+3. **Vor dem Push:** `sh scripts/vor-dem-push.sh`
+
+   Faehrt in wenigen Sekunden genau die billigen Pruefungen der Pipeline ab —
+   Lint, Format (beide Wurzeln), Frontend-Tests und alle Waechter — und nennt
+   bei einem Mangel den CI-Job, der ohne ihn rot wuerde. Die langen Suiten
+   (Backend, E2E) fehlen dort bewusst: Sie laufen lokal so lang wie in der
+   Pipeline, dort gaebe es nichts zu gewinnen.
+
+4. Vor einem Release zusaetzlich alle drei Suiten: `sh scripts/pruefstand.sh`
 5. Cache-Buster in `index.html` hochzaehlen bei Frontend-Aenderungen
 6. Pull Request erstellen
+
+Die Einzelbefehle, falls du gezielt etwas laufen lassen willst:
+
+- Backend: `cd functions && npm test` · Lint `npm run lint` · Format `npm run format:check`
+- Frontend: `npm run test:frontend` · Lint `npm run lint:frontend` · Format `npm run format:frontend:check`
+- E2E: `npm run test:e2e`
 
 ## Code-Stil
 

--- a/functions/src/__tests__/vor-dem-push-script.test.js
+++ b/functions/src/__tests__/vor-dem-push-script.test.js
@@ -1,0 +1,111 @@
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Wächter für scripts/vor-dem-push.sh.
+ *
+ * Das Skript fährt die billigen Prüfungen der Pipeline lokal ab, damit ein
+ * vergessener Formatlauf nicht erst nach dreieinhalb Minuten Wartezeit
+ * auffällt. Sein einziger Wert liegt in der Deckungsgleichheit: Kommt in der
+ * Pipeline ein Schritt dazu und hier nicht, ist das Skript ab dann eine
+ * Beruhigungspille — es sagt „alles grün" für etwas, das es nicht mehr prüft.
+ *
+ * Genau diese Fehlerklasse ist in diesem Projekt schon aufgetreten
+ * (`DOC-2026-08-12-07`): Ein Wächter prüfte die EXISTENZ eines CI-Jobs, nicht
+ * die ZUORDNUNG — und blieb grün, während die Zuordnung falsch war.
+ *
+ * Reine Textanalyse beider Dateien. Kein Netz, kein Lauf, keine Schreibzugriffe.
+ */
+
+const WURZEL = path.join(__dirname, "../../..");
+const WORKFLOW = path.join(WURZEL, ".github/workflows/ci.yml");
+const SKRIPT = path.join(WURZEL, "scripts/vor-dem-push.sh");
+
+/* Diese Schritte gehören bewusst NICHT ins lokale Skript. Jeder mit Grund —
+   eine Ausnahme, die man nicht liest, ist ein Loch. */
+const BEWUSST_DRAUSSEN = {
+  "npm ci": "Installation, keine Prüfung",
+  "npm test": "Backend-Suite, läuft lokal so lang wie in der Pipeline (~2,5 min)",
+  "npm run test:e2e": "E2E-Suite, dito (~3,5 min) — beides deckt scripts/pruefstand.sh ab",
+};
+
+/** Alle `- run:`-Schritte der drei billigen Jobs aus der Workflow-Datei. */
+function billigeSchritte() {
+  const yml = fs.readFileSync(WORKFLOW, "utf8");
+  const zeilen = yml.split("\n");
+  const jobs = ["test-frontend:", "test-backend:", "pruefungen:"];
+  const schritte = [];
+  let inJob = false;
+
+  for (const zeile of zeilen) {
+    const jobKopf = zeile.match(/^ {2}([a-z-]+):\s*$/);
+    if (jobKopf) {
+      inJob = jobs.includes(`${jobKopf[1]}:`);
+      continue;
+    }
+    if (!inJob) continue;
+    const run = zeile.match(/^\s+- run:\s+(.+?)\s*$/);
+    if (run) schritte.push(run[1]);
+  }
+  return schritte;
+}
+
+describe("vor-dem-push.sh deckt die billigen Pipeline-Schritte ab", () => {
+  test("die Workflow-Datei liefert überhaupt Schritte", () => {
+    /* Positivkontrolle für die Messung selbst: Findet das Auslesen nichts,
+       ist nicht die Abdeckung in Ordnung, sondern der Test blind. */
+    expect(billigeSchritte().length).toBeGreaterThan(8);
+  });
+
+  test("jeder billige Schritt der Pipeline steht auch im Skript", () => {
+    const skript = fs.readFileSync(SKRIPT, "utf8");
+    const fehlend = [];
+
+    for (const schritt of billigeSchritte()) {
+      if (BEWUSST_DRAUSSEN[schritt]) continue;
+
+      /* Der Vergleich läuft über den Kern des Befehls, nicht über die ganze
+         Zeile: Das Skript ruft `npm run --silent lint:frontend` statt
+         `npm run lint:frontend` und wechselt für die Backend-Schritte das
+         Verzeichnis. */
+      const kern = schritt
+        .replace(/^npm run\s+/, "")
+        .replace(/^node\s+\.\.\//, "")
+        .replace(/^node\s+/, "")
+        .replace(/^python3\s+/, "")
+        .replace(/^sh\s+/, "")
+        .replace(/\s+\.$/, "")
+        .trim();
+
+      if (!skript.includes(kern)) fehlend.push(`${schritt}  (gesucht: "${kern}")`);
+    }
+
+    /* Jest kennt keine Zusatz-Meldung an expect() — der Hinweis steht deshalb
+       IM erwarteten Wert, damit er im Fehlschlag sichtbar ist. */
+    expect({
+      hinweis: "fehlende Schritte aufnehmen oder mit Grund in BEWUSST_DRAUSSEN eintragen",
+      fehlend,
+    }).toEqual({
+      hinweis: "fehlende Schritte aufnehmen oder mit Grund in BEWUSST_DRAUSSEN eintragen",
+      fehlend: [],
+    });
+  });
+
+  test("jede Ausnahme trägt eine Begründung", () => {
+    for (const [schritt, grund] of Object.entries(BEWUSST_DRAUSSEN)) {
+      expect({ schritt, typ: typeof grund }).toEqual({ schritt, typ: "string" });
+      expect({ schritt, langGenug: grund.length > 10 }).toEqual({ schritt, langGenug: true });
+    }
+  });
+
+  test("jeder Schritt nennt den Pipeline-Job, der ohne ihn rot würde", () => {
+    /* Ohne diese Angabe muss man raten, wo es in der Pipeline knallt. */
+    const skript = fs.readFileSync(SKRIPT, "utf8");
+    const aufrufe = [...skript.matchAll(/^lauf "([^"]+)" "([^"]+)"/gm)];
+    expect(aufrufe.length).toBeGreaterThan(8);
+    const unbekannt = aufrufe
+      .filter(([, , job]) => !["test-frontend", "test-backend", "pruefungen"].includes(job))
+      .map(([, beschreibung, job]) => `${beschreibung} → "${job}"`);
+    expect(unbekannt).toEqual([]);
+  });
+});

--- a/scripts/vor-dem-push.sh
+++ b/scripts/vor-dem-push.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# vor-dem-push.sh — faehrt genau die BILLIGEN Pruefungen der Pipeline ab,
+# in derselben Reihenfolge, vor dem Push.
+#
+# Warum es das gibt: Am 2026-08-13 gingen drei Pipeline-Laeufe rot. Zwei davon
+# waren reine Nachlaessigkeit — Prettier nicht gelaufen, die vendorierte Kopie
+# statt der Quelle bearbeitet. Beide haetten diese Pruefungen gefangen. Sie
+# dauern zusammen wenige Sekunden; ein roter Lauf kostet dagegen Push, dreieinhalb
+# Minuten Warten, Protokoll lesen, beheben und noch einmal dasselbe.
+#
+# Was hier ABSICHTLICH FEHLT: die Backend- und die E2E-Suite. Sie laufen lokal
+# ungefaehr so lang wie in der Pipeline, weil GitHub sie auf mehrere Maschinen
+# verteilt. Dort gaebe es nichts zu gewinnen. Wer sie will, nimmt
+# scripts/pruefstand.sh — das ist der Lauf vor einem Release.
+#
+# Kein `set -e`: Dieses Skript ist ein Sammel-Berichter. Es soll ALLE Mangel
+# zeigen, nicht beim ersten stehenbleiben (Entscheidung E-001 der Familie).
+
+WURZEL=$(cd "$(dirname "$0")/.." && pwd)
+cd "$WURZEL" || exit 2
+
+FEHLER=0
+LISTE=""
+
+# Fuehrt einen Schritt aus und merkt sich den Rueckgabewert.
+# Die Ausgabe wird nur bei einem Mangel gezeigt — sonst bleibt der Lauf ruhig.
+lauf() {
+  BESCHREIBUNG="$1"
+  CI_JOB="$2"
+  shift 2
+  AUSGABE=$("$@" 2>&1)
+  RC=$?
+  if [ "$RC" -eq 0 ]; then
+    printf '  ok    %s\n' "$BESCHREIBUNG"
+  else
+    printf '  ROT   %s   (Pipeline-Job: %s)\n' "$BESCHREIBUNG" "$CI_JOB"
+    printf '%s\n' "$AUSGABE" | sed 's/^/        /' | tail -20
+    FEHLER=$((FEHLER + 1))
+    LISTE="$LISTE
+  - $BESCHREIBUNG  ($CI_JOB)"
+  fi
+}
+
+START=$(date +%s)
+echo "Vor dem Push — die billigen Pruefungen der Pipeline"
+echo "-----------------------------------------------------------"
+
+# ── Job: test-frontend ──────────────────────────────────────────────────────
+lauf "Frontend: Lint" "test-frontend" npm run --silent lint:frontend
+lauf "Frontend: Format" "test-frontend" npm run --silent format:frontend:check
+lauf "Frontend: Unit-Tests" "test-frontend" npm run --silent test:frontend
+
+# ── Job: test-backend (ohne die lange Suite) ────────────────────────────────
+lauf "Backend: Abhaengigkeits-Gate" "test-backend" node scripts/audit-gate.mjs functions .
+lauf "Backend: Lint" "test-backend" sh -c 'cd functions && npm run --silent lint'
+lauf "Backend: Format" "test-backend" sh -c 'cd functions && npm run --silent format:check'
+
+# ── Job: pruefungen ─────────────────────────────────────────────────────────
+lauf "Pruefungen: Selbstpruefung" "pruefungen" sh scripts/pruefungen/selbstpruefung.sh
+lauf "Pruefungen: Aussentext-Sperrliste" "pruefungen" python3 scripts/pruefungen/checks/aussentext.py .
+lauf "Pruefungen: Fakten-Drift" "pruefungen" python3 scripts/pruefungen/checks/fakten-drift.py .
+lauf "Pruefungen: Stiller Fehlschlag" "pruefungen" python3 scripts/pruefungen/checks/stiller-fehlschlag.py .
+lauf "Pruefungen: Tests ohne Zusicherung" "pruefungen" python3 scripts/pruefungen/checks/test-blind.py .
+lauf "Pruefungen: Fremddateien" "pruefungen" node scripts/pruefe-fremddateien.mjs
+lauf "Pruefungen: Vendorierung" "pruefungen" node scripts/pruefe-vendorierung.mjs
+
+DAUER=$(($(date +%s) - START))
+echo "-----------------------------------------------------------"
+
+if [ "$FEHLER" -eq 0 ]; then
+  echo "Alles gruen in ${DAUER} s. Die langen Suiten (Backend, E2E) fehlen hier"
+  echo "bewusst — vor einem Release faehrt scripts/pruefstand.sh alles ab."
+  exit 0
+fi
+
+printf 'ROT: %s Pruefung(en) wuerden die Pipeline brechen:%s\n' "$FEHLER" "$LISTE"
+echo ""
+echo "Erst beheben, dann pushen. Das spart pro Fehlschlag rund acht Minuten"
+echo "Wartezeit an der Pipeline."
+exit 1


### PR DESCRIPTION
Heute gingen drei Pipeline-Läufe rot. **Zwei davon waren reine Nachlässigkeit** — Prettier nicht gelaufen, und die vendorierte Kopie der Prüfmittel bearbeitet statt der Quelle. Beide hätte dieses Skript gefangen.

Die Ursache war nicht Unwissen, sondern das Fehlen **eines** Befehls: Es gab keinen Weg, lokal genau das laufen zu lassen, was die Pipeline laufen lässt. `pruefstand.sh` fährt die drei Suiten, aber weder Lint noch Format noch die Wächter. Die Liste stellte sich jeder im Kopf zusammen — und im Kopf fehlt dann eben etwas.

## Was drin ist

13 Prüfungen aus den Jobs `test-frontend`, `test-backend` und `pruefungen`. Bei einem Mangel nennt die Zeile den Job, der ohne ihn rot würde — sonst muss man raten, wo es knallt.

**Gemessen: 6 bis 7 Sekunden.** Ein roter Pipeline-Lauf kostet dagegen Push, dreieinhalb Minuten Warten, Protokoll lesen, beheben, wieder pushen.

## Was bewusst fehlt

Die Backend- und die E2E-Suite. Sie laufen lokal so lang wie in der Pipeline, weil GitHub sie auf mehrere Maschinen verteilt — dort gibt es nichts zu gewinnen. Vor einem Release fährt `scripts/pruefstand.sh` weiterhin alles ab.

## Der Wächter ist wichtiger als das Skript

`vor-dem-push-script.test.js` liest die **Workflow-Datei** und das Skript und meldet jeden Pipeline-Schritt, den das Skript nicht kennt. Ohne ihn würde es beim ersten neuen CI-Schritt zur Beruhigungspille: „alles grün" für etwas, das es nicht mehr prüft. Genau die Fehlerklasse, die in diesem Projekt schon einmal auftrat (`DOC-2026-08-12-07`: ein Wächter prüfte Existenz statt Zuordnung und blieb grün).

Jede bewusste Auslassung braucht eine Begründung — auch das prüft ein Test, damit die Ausnahmeliste nicht still wächst.

## Beweise

Die drei echten Fehler von heute einzeln wieder eingebaut:

| Wieder eingebauter Fehler | Meldung |
|---|---|
| Format nicht gelaufen | ROT, Job `test-backend` |
| Kopie statt Quelle bearbeitet | ROT, Job `pruefungen` |
| gesperrte Formulierung im Außentext | ROT, Job `pruefungen` |

Dazu: Rückbauprobe am Wächter — ein zusätzlicher Schritt in `ci.yml` macht ihn rot und nennt den fehlenden Befehl. Das Skript auf sich selbst angewendet: grün in 6 s. `vor-dem-push-script` → 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
