### PR TITLE
fix: abgebrochene Analysen, verschluckte Fehler, localStorage entfernt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,139 +6,6 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
 ## [Unveröffentlicht]
 
-### Behoben — Abbrüche und verschluckte Fehler
-
-- **Die Analyse hatte eine Zeitgrenze, die sie gar nicht einhalten konnte.**
-  Ein Nutzer meldete abgebrochene Analysen und lange Wartezeiten. Am
-  30-Tage-Diagnose-Bucket nachgemessen: Der KI-Aufruf darf **8000 Token**
-  schreiben, wird aber nach **90 Sekunden** abgebrochen. Das Modell schreibt
-  gemessen mit 47 Token/s (langsamster Lauf 39,4) — 8000 Token brauchen also
-  rund 170 Sekunden. Die erlaubte Textmenge passte nie in die erlaubte Zeit.
-
-  Aufgefallen ist es erst jetzt, weil die Grenze bis v3.0.0 gar nicht zubiss:
-  Ohne Stream räumt `mistral.js` die Uhr schon nach den Antwortkopfzeilen weg,
-  das eigentliche Warten lief ungebremst. Der Live-Text (11.08.) hält die Uhr
-  bewusst scharf bis zum letzten Zeichen — und schaltete damit eine seit Mai
-  schlafende Grenze zum ersten Mal wirksam. Die Zahlen dazu:
-
-  | Zeitraum | Läufe | technische Fehler | Läufe über 90 s |
-  |---|---|---|---|
-  | vor v3.0.0 (19.07.–11.08.) | 121 | 0 | 8 — **alle wurden fertig** |
-  | nach v3.0.0 (11.08.–16.08.) | 28 | 2 (7,1 %) | 3 |
-
-  Jetzt hat der Single-Large-Aufruf ein eigenes, gemessenes Zeitbudget
-  (150 s statt 90 s), und die Textmenge ist auf 5000 Token gesetzt — reichlich
-  über dem längsten je gemessenen Lauf (4394 Token). Beide Werte stehen
-  nebeneinander in `config.js` und werden **gegeneinander gerechnet**: Die
-  Startprüfung wirft, und `mistral-zeitbudget.test.js` wird rot, sobald jemand
-  einen der beiden allein verschiebt. Genau diese Rechnung hatte gefehlt —
-  einzeln sah jeder Wert plausibel aus, und daran sind zwei Audits
-  vorbeigelaufen.
-
-- **Der abgebrochene Lauf schlug keinen Alarm — der Ersatz-Werbeaufruf schon.**
-  Die gescheiterte Analyse wurde mit `console.log` festgehalten, also ohne
-  Severity, und fiel damit nicht unter die aktive Alarm-Richtlinie
-  (`malziME Function Errors`, deckt `processjob` ab `severity>=ERROR` ab).
-  Zwei tote Läufe (11.08., 14.08.) haben so niemanden erreicht; gefunden wurden
-  sie, weil sich ein Nutzer beschwerte. Jetzt `console.error` mit
-  `alert: "single-large-failed"` und dem Fehler-Code, der „Modell zu langsam"
-  von „API weg" unterscheidet.
-
-- **Die Meldung über eine abgerissene Verbindung brauchte die abgerissene
-  Verbindung.** `error-logger.js` schickte jeden Fehler per `fetch` und
-  verschluckte einen Fehlschlag dabei still. Damit blieb ausgerechnet die
-  häufigste Fehlerklasse systematisch unsichtbar: In 30 Tagen lagen **zwei**
-  Client-Fehler im Bucket, obwohl mehrere gemeldet wurden. Jetzt wartet eine
-  misslungene Meldung **im Arbeitsspeicher** und wird beim Ereignis „wieder
-  online" sowie ein letztes Mal beim Verlassen der Seite nachgeschickt. Ein 4xx
-  wird nicht wiederholt (der Server will sie nicht), ein 5xx schon.
-
-  **Bewusst ohne Browser-Speicher.** Ein erster Entwurf legte die Meldungen in
-  den `sessionStorage`. Das war der falsche Weg: Die Datenschutzerklärung zählt
-  abschließend auf, was dort liegt — ein sechster Eintrag hätte bedeutet, den
-  Rechtstext an eine Funktion anzupassen. Die Reihenfolge ist umgekehrt. Der
-  Preis ist ehrlich benannt: Wer den Tab schließt, während das Netz weg ist,
-  dessen Meldung ist verloren. Abgedeckt ist der Fall, der in den Logs
-  tatsächlich auftrat. `error-logger-puffer.test.js` prüft, dass in
-  `sessionStorage` und `localStorage` nichts landet.
-
-- **Die Karte „technischer Fehler" wurde nirgends als Fehler gezählt.**
-  Ein `blocked`-Ergebnis lief ausschließlich als `analyze-success` durch die
-  Telemetrie. Der für den Nutzer sichtbarste Fehler war damit der einzige ohne
-  Fehlermeldung. Jetzt löst er `logClientError` mit dem `blockedReason` aus.
-
-### Geändert — der Live-Text überlebt einen Verbindungsabbruch
-
-- **Der geschriebene Text bleibt jetzt stehen.** Bis v3.3.0 räumte ein
-  Verbindungsabbruch Karte und Text weg und stellte eine Fehlermeldung hin.
-  Aus Nutzersicht sah das nach Datenverlust aus, obwohl serverseitig nichts
-  verloren war — das Ergebnis liegt rund zwei Stunden bereit. Jetzt wird
-  pausiert statt abgeräumt: Der Text bleibt gedämpft stehen, die Begründung
-  trägt die Statuszeile.
-
-  Zwei Zusicherungen dazu stehen als Prüfung, nicht als Vorsatz:
-  **Was schon gelesen wurde, wird nie umgeschrieben** (eine Welle wird nur
-  übernommen, wenn sie mit dem bereits Getippten beginnt), und **es geht
-  wirklich weiter** — die Schleife tippt an derselben Stelle weiter.
-
-- **„Erscheint automatisch, sobald du wieder online bist" stimmt jetzt.**
-  Diese Zusage stand seit Langem in der Fehlermeldung, war aber ungedeckt: Es
-  lauschte niemand auf „online", die Wiederaufnahme setzte den Live-Text zurück
-  und fragte ohne ihn weiter. Nachgerüstet sind alle drei Teile — der Lauscher,
-  die Fortsetzung des Textes und ein Anker (`state.wartetAufVerbindung`), der
-  den offenen Durchgang überhaupt erst auffindbar macht.
-
-- **Ein zweiter Abbruch wirft die Job-Nummer nicht mehr weg.** Die
-  Wiederaufnahme räumte bei jedem Fehler auf. Solange sie nur beim Seitenstart
-  lief, war das folgenlos; seit sie auch mitten im Lauf greift, hätte sie ein
-  fertiges Profil endgültig unerreichbar gemacht.
-
-### Entfernt — der `localStorage` und die Erprobungs-Türen
-
-- **Die Datenschutzerklärung sagt „kein localStorage" zu — seit v3.3.0 stimmte
-  das nicht mehr.** `sprachumschalter.js` legte bei **jedem** Besucher den
-  Eintrag `malzime-umschalter-aktiv` an, damit die Rechtsseiten erfahren, dass
-  der DE/EN-Umschalter im Betrieb ist (sie öffnen mit `target="_blank"` und
-  bekommen einen leeren `sessionStorage`). Live nachgemessen am 17.08.:
-  `/api/stats` liefert `sprachumschalter: true`, der Eintrag entstand also
-  wirklich bei allen. Inhaltlich harmlos — für alle Besucher derselbe Wert `1`,
-  keine Kennung, nicht zum Wiedererkennen geeignet — aber die Zusage war
-  unzutreffend.
-
-  **Behoben wurde der Code, nicht der Rechtstext.** Beide Türen, mit denen sich
-  der Umschalter vor seiner Freischaltung vorführen ließ, sind ersatzlos weg:
-  das Adress-Anhängsel `?sprachumschalter=1` und der Konsolen-Aufruf
-  `malziME.sprachumschalter()`. Mit ihnen die beiden `localStorage`-Schlüssel.
-  Sie stammten aus der Zeit vor v3.3.0; seit der Umschalter live ist, führen sie
-  an einem offenen Zimmer vorbei.
-
-  Die Rechtsseiten zeigen den Umschalter jetzt schlicht immer — **ohne** dafür
-  eine Schnittstelle aufzurufen. Diese Festlegung („eine Rechtsseite macht
-  keinen Netzweg auf") bleibt unangetastet; auf Startseite und Zahlen-Seite
-  entscheidet weiterhin allein das Merkmals-Schloss.
-
-  Nachgemessen: **null `localStorage`-Zugriffe** im gesamten Frontend
-  (Positivkontrolle: dieselbe Suche findet 23 `sessionStorage`-Zugriffe). Zwei
-  Prüfungen halten das fest — eine im Unit-Test, eine im E2E-Test, die auf den
-  Rechtsseiten beide Speicher als leer nachweist.
-
-- **Nebenbei stimmte `docs/FLAGS.md` nicht mit dem Code überein.** Dort stand,
-  die Erprobungs-Tür „überlebt kein Neuladen" — der `localStorage` machte daraus
-  geräteweit und dauerhaft. Mit dem Rückbau ist auch diese Abweichung weg.
-
-### Behoben — Google Search Console
-
-- **Bild-Metadaten für strukturierte Daten vervollständigt.** Die Search
-  Console meldete am 17.08. zwei nicht kritische Befunde: In den drei
-  `ImageObject`-Blöcken fehlten `license` und `acquireLicensePage`. Beide sind
-  ergänzt: `license` zeigt auf die MIT-Lizenz im Repository, für
-  `acquireLicensePage` verlangt Google eine Seite, auf der man erfährt, wie man
-  eine Lizenz bekommt — dafür das Impressum mit den Kontaktdaten. **Kein
-  Rechtstext wurde dafür geändert.** `strukturdaten-bilder.test.js` prüft
-  dauerhaft, dass alle sechs Felder da sind, dass es URLs sind, dass die
-  verlinkte Seite existiert und dass sie tatsächlich eine Kontaktmöglichkeit
-  trägt.
-
 ### Hinzugefügt
 
 - **`scripts/vor-dem-push.sh` — die Pipeline in wenigen Sekunden vorweggenommen.**
@@ -162,7 +29,122 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   Beruhigungspille — „alles grün" für etwas, das es nicht mehr prüft. Jede
   bewusste Auslassung braucht eine Begründung, auch das prüft ein Test.
 
+### Geändert
+
+- **Der Live-Text überlebt jetzt einen Verbindungsabbruch.** Bisher räumte ein
+  Abbruch Karte und Text weg und stellte eine Fehlermeldung hin. Aus Nutzersicht
+  sah das nach Datenverlust aus, obwohl serverseitig nichts verloren war — das
+  Ergebnis liegt rund zwei Stunden bereit. Jetzt wird pausiert statt abgeräumt:
+  Der Text bleibt gedämpft stehen, die Begründung trägt die Statuszeile.
+
+  Zwei Zusicherungen dazu stehen als Prüfung, nicht als Vorsatz: **Was schon
+  gelesen wurde, wird nie umgeschrieben** (eine Welle wird nur übernommen, wenn
+  sie mit dem bereits Getippten beginnt), und **es geht wirklich weiter** — die
+  Schleife tippt an derselben Stelle wieder los.
+
+- **„Erscheint automatisch, sobald du wieder online bist" stimmt jetzt.** Diese
+  Zusage stand seit Langem in der Fehlermeldung, war aber ungedeckt: Es lauschte
+  niemand auf „online", und die Wiederaufnahme setzte den Live-Text zurück und
+  fragte ohne ihn weiter. Nachgerüstet sind alle drei Teile — der Lauscher, die
+  Fortsetzung des Textes und ein Anker im Zustand, der den offenen Durchgang
+  überhaupt erst auffindbar macht.
+
+  Dazu: Ein zweiter Abbruch während der Wiederaufnahme wirft die Job-Nummer
+  nicht mehr weg. Sie ist der einzige Weg zurück zu einem fertigen Profil.
+
+- **Die Formulierungs-Sperrliste prüft jetzt auch Englisch.** Sie kannte nur
+  deutsche Wendungen — deshalb konnte die englische Fassung einer gesperrten
+  Zusage jahrelang unbemerkt dastehen. Vier englische Regeln ergänzt; die
+  Rückbauprobe belegt, dass sie den echten Fall fangen.
+
+- **Der Fakten-Wächter bewacht 14 statt 4 Fakten.** Vier waren zu wenig: Er
+  meldete zuverlässig „kein Drift", und das klang wie eine Aussage über die
+  Doku. Es war eine über vier Zeilen.
+
+  Beim Anlegen zeigte sich zweierlei. Zwei Muster trafen ins Leere und wären
+  stumme Wächter geblieben — repariert. Zwei weitere meldeten **Historie als
+  Drift** (ein alter Vergleichsbericht, die Rückbau-Anweisungen im RUNBOOK, wo
+  abweichende Werte richtig sind) und mussten wieder heraus. Lieber vierzehn
+  verlässliche Muster als sechzehn mit zwei Lügen.
+
 ### Behoben
+
+- **Die Analyse hatte eine Zeitgrenze, die sie gar nicht einhalten konnte.**
+  Gemeldet wurden abgebrochene Analysen und lange Wartezeiten. Am
+  30-Tage-Diagnose-Bucket nachgemessen: Der KI-Aufruf durfte **8000 Token**
+  schreiben, wurde aber nach **90 Sekunden** abgebrochen. Das Modell schreibt
+  gemessen mit 47 Token/s (langsamster Lauf 39,4) — 8000 Token brauchen also
+  rund 170 Sekunden. Die erlaubte Textmenge passte nie in die erlaubte Zeit.
+
+  Aufgefallen ist es erst jetzt, weil die Grenze bis v3.0.0 gar nicht zubiss:
+  Ohne Stream wird die Uhr schon nach den Antwortkopfzeilen abgeräumt, das
+  eigentliche Warten lief ungebremst. Der Live-Text hält sie bewusst scharf bis
+  zum letzten Zeichen — und schaltete damit eine seit Mai schlafende Grenze zum
+  ersten Mal wirksam:
+
+  | Zeitraum | Läufe | technische Fehler | Läufe über 90 s |
+  |---|---|---|---|
+  | vor v3.0.0 (19.07.–11.08.) | 121 | 0 | 8 — **alle wurden fertig** |
+  | nach v3.0.0 (11.08.–16.08.) | 28 | 2 (7,1 %) | 3 |
+
+  Jetzt hat der Single-Large-Aufruf ein eigenes, gemessenes Zeitbudget (150 s
+  statt 90 s), und die Textmenge ist auf 5000 Token gesetzt — reichlich über dem
+  längsten je gemessenen Lauf (4394 Token). Beide Werte stehen nebeneinander in
+  `config.js` und werden **gegeneinander gerechnet**: Die Startprüfung wirft, und
+  `mistral-zeitbudget.test.js` wird rot, sobald jemand einen der beiden allein
+  verschiebt. Genau diese Rechnung hatte gefehlt — einzeln sah jeder Wert
+  plausibel aus, und daran sind zwei Audits vorbeigelaufen.
+
+- **Der abgebrochene Lauf schlug keinen Alarm — der Ersatz-Werbeaufruf schon.**
+  Die gescheiterte Analyse wurde ohne Severity festgehalten und fiel damit nicht
+  unter die aktive Alarm-Richtlinie (`malziME Function Errors`, deckt
+  `processjob` ab `severity>=ERROR` ab). Zwei tote Läufe (11.08., 14.08.) haben
+  so niemanden erreicht; gefunden wurden sie, weil sich ein Nutzer beschwerte.
+  Jetzt `console.error` mit `alert: "single-large-failed"` und dem Fehler-Code,
+  der „Modell zu langsam" von „API weg" unterscheidet.
+
+- **Die Meldung über eine abgerissene Verbindung brauchte die abgerissene
+  Verbindung.** Client-Fehler gingen per `fetch` raus, und ein Fehlschlag dabei
+  wurde still verschluckt. Damit blieb ausgerechnet die häufigste Fehlerklasse
+  systematisch unsichtbar: In 30 Tagen lagen **zwei** Client-Fehler im Bucket,
+  obwohl mehrere gemeldet wurden.
+
+  Jetzt wartet eine misslungene Meldung in einer Warteschlange und wird beim
+  Ereignis „wieder online" sowie ein letztes Mal beim Verlassen der Seite
+  nachgeschickt. Ein 4xx wird nicht wiederholt (der Server will sie nicht), ein
+  5xx schon. Die Warteschlange liegt **ausschließlich im Arbeitsspeicher** — im
+  Browser wird dafür nichts abgelegt, und ein Test hält das fest. Der Preis ist
+  ehrlich benannt: Wer den Tab schließt, während das Netz weg ist, dessen
+  Meldung ist verloren.
+
+- **Die Karte „technischer Fehler" wurde nirgends als Fehler gezählt.** Ein
+  `blocked`-Ergebnis lief ausschließlich als Erfolg durch die Telemetrie. Der
+  für den Nutzer sichtbarste Fehler war damit der einzige ohne Fehlermeldung.
+  Jetzt löst er eine aus, mit dem Grund im Gepäck.
+
+- **Von der englischen Startseite landete man überall wieder auf Deutsch.** Die
+  Sprachwahl liegt im `sessionStorage` — bewusst pro Tab, damit ein
+  weitergereichtes Workshop-Gerät wieder in der Gerätesprache startet. Ein mit
+  `target="_blank"` geöffneter Tab bekommt aber einen **leeren**
+  `sessionStorage`. Gezählt über alle Seiten: **6 interne Links öffnen einen
+  neuen Tab — und alle sechs sitzen auf der Startseite**, es sind also genau
+  die, die von dort wegführen. Die 28 Links auf den Unterseiten öffnen im selben
+  Tab und waren nie betroffen.
+
+  Jetzt hängt die Übersetzungs-Routine die aktuelle Sprache an genau diese Links
+  (`/stats?lang=en`). Kein Speicher, keine Schnittstelle — die Sprache reist
+  sichtbar in der Adresse mit, und sie schlägt beim Seitenstart alles andere.
+  Die kanonischen Adressen bleiben parameterfrei, für Google ändert sich nichts.
+
+- **Bild-Metadaten für strukturierte Daten vervollständigt.** Die Google Search
+  Console meldete zwei nicht kritische Befunde: In den drei
+  `ImageObject`-Blöcken fehlten `license` und `acquireLicensePage`. Beide sind
+  ergänzt — `license` zeigt auf die MIT-Lizenz im Repository, für
+  `acquireLicensePage` verlangt Google eine Seite, auf der man erfährt, wie man
+  eine Lizenz bekommt: das Impressum mit den Kontaktdaten.
+  `strukturdaten-bilder.test.js` prüft dauerhaft, dass alle sechs Felder da
+  sind, dass es URLs sind, dass die verlinkte Seite existiert und dass sie
+  tatsächlich eine Kontaktmöglichkeit trägt.
 
 - **Die Sicherheitsrichtlinie behauptete zwei Dinge, die nicht stimmten.**
   Aufgefallen, nachdem die Doku als Ganzes in Zweifel gezogen wurde — zu Recht.
@@ -179,22 +161,36 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   verlassen den Browser aber sehr wohl. Der Wortlaut steht bewusst nicht hier —
   die Sperrliste würde ihn auch im Zitat beanstanden, und das ist richtig so.
 
-### Geändert
+### Entfernt
 
-- **Die Formulierungs-Sperrliste prüft jetzt auch Englisch.** Sie kannte nur
-  deutsche Wendungen — deshalb konnte die englische Fassung einer gesperrten
-  Zusage jahrelang unbemerkt dastehen. Vier englische Regeln ergänzt; die
-  Rückbauprobe belegt, dass sie den echten Fall fangen.
+- **Der `localStorage` — die Datenschutzerklärung sagt zu, keinen zu nutzen.**
+  Seit v3.3.0 legte der Sprachumschalter bei **jedem** Besucher den Eintrag
+  `malzime-umschalter-aktiv` an, damit die Rechtsseiten erfahren, dass der
+  DE/EN-Umschalter im Betrieb ist (sie öffnen in einem neuen Tab und bekommen
+  einen leeren `sessionStorage`). Live nachgemessen: Das Merkmal ist an, der
+  Eintrag entstand also wirklich bei allen. Inhaltlich harmlos — für alle
+  Besucher derselbe Wert, keine Kennung, nicht zum Wiedererkennen geeignet —
+  aber die Zusage war unzutreffend.
 
-- **Der Fakten-Wächter bewacht 14 statt 4 Fakten.** Vier waren zu wenig: Er
-  meldete zuverlässig „kein Drift", und das klang wie eine Aussage über die
-  Doku. Es war eine über vier Zeilen.
+  Behoben wurde der **Code**, nicht der Rechtstext. Mit entfernt sind die beiden
+  Türen, mit denen sich der Umschalter vor seiner Freischaltung vorführen ließ:
+  das Adress-Anhängsel `?sprachumschalter=1` und der Konsolen-Aufruf
+  `malziME.sprachumschalter()`. Sie stammten aus der Zeit vor v3.3.0; seit der
+  Umschalter live ist, führen sie an einem offenen Zimmer vorbei.
 
-  Beim Anlegen zeigte sich zweierlei. Zwei Muster trafen ins Leere und wären
-  stumme Wächter geblieben — repariert. Zwei weitere meldeten **Historie als
-  Drift** (ein alter Vergleichsbericht, die Rückbau-Anweisungen im RUNBOOK, wo
-  abweichende Werte richtig sind) und mussten wieder heraus. Lieber vierzehn
-  verlässliche Muster als sechzehn mit zwei Lügen.
+  Die Rechtsseiten zeigen den Umschalter jetzt schlicht immer — **ohne** dafür
+  eine Schnittstelle aufzurufen. Diese Festlegung („eine Rechtsseite macht
+  keinen Netzweg auf") bleibt unangetastet; auf Startseite und Zahlen-Seite
+  entscheidet weiterhin allein das Merkmals-Schloss.
+
+  Nachgemessen: **null `localStorage`-Zugriffe** im gesamten Frontend
+  (Positivkontrolle: dieselbe Suche findet 23 `sessionStorage`-Zugriffe). Drei
+  Prüfungen halten das fest — eine im Unit-Test, zwei im E2E-Test, die auf den
+  Rechtsseiten beide Speicher als leer nachweisen.
+
+  Nebenbei stimmte `docs/FLAGS.md` nicht mit dem Code überein: Dort stand, die
+  Erprobungs-Tür „überlebt kein Neuladen" — der `localStorage` machte daraus
+  geräteweit und dauerhaft. Mit dem Rückbau ist auch diese Abweichung weg.
 
 ## [3.3.0] — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,139 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
 ## [Unveröffentlicht]
 
+### Behoben — Abbrüche und verschluckte Fehler
+
+- **Die Analyse hatte eine Zeitgrenze, die sie gar nicht einhalten konnte.**
+  Ein Nutzer meldete abgebrochene Analysen und lange Wartezeiten. Am
+  30-Tage-Diagnose-Bucket nachgemessen: Der KI-Aufruf darf **8000 Token**
+  schreiben, wird aber nach **90 Sekunden** abgebrochen. Das Modell schreibt
+  gemessen mit 47 Token/s (langsamster Lauf 39,4) — 8000 Token brauchen also
+  rund 170 Sekunden. Die erlaubte Textmenge passte nie in die erlaubte Zeit.
+
+  Aufgefallen ist es erst jetzt, weil die Grenze bis v3.0.0 gar nicht zubiss:
+  Ohne Stream räumt `mistral.js` die Uhr schon nach den Antwortkopfzeilen weg,
+  das eigentliche Warten lief ungebremst. Der Live-Text (11.08.) hält die Uhr
+  bewusst scharf bis zum letzten Zeichen — und schaltete damit eine seit Mai
+  schlafende Grenze zum ersten Mal wirksam. Die Zahlen dazu:
+
+  | Zeitraum | Läufe | technische Fehler | Läufe über 90 s |
+  |---|---|---|---|
+  | vor v3.0.0 (19.07.–11.08.) | 121 | 0 | 8 — **alle wurden fertig** |
+  | nach v3.0.0 (11.08.–16.08.) | 28 | 2 (7,1 %) | 3 |
+
+  Jetzt hat der Single-Large-Aufruf ein eigenes, gemessenes Zeitbudget
+  (150 s statt 90 s), und die Textmenge ist auf 5000 Token gesetzt — reichlich
+  über dem längsten je gemessenen Lauf (4394 Token). Beide Werte stehen
+  nebeneinander in `config.js` und werden **gegeneinander gerechnet**: Die
+  Startprüfung wirft, und `mistral-zeitbudget.test.js` wird rot, sobald jemand
+  einen der beiden allein verschiebt. Genau diese Rechnung hatte gefehlt —
+  einzeln sah jeder Wert plausibel aus, und daran sind zwei Audits
+  vorbeigelaufen.
+
+- **Der abgebrochene Lauf schlug keinen Alarm — der Ersatz-Werbeaufruf schon.**
+  Die gescheiterte Analyse wurde mit `console.log` festgehalten, also ohne
+  Severity, und fiel damit nicht unter die aktive Alarm-Richtlinie
+  (`malziME Function Errors`, deckt `processjob` ab `severity>=ERROR` ab).
+  Zwei tote Läufe (11.08., 14.08.) haben so niemanden erreicht; gefunden wurden
+  sie, weil sich ein Nutzer beschwerte. Jetzt `console.error` mit
+  `alert: "single-large-failed"` und dem Fehler-Code, der „Modell zu langsam"
+  von „API weg" unterscheidet.
+
+- **Die Meldung über eine abgerissene Verbindung brauchte die abgerissene
+  Verbindung.** `error-logger.js` schickte jeden Fehler per `fetch` und
+  verschluckte einen Fehlschlag dabei still. Damit blieb ausgerechnet die
+  häufigste Fehlerklasse systematisch unsichtbar: In 30 Tagen lagen **zwei**
+  Client-Fehler im Bucket, obwohl mehrere gemeldet wurden. Jetzt wartet eine
+  misslungene Meldung **im Arbeitsspeicher** und wird beim Ereignis „wieder
+  online" sowie ein letztes Mal beim Verlassen der Seite nachgeschickt. Ein 4xx
+  wird nicht wiederholt (der Server will sie nicht), ein 5xx schon.
+
+  **Bewusst ohne Browser-Speicher.** Ein erster Entwurf legte die Meldungen in
+  den `sessionStorage`. Das war der falsche Weg: Die Datenschutzerklärung zählt
+  abschließend auf, was dort liegt — ein sechster Eintrag hätte bedeutet, den
+  Rechtstext an eine Funktion anzupassen. Die Reihenfolge ist umgekehrt. Der
+  Preis ist ehrlich benannt: Wer den Tab schließt, während das Netz weg ist,
+  dessen Meldung ist verloren. Abgedeckt ist der Fall, der in den Logs
+  tatsächlich auftrat. `error-logger-puffer.test.js` prüft, dass in
+  `sessionStorage` und `localStorage` nichts landet.
+
+- **Die Karte „technischer Fehler" wurde nirgends als Fehler gezählt.**
+  Ein `blocked`-Ergebnis lief ausschließlich als `analyze-success` durch die
+  Telemetrie. Der für den Nutzer sichtbarste Fehler war damit der einzige ohne
+  Fehlermeldung. Jetzt löst er `logClientError` mit dem `blockedReason` aus.
+
+### Geändert — der Live-Text überlebt einen Verbindungsabbruch
+
+- **Der geschriebene Text bleibt jetzt stehen.** Bis v3.3.0 räumte ein
+  Verbindungsabbruch Karte und Text weg und stellte eine Fehlermeldung hin.
+  Aus Nutzersicht sah das nach Datenverlust aus, obwohl serverseitig nichts
+  verloren war — das Ergebnis liegt rund zwei Stunden bereit. Jetzt wird
+  pausiert statt abgeräumt: Der Text bleibt gedämpft stehen, die Begründung
+  trägt die Statuszeile.
+
+  Zwei Zusicherungen dazu stehen als Prüfung, nicht als Vorsatz:
+  **Was schon gelesen wurde, wird nie umgeschrieben** (eine Welle wird nur
+  übernommen, wenn sie mit dem bereits Getippten beginnt), und **es geht
+  wirklich weiter** — die Schleife tippt an derselben Stelle weiter.
+
+- **„Erscheint automatisch, sobald du wieder online bist" stimmt jetzt.**
+  Diese Zusage stand seit Langem in der Fehlermeldung, war aber ungedeckt: Es
+  lauschte niemand auf „online", die Wiederaufnahme setzte den Live-Text zurück
+  und fragte ohne ihn weiter. Nachgerüstet sind alle drei Teile — der Lauscher,
+  die Fortsetzung des Textes und ein Anker (`state.wartetAufVerbindung`), der
+  den offenen Durchgang überhaupt erst auffindbar macht.
+
+- **Ein zweiter Abbruch wirft die Job-Nummer nicht mehr weg.** Die
+  Wiederaufnahme räumte bei jedem Fehler auf. Solange sie nur beim Seitenstart
+  lief, war das folgenlos; seit sie auch mitten im Lauf greift, hätte sie ein
+  fertiges Profil endgültig unerreichbar gemacht.
+
+### Entfernt — der `localStorage` und die Erprobungs-Türen
+
+- **Die Datenschutzerklärung sagt „kein localStorage" zu — seit v3.3.0 stimmte
+  das nicht mehr.** `sprachumschalter.js` legte bei **jedem** Besucher den
+  Eintrag `malzime-umschalter-aktiv` an, damit die Rechtsseiten erfahren, dass
+  der DE/EN-Umschalter im Betrieb ist (sie öffnen mit `target="_blank"` und
+  bekommen einen leeren `sessionStorage`). Live nachgemessen am 17.08.:
+  `/api/stats` liefert `sprachumschalter: true`, der Eintrag entstand also
+  wirklich bei allen. Inhaltlich harmlos — für alle Besucher derselbe Wert `1`,
+  keine Kennung, nicht zum Wiedererkennen geeignet — aber die Zusage war
+  unzutreffend.
+
+  **Behoben wurde der Code, nicht der Rechtstext.** Beide Türen, mit denen sich
+  der Umschalter vor seiner Freischaltung vorführen ließ, sind ersatzlos weg:
+  das Adress-Anhängsel `?sprachumschalter=1` und der Konsolen-Aufruf
+  `malziME.sprachumschalter()`. Mit ihnen die beiden `localStorage`-Schlüssel.
+  Sie stammten aus der Zeit vor v3.3.0; seit der Umschalter live ist, führen sie
+  an einem offenen Zimmer vorbei.
+
+  Die Rechtsseiten zeigen den Umschalter jetzt schlicht immer — **ohne** dafür
+  eine Schnittstelle aufzurufen. Diese Festlegung („eine Rechtsseite macht
+  keinen Netzweg auf") bleibt unangetastet; auf Startseite und Zahlen-Seite
+  entscheidet weiterhin allein das Merkmals-Schloss.
+
+  Nachgemessen: **null `localStorage`-Zugriffe** im gesamten Frontend
+  (Positivkontrolle: dieselbe Suche findet 23 `sessionStorage`-Zugriffe). Zwei
+  Prüfungen halten das fest — eine im Unit-Test, eine im E2E-Test, die auf den
+  Rechtsseiten beide Speicher als leer nachweist.
+
+- **Nebenbei stimmte `docs/FLAGS.md` nicht mit dem Code überein.** Dort stand,
+  die Erprobungs-Tür „überlebt kein Neuladen" — der `localStorage` machte daraus
+  geräteweit und dauerhaft. Mit dem Rückbau ist auch diese Abweichung weg.
+
+### Behoben — Google Search Console
+
+- **Bild-Metadaten für strukturierte Daten vervollständigt.** Die Search
+  Console meldete am 17.08. zwei nicht kritische Befunde: In den drei
+  `ImageObject`-Blöcken fehlten `license` und `acquireLicensePage`. Beide sind
+  ergänzt: `license` zeigt auf die MIT-Lizenz im Repository, für
+  `acquireLicensePage` verlangt Google eine Seite, auf der man erfährt, wie man
+  eine Lizenz bekommt — dafür das Impressum mit den Kontaktdaten. **Kein
+  Rechtstext wurde dafür geändert.** `strukturdaten-bilder.test.js` prüft
+  dauerhaft, dass alle sechs Felder da sind, dass es URLs sind, dass die
+  verlinkte Seite existiert und dass sie tatsächlich eine Kontaktmöglichkeit
+  trägt.
+
 ### Hinzugefügt
 
 - **`scripts/vor-dem-push.sh` — die Pipeline in wenigen Sekunden vorweggenommen.**

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -134,16 +134,25 @@ wäre schlimmer als keiner — man klickt darauf, und nichts passiert. Ein Test
 prüft die Elementzahl auf null, ein zweiter (Positivkontrolle) prüft, dass er
 mit Flag sehr wohl entsteht.
 
-**Erproben ohne Flag:** In der Browser-Konsole auf der echten Seite
+**Erproben ohne Flag: entfallen mit v3.3.1.** Es gab zwei Türen — das Anhängsel
+`?sprachumschalter=1` in der Adresse und den Konsolen-Aufruf
+`malziME.sprachumschalter()`. Beide sind ersatzlos entfernt. Zwei Gründe:
 
-```js
-malziME.sprachumschalter();        // einblenden, nur in diesem Tab
-malziME.sprachumschalter(false);   // wieder entfernen
-```
+1. **Sie legten eine Spur im `localStorage` ab** (`malzime-tuer-sprachumschalter`
+   und `malzime-umschalter-aktiv`) — Letzteres bei *jedem* Besucher, weil es den
+   Merkmals-Stand an die Unterseiten weiterreichte. Die Datenschutzerklärung
+   sagt zu, im Browser nichts Dauerhaftes abzulegen. Der Rechtstext ist die
+   Vorgabe, nicht der Code.
+2. **Sie waren für die Zeit vor der Freischaltung gedacht.** Seit v3.3.0 ist der
+   Umschalter live; eine Tür an einem offenen Zimmer braucht niemand.
 
-Die Tür steht unabhängig vom Flag offen und überlebt kein Neuladen. Damit lässt
-sich die fertige Bedienung live durchspielen, ohne dass ein Workshop-Publikum
-etwas davon sieht.
+Nebenbei stimmte die Beschreibung hier nicht mehr mit dem Code überein: Sie sagte,
+die Tür überlebe kein Neuladen — der `localStorage` machte daraus geräteweit und
+dauerhaft. Mit dem Rückbau ist auch diese Abweichung weg.
+
+Die Unterseiten mit den Rechtstexten zeigen den Umschalter jetzt unabhängig vom
+Flag (sie rufen bewusst keine Schnittstelle auf — diese Festlegung bleibt). Auf
+Startseite und Zahlen-Seite entscheidet allein das Flag.
 
 **Verhalten beim Umschalten:** Auf der leeren Seite sofort. Läuft eine Analyse
 oder liegt ein Profil vor, kommt erst eine Rückfrage — in der aktuellen

--- a/e2e/sprachumschalter-unterseiten.test.js
+++ b/e2e/sprachumschalter-unterseiten.test.js
@@ -18,38 +18,47 @@ import AxeBuilder from "@axe-core/playwright";
 const NUR_DEUTSCH = ["/datenschutz.html", "/impressum.html", "/nutzungsbedingungen.html"];
 
 async function ruhe(page) {
-  await page.evaluate(
-    () =>
-      new Promise((fertig) => requestAnimationFrame(() => requestAnimationFrame(fertig)))
-  );
+  await page.evaluate(() => new Promise((fertig) => requestAnimationFrame(() => requestAnimationFrame(fertig))));
 }
 
 test.describe("Nur-deutsche Seiten: Hinweis statt Wechsel", () => {
   test.use({ locale: "en-US" });
 
   for (const seite of NUR_DEUTSCH) {
-    test(`${seite}: ohne Tür kein Schalter, mit Tür einer`, async ({ page }) => {
+    test(`${seite}: genau ein Schalter, ohne jedes Anhängsel`, async ({ page }) => {
       await page.goto(seite);
       await ruhe(page);
-      await expect(page.locator(".sprach-pille")).toHaveCount(0);
-
-      /* Positivkontrolle: Die Null oben wäre auch dann erfüllt, wenn der
-         Schalter überhaupt nicht mehr gebaut werden könnte. */
-      await page.goto(`${seite}?sprachumschalter=1`);
+      /* v3.3.1: Der Umschalter ist hier schlicht immer da. Die frühere
+         Erprobungs-Tür (`?sprachumschalter=1`) ist entfallen — sie stammte aus
+         der Zeit vor der Freischaltung, und ihre Spur lag im localStorage. */
+      await expect(page.locator(".sprach-pille")).toHaveCount(1);
       await expect(page.locator(".sprach-pille")).toBeVisible();
+    });
+
+    test(`${seite}: legt NICHTS im Browser ab`, async ({ page }) => {
+      /* Die Datenschutzerklärung sagt zu, im Browser nichts Dauerhaftes
+         abzulegen. Bis v3.3.0 stand hier `malzime-umschalter-aktiv`. */
+      await page.goto(seite);
+      await ruhe(page);
+      const speicher = await page.evaluate(() => ({
+        local: Object.keys(localStorage),
+        session: Object.keys(sessionStorage),
+      }));
+      expect(speicher.local).toEqual([]);
+      expect(speicher.session).toEqual([]);
     });
   }
 
   test("der Schalter steht auf DE — auch bei englischem Browser", async ({ page }) => {
     /* Er sagt aus, in welcher Sprache das dasteht, was man liest. Auf einer
        deutschen Seite EN anzuzeigen wäre gelogen. */
-    await page.goto("/datenschutz.html?sprachumschalter=1");
+    await page.goto("/datenschutz.html");
     await expect(page.locator('.sprach-knopf[data-lang="de"]')).toHaveClass(/aktiv/);
     await expect(page.locator('.sprach-knopf[data-lang="en"]')).not.toHaveClass(/aktiv/);
   });
 
   test("EN öffnet einen zweisprachigen Hinweis und ändert nichts", async ({ page }) => {
-    await page.goto("/datenschutz.html?sprachumschalter=1");
+    await page.goto("/datenschutz.html");
     await page.click('.sprach-knopf[data-lang="en"]');
 
     const hinweis = page.locator('.sw-grund[data-modal="unuebersetzt"]');
@@ -73,7 +82,7 @@ test.describe("Nur-deutsche Seiten: Hinweis statt Wechsel", () => {
   });
 
   test("Escape schließt, der Fokus kehrt auf den Schalter zurück", async ({ page }) => {
-    await page.goto("/datenschutz.html?sprachumschalter=1");
+    await page.goto("/datenschutz.html");
     const en = page.locator('.sprach-knopf[data-lang="en"]');
     await en.focus();
     await en.click();
@@ -98,7 +107,7 @@ test.describe("Nur-deutsche Seiten: Hinweis statt Wechsel", () => {
       const u = new URL(r.url());
       if (u.pathname.startsWith("/api/")) rufe.push(u.pathname);
     });
-    await page.goto("/datenschutz.html?sprachumschalter=1");
+    await page.goto("/datenschutz.html");
     await page.click('.sprach-knopf[data-lang="en"]');
     await ruhe(page);
     expect(rufe).toEqual([]);
@@ -106,15 +115,14 @@ test.describe("Nur-deutsche Seiten: Hinweis statt Wechsel", () => {
 
   test("axe: Seite mit offenem Hinweis ohne ernste Verstöße", async ({ page }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
-    await page.goto("/datenschutz.html?sprachumschalter=1");
+    await page.goto("/datenschutz.html");
     await page.click('.sprach-knopf[data-lang="en"]');
     await expect(page.locator(".sw-grund.sichtbar")).toHaveCount(1);
-    await page.evaluate(
-      () =>
-        Promise.race([
-          Promise.all(document.getAnimations().map((a) => a.finished.catch(() => {}))),
-          new Promise((f) => setTimeout(f, 1000)),
-        ])
+    await page.evaluate(() =>
+      Promise.race([
+        Promise.all(document.getAnimations().map((a) => a.finished.catch(() => {}))),
+        new Promise((f) => setTimeout(f, 1000)),
+      ])
     );
     const funde = (await new AxeBuilder({ page }).analyze()).violations;
     const ernst = funde.filter((v) => v.impact === "serious" || v.impact === "critical");
@@ -126,9 +134,7 @@ test.describe("Nur-deutsche Seiten: Hinweis statt Wechsel", () => {
 });
 
 test.describe("Spur aus dem Tab", () => {
-  test("wer den Schalter auf der Startseite gesehen hat, sieht ihn auch auf der Rechtsseite", async ({
-    page,
-  }) => {
+  test("wer den Schalter auf der Startseite gesehen hat, sieht ihn auch auf der Rechtsseite", async ({ page }) => {
     await page.route("**/api/stats", (route) =>
       route.fulfill({
         status: 200,
@@ -154,7 +160,23 @@ test.describe("Zahlen-Seite: echter Wechsel", () => {
   test.use({ locale: "de-AT" });
 
   test("stats.html schaltet wirklich um, ohne Rückfrage", async ({ page }) => {
-    await page.goto("/stats.html?sprachumschalter=1");
+    /* v3.3.1: Ohne die frühere Erprobungs-Tür entscheidet allein das
+       Merkmals-Schloss, ob der Umschalter entsteht — stats.js liest es aus
+       /api/stats. Der Testserver liefert die Schnittstelle nicht, also wird
+       sie hier gestellt. */
+    await page.route("**/api/stats", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          current: { count: 10, limit: 500, limitActive: false, retryAfterSeconds: 0 },
+          totals: { today: 10, week: 50, month: 200, total: 1000 },
+          useQueue: true,
+          sprachumschalter: true,
+        }),
+      })
+    );
+    await page.goto("/stats.html");
     await expect(page.locator(".sprach-pille")).toBeVisible();
     await expect(page.locator("h1")).toContainText("Zahlen");
 

--- a/e2e/sprachumschalter.test.js
+++ b/e2e/sprachumschalter.test.js
@@ -199,17 +199,29 @@ test("Positivkontrolle: mit Flag entsteht er sehr wohl", async ({ page }) => {
   await expect(page.locator(".sw-grund")).toHaveCount(2);
 });
 
-test("Adress-Tür blendet ihn auch ohne Flag ein — ohne Konsole, auch am Handy", async ({
+test("die Adress-Tür ist entfernt — das Anhängsel wirkt nicht mehr (v3.3.1)", async ({
   page,
 }) => {
-  /* Der wichtigere der beiden Wege: Auf iPhone und iPad gibt es keine Konsole,
-     und Chrome sperrt am Rechner das Einfügen in die Konsole. */
+  /* Bis v3.3.0 blendete `?sprachumschalter=1` den Schalter auch ohne Flag ein
+     und hinterliess dafuer eine Spur im localStorage. Der Umschalter ist seit
+     v3.3.0 live, die Tuer also ueberfluessig — und ihre Spur widersprach der
+     Datenschutzerklaerung. */
   await seiteVorbereiten(page, { merkmal: false });
-  await page.setViewportSize({ width: 390, height: 844 });
+  const antwort = page.waitForResponse("**/api/stats");
   await page.goto("/?sprachumschalter=1");
-  await expect(page.locator(".sprach-pille")).toBeVisible();
+  await antwort;
+  await settle(page);
+  await expect(page.locator(".sprach-pille")).toHaveCount(0);
+});
 
-  /* Und die Daumen-Größe stimmt auch auf diesem Weg. */
+test("die Daumen-Größe stimmt auch am Handy", async ({ page }) => {
+  /* Positivkontrolle zum Test darueber: ueber das Merkmals-Schloss entsteht er
+     sehr wohl — und ist dort gross genug fuer einen Daumen. */
+  await seiteVorbereiten(page, { merkmal: true });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+  await warteAufSchalter(page);
+
   const f = await trefferflaeche(page, '.sprach-knopf[data-lang="en"]');
   expect(f.breite).toBeGreaterThanOrEqual(44);
   expect(f.hoehe).toBeGreaterThanOrEqual(44);
@@ -224,19 +236,20 @@ test("ein Tippfehler in der Adresse blendet nichts ein", async ({ page }) => {
   await expect(page.locator(".sprach-pille")).toHaveCount(0);
 });
 
-test("Konsolen-Tür blendet ihn auch ohne Flag ein", async ({ page }) => {
-  await seiteVorbereiten(page, { merkmal: false });
-  const antwort = page.waitForResponse("**/api/stats");
+test("die Konsolen-Tür ist entfernt, und der Browser bleibt leer (v3.3.1)", async ({ page }) => {
+  await seiteVorbereiten(page, { merkmal: true });
   await page.goto("/");
-  await antwort;
-  await settle(page);
-  await expect(page.locator(".sprach-pille")).toHaveCount(0);
+  await warteAufSchalter(page);
 
-  await page.evaluate(() => window.malziME.sprachumschalter());
-  await expect(page.locator(".sprach-pille")).toBeVisible();
+  /* Die Tuer gibt es nicht mehr. */
+  const tuer = await page.evaluate(() => typeof (window.malziME && window.malziME.sprachumschalter));
+  expect(tuer).toBe("undefined");
 
-  await page.evaluate(() => window.malziME.sprachumschalter(false));
-  await expect(page.locator(".sprach-pille")).toHaveCount(0);
+  /* Und der eigentliche Punkt: Der Umschalter legt nichts Dauerhaftes ab.
+     Bis v3.3.0 stand hier `malzime-umschalter-aktiv` — bei JEDEM Besucher,
+     waehrend die Datenschutzerklaerung zusagt, keinen localStorage zu nutzen. */
+  const speicher = await page.evaluate(() => Object.keys(localStorage));
+  expect(speicher).toEqual([]);
 });
 
 /* ══ Die drei Zustände ══════════════════════════════════════════════════ */

--- a/e2e/sprachumschalter.test.js
+++ b/e2e/sprachumschalter.test.js
@@ -88,9 +88,7 @@ async function seiteVorbereiten(page, { merkmal = true, jobHaengt = false } = {}
 /** Lässt die Seite zwei Bildschirmrahmen weiterlaufen — danach hat der
     Antwort-Empfänger von /api/stats sicher gearbeitet. */
 async function settle(page) {
-  await page.evaluate(
-    () => new Promise((fertig) => requestAnimationFrame(() => requestAnimationFrame(fertig)))
-  );
+  await page.evaluate(() => new Promise((fertig) => requestAnimationFrame(() => requestAnimationFrame(fertig))));
 }
 
 /** Wartet, bis der Umschalter da ist (er entsteht erst nach /api/stats). */
@@ -109,12 +107,11 @@ async function profilErzeugen(page) {
     an Elementen, die dem Umschalter gar nicht gehoeren). Mit Zeitdeckel,
     damit eine endlose Animation den Lauf nicht anhaelt. */
 async function ruhe(page) {
-  await page.evaluate(
-    () =>
-      Promise.race([
-        Promise.all(document.getAnimations().map((a) => a.finished.catch(() => {}))),
-        new Promise((fertig) => setTimeout(fertig, 1000)),
-      ])
+  await page.evaluate(() =>
+    Promise.race([
+      Promise.all(document.getAnimations().map((a) => a.finished.catch(() => {}))),
+      new Promise((fertig) => setTimeout(fertig, 1000)),
+    ])
   );
   /* WebKit meldet laufende CSS-Übergänge über getAnimations() NICHT — dort
      misst axe sonst mitten im Themenwechsel und findet Schein-Kontraste an
@@ -199,9 +196,7 @@ test("Positivkontrolle: mit Flag entsteht er sehr wohl", async ({ page }) => {
   await expect(page.locator(".sw-grund")).toHaveCount(2);
 });
 
-test("die Adress-Tür ist entfernt — das Anhängsel wirkt nicht mehr (v3.3.1)", async ({
-  page,
-}) => {
+test("die Adress-Tür ist entfernt — das Anhängsel wirkt nicht mehr (v3.3.1)", async ({ page }) => {
   /* Bis v3.3.0 blendete `?sprachumschalter=1` den Schalter auch ohne Flag ein
      und hinterliess dafuer eine Spur im localStorage. Der Umschalter ist seit
      v3.3.0 live, die Tuer also ueberfluessig — und ihre Spur widersprach der
@@ -267,9 +262,7 @@ test("leer: Wechsel ohne Rückfrage, Seite wird englisch", async ({ page }) => {
   await expect(page.locator('[data-demo="selfie"] img')).toHaveAttribute("src", /-en\.jpg/);
 });
 
-test("Profil fertig: Rückfrage in der AKTUELLEN Sprache, Abbrechen ändert nichts", async ({
-  page,
-}) => {
+test("Profil fertig: Rückfrage in der AKTUELLEN Sprache, Abbrechen ändert nichts", async ({ page }) => {
   await seiteVorbereiten(page);
   await page.goto("/");
   await warteAufSchalter(page);
@@ -373,9 +366,7 @@ async function trefferflaeche(page, waehler) {
   }, waehler);
 }
 
-test("Ziel-Größen erreichen 44 px — tastbar, ohne dass der Schalter aufgeblasen wird", async ({
-  page,
-}) => {
+test("Ziel-Größen erreichen 44 px — tastbar, ohne dass der Schalter aufgeblasen wird", async ({ page }) => {
   await seiteVorbereiten(page);
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
@@ -422,18 +413,11 @@ test("Kontrast der gefüllten Flächen reicht in hell UND dunkel", async ({ page
 
   await page.click('.sprach-knopf[data-lang="en"]');
   await expect(page.locator('.sw-grund[data-modal="fertig"]')).toBeVisible();
-  const knopf = await page.evaluate(
-    kontrastImBrowser,
-    '.sw-grund[data-modal="fertig"] .sw-knopf--bleiben'
-  );
-  expect(knopf, `Kontrast Hauptknopf im Beast-Modus: ${knopf.toFixed(2)}`).toBeGreaterThanOrEqual(
-    4.5
-  );
+  const knopf = await page.evaluate(kontrastImBrowser, '.sw-grund[data-modal="fertig"] .sw-knopf--bleiben');
+  expect(knopf, `Kontrast Hauptknopf im Beast-Modus: ${knopf.toFixed(2)}`).toBeGreaterThanOrEqual(4.5);
 });
 
-test("axe über die ganze Matrix: 2 Sprachen × 2 Themen, Rückfrage offen und zu", async ({
-  page,
-}) => {
+test("axe über die ganze Matrix: 2 Sprachen × 2 Themen, Rückfrage offen und zu", async ({ page }) => {
   await seiteVorbereiten(page);
   await page.goto("/");
   await warteAufSchalter(page);
@@ -473,8 +457,32 @@ test.describe("Startsprache folgt dem Gerät", () => {
     /* Und die Rückfrage erscheint dann folgerichtig auf Englisch. */
     await profilErzeugen(page);
     await page.click('.sprach-knopf[data-lang="de"]');
-    await expect(page.locator('.sw-grund[data-modal="fertig"] .sw-knopf--bleiben')).toHaveText(
-      "Cancel"
-    );
+    await expect(page.locator('.sw-grund[data-modal="fertig"] .sw-knopf--bleiben')).toHaveText("Cancel");
   });
+});
+
+test("die Sprache reist in einen neuen Tab mit (v3.3.1)", async ({ page }) => {
+  /* Die Wahl liegt im sessionStorage — bewusst pro Tab. Ein mit
+     target="_blank" geoeffneter Tab bekommt einen LEEREN sessionStorage, und
+     alle sechs Links der Startseite oeffnen einen neuen Tab. Ohne Anhaengsel
+     landete man von der englischen Startseite ueberall wieder auf Deutsch. */
+  await seiteVorbereiten(page, { merkmal: true });
+  await page.goto("/");
+  await warteAufSchalter(page);
+
+  /* Vorher: deutsch, also traegt der Link auch deutsch. */
+  await expect(page.locator('a[href^="/stats"]').first()).toHaveAttribute("href", /lang=de/);
+
+  await page.click('.sprach-knopf[data-lang="en"]');
+  await expect(page.locator("html")).toHaveAttribute("lang", "en");
+
+  /* Nachher: englisch — und zwar an ALLEN Links in einen neuen Tab. */
+  const ziele = await page.$$eval('a[target="_blank"][href^="/"]', (as) => as.map((a) => a.getAttribute("href")));
+  expect(ziele.length).toBeGreaterThan(0);
+  for (const z of ziele) expect(z).toContain("lang=en");
+
+  /* Und die Probe aufs Exempel: Der neue Tab startet wirklich englisch. */
+  const stats = ziele.find((z) => z.startsWith("/stats"));
+  await page.goto(stats.replace("/stats", "/stats.html"));
+  await expect(page.locator("html")).toHaveAttribute("lang", "en");
 });

--- a/functions/src/__tests__/mistral-zeitbudget.test.js
+++ b/functions/src/__tests__/mistral-zeitbudget.test.js
@@ -1,0 +1,70 @@
+/**
+ * mistral-zeitbudget.test.js — Die erlaubte Ausgabelaenge muss in die erlaubte
+ * Zeit passen.
+ *
+ * HINTERGRUND (BUG-2026-08-17-01): Zwei Konstanten standen jahrelang in
+ * verschiedenen Dateien und sahen jede fuer sich plausibel aus — 8000 erlaubte
+ * Ausgabe-Token in `mistral.js`, 90 s Zeitgrenze in `config.js`. Multipliziert
+ * man sie mit dem gemessenen Schreibtempo, war die Kombination nie erfuellbar:
+ * 8000 Token brauchen rund 170 s. Solange der Aufruf ohne Stream lief, fiel das
+ * nicht auf, weil die Uhr schon nach den Antwortkopfzeilen abgeraeumt wurde.
+ * Seit v3.0.0 laeuft der Aufruf gestreamt und die Uhr bleibt scharf — seitdem
+ * starben 2 von 38 Laeufen an einer Grenze, die das Token-Budget ausdruecklich
+ * erlaubt hatte.
+ *
+ * Zwei Audits sind daran vorbeigelaufen, weil niemand die beiden Zahlen
+ * gegeneinander gerechnet hat. Genau das tut dieser Test — er ersetzt die
+ * Bitte um Sorgfalt durch eine Rechnung, die rot wird.
+ *
+ * Reine Rechnung auf Konstanten — kein Netzwerk, keine Cloud.
+ */
+
+const {
+  MISTRAL_SINGLE_LARGE_MAX_TOKENS,
+  MISTRAL_SINGLE_LARGE_TIMEOUT_MS,
+  MISTRAL_SLOWEST_TOKENS_PER_SECOND,
+  MISTRAL_TIMEOUT_MS,
+  REQUEST_BUDGET_MS,
+} = require("../config");
+
+describe("Zeitbudget des Single-Large-Aufrufs", () => {
+  test("die erlaubte Ausgabelaenge passt in die erlaubte Zeit", () => {
+    const benoetigteSekunden = MISTRAL_SINGLE_LARGE_MAX_TOKENS / MISTRAL_SLOWEST_TOKENS_PER_SECOND;
+    const erlaubteSekunden = MISTRAL_SINGLE_LARGE_TIMEOUT_MS / 1000;
+
+    expect(benoetigteSekunden).toBeLessThanOrEqual(erlaubteSekunden);
+  });
+
+  test("es bleibt Reserve — die Grenze liegt nicht auf der Kante", () => {
+    /* 15 % Reserve. Ohne diese Zeile waere ein Wertepaar zulaessig, das exakt
+       aufgeht: Der langsamste je gemessene Lauf ist keine Untergrenze fuer
+       alle kuenftigen Laeufe, sondern nur die langsamste Beobachtung. */
+    const benoetigteMs = (MISTRAL_SINGLE_LARGE_MAX_TOKENS / MISTRAL_SLOWEST_TOKENS_PER_SECOND) * 1000;
+
+    expect(MISTRAL_SINGLE_LARGE_TIMEOUT_MS).toBeGreaterThanOrEqual(benoetigteMs * 1.15);
+  });
+
+  test("der laengste real gemessene Lauf haette ueberlebt", () => {
+    /* 4394 Ausgabe-Token in 83,7 s — der laengste erfolgreiche Lauf im
+       Diagnose-Bucket (11.-16.08.2026). Er lag 6 s vor der alten Klippe.
+       Diese Probe haelt den Realfall fest, nicht nur die Rechnung. */
+    const REAL_LAENGSTER_LAUF_TOKEN = 4394;
+    const brauchtMs = (REAL_LAENGSTER_LAUF_TOKEN / MISTRAL_SLOWEST_TOKENS_PER_SECOND) * 1000;
+
+    expect(REAL_LAENGSTER_LAUF_TOKEN).toBeLessThanOrEqual(MISTRAL_SINGLE_LARGE_MAX_TOKENS);
+    expect(brauchtMs).toBeLessThan(MISTRAL_SINGLE_LARGE_TIMEOUT_MS);
+  });
+
+  test("das eigene Budget ist groesser als die allgemeine Zeitgrenze", () => {
+    /* Waere es kleiner oder gleich, waere die ganze Konstante wirkungslos —
+       und der Fehler zurueck, ohne dass es jemand merkt. */
+    expect(MISTRAL_SINGLE_LARGE_TIMEOUT_MS).toBeGreaterThan(MISTRAL_TIMEOUT_MS);
+  });
+
+  test("das Gesamtbudget des Requests deckt den laengsten Einzelaufruf noch ab", () => {
+    /* Der Single-Large-Call ist nicht der einzige Aufruf im Durchgang (danach
+       kommt beast-ads). Reisst sein Budget das Request-Budget, verschiebt sich
+       der Fehler nur eine Ebene nach oben. */
+    expect(MISTRAL_SINGLE_LARGE_TIMEOUT_MS).toBeLessThan(REQUEST_BUDGET_MS);
+  });
+});

--- a/functions/src/config.js
+++ b/functions/src/config.js
@@ -71,6 +71,50 @@ const MISTRAL_DESCRIBE_MAX_TOKENS = 2048;
 const MISTRAL_PROFILE_MAX_TOKENS = 16000;
 const MISTRAL_TIMEOUT_MS = 90000;
 
+/* ── Eigene Zeitgrenze fuer den Single-Large-Aufruf ──
+   BUG-2026-08-17-01. Der Single-Large-Call schreibt Standard- UND Beast-Profil
+   in EINEM Zug und ist damit der mit Abstand laengste Aufruf der Pipeline. Die
+   allgemeinen 90 s passen zu den kurzen Aufrufen (describe, beast-ads), nicht
+   zu diesem.
+
+   WARUM DAS ERST SEIT v3.0.0 WEH TUT: Vor dem Live-Text lief der Aufruf ohne
+   Stream, und `mistral.js` raeumt die Uhr im Nicht-Stream-Fall schon nach den
+   Antwortkopfzeilen weg — das eigentliche Warten auf den Text lief ungebremst.
+   Die 90 s standen seit v1.6.0 (14.05.) in der Konfiguration, haben aber nie
+   zugebissen. Im Stream-Modus bleibt die Uhr bewusst scharf bis zum letzten
+   Zeichen; damit wurde eine schlafende Grenze zum ersten Mal wirksam.
+
+   WARUM 150 s: Gemessen an 35 erfolgreichen Laeufen (Log-Bucket
+   `client-diagnostics`, 11.-16.08.2026) schreibt das Modell mit 47 Token/s im
+   Median, im langsamsten Lauf mit 39,4 Token/s. MISTRAL_SINGLE_LARGE_MAX_TOKENS
+   (5000) braucht damit im schlechtesten gemessenen Fall 127 s. 150 s deckt das
+   mit Reserve ab. Damit kann die Uhr keinen Lauf mehr toeten, den das
+   Token-Budget ausdruecklich erlaubt — genau der Widerspruch, der 2 von 38
+   Laeufen gekostet hat.
+
+   Die Kopplung der beiden Werte ist keine Bitte um Sorgfalt, sondern geprueft:
+   `__tests__/mistral-zeitbudget.test.js` rechnet sie gegeneinander und wird
+   rot, sobald jemand einen der beiden Werte allein verschiebt. */
+const MISTRAL_SINGLE_LARGE_TIMEOUT_MS = 150000;
+
+/* Langsamstes gemessenes Schreibtempo (Token/s) aus dem 30-Tage-Diagnose-Bucket.
+   Kanonische Quelle fuer die Zeitbudget-Rechnung; steht hier, damit Test und
+   Konfiguration dieselbe Zahl benutzen und nicht auseinanderdriften. */
+const MISTRAL_SLOWEST_TOKENS_PER_SECOND = 39.4;
+
+/* Obergrenze der Ausgabelaenge fuer den Single-Large-Aufruf.
+   v2.1.1 (23.05.) stand hier 8000 — das war rechnerisch nie erreichbar: 8000
+   Token brauchen beim gemessenen Tempo rund 170 s und wurden nach 90 s
+   abgeschnitten. Der laengste je gemessene erfolgreiche Lauf lag bei 4394
+   Token; der Median liegt bei 2750. 5000 laesst dem Modell also reichlich
+   Luft nach oben und passt zugleich in MISTRAL_SINGLE_LARGE_TIMEOUT_MS.
+
+   Diese Konstante lag bis v3.3.1 in `mistral.js`. Sie steht jetzt neben ihrer
+   Zeitgrenze, weil die beiden nur GEMEINSAM richtig sind (Ein-Quellen-Regel):
+   getrennt aufgestellt sah jede fuer sich plausibel aus, und genau daran ist
+   der Fehler zwei Audits lang vorbeigelaufen. */
+const MISTRAL_SINGLE_LARGE_MAX_TOKENS = 5000;
+
 /* ── Globales Stundenlimit ──
    500 Analysen pro rollendem 60-Minuten-Fenster — der gewuenschte Betriebswert
    (kostenstabil beim aktuellen Budget). Mit Auto-Retries auf Client-Seite plus
@@ -230,6 +274,17 @@ if (HOURLY_LIMIT < 1) throw new Error("Config: HOURLY_LIMIT must be >= 1");
 if (RATE_LIMIT < 1) throw new Error("Config: RATE_LIMIT must be >= 1");
 if (MAX_UPLOAD_BYTES < 1) throw new Error("Config: MAX_UPLOAD_BYTES must be >= 1");
 if (MISTRAL_PROFILE_MAX_TOKENS < 1) throw new Error("Config: MISTRAL_PROFILE_MAX_TOKENS must be >= 1");
+/* BUG-2026-08-17-01: Die erlaubte Ausgabelaenge muss in die erlaubte Zeit
+   passen. Sonst toetet die Uhr Laeufe, die das Token-Budget ausdruecklich
+   zulaesst — und der Nutzer wartet zwei Minuten auf einen Fehler. Fail-fast
+   beim Start statt still im Betrieb. */
+if (MISTRAL_SINGLE_LARGE_MAX_TOKENS / MISTRAL_SLOWEST_TOKENS_PER_SECOND > MISTRAL_SINGLE_LARGE_TIMEOUT_MS / 1000) {
+  throw new Error(
+    `Config: MISTRAL_SINGLE_LARGE_MAX_TOKENS (${MISTRAL_SINGLE_LARGE_MAX_TOKENS}) braucht bei ` +
+      `${MISTRAL_SLOWEST_TOKENS_PER_SECOND} Token/s mehr als MISTRAL_SINGLE_LARGE_TIMEOUT_MS ` +
+      `(${MISTRAL_SINGLE_LARGE_TIMEOUT_MS} ms) erlaubt`
+  );
+}
 
 module.exports = {
   FIRESTORE_DATABASE_ID,
@@ -245,6 +300,9 @@ module.exports = {
   MISTRAL_DESCRIBE_MAX_TOKENS,
   MISTRAL_PROFILE_MAX_TOKENS,
   MISTRAL_TIMEOUT_MS,
+  MISTRAL_SINGLE_LARGE_TIMEOUT_MS,
+  MISTRAL_SINGLE_LARGE_MAX_TOKENS,
+  MISTRAL_SLOWEST_TOKENS_PER_SECOND,
   REQUEST_BUDGET_MS,
   HOURLY_LIMIT,
   HOURLY_WINDOW_MINUTES,

--- a/functions/src/mistral.js
+++ b/functions/src/mistral.js
@@ -22,6 +22,8 @@ const {
   MISTRAL_DESCRIBE_MAX_TOKENS,
   MISTRAL_PROFILE_MAX_TOKENS,
   MISTRAL_TIMEOUT_MS,
+  MISTRAL_SINGLE_LARGE_TIMEOUT_MS,
+  MISTRAL_SINGLE_LARGE_MAX_TOKENS,
 } = require("./config");
 const { loadPrompts } = require("./i18n");
 const { parseSafely } = require("./json-repair");
@@ -398,6 +400,7 @@ async function callMistralRawUnthrottled({
   temperature,
   forceJSON,
   timeoutMs,
+  timeoutCapMs,
   cacheKey,
   onLiveText,
 }) {
@@ -452,13 +455,19 @@ async function callMistralRawUnthrottled({
        Restbudget gar nicht mehr stattfinden dürfte, bekam 90 s und konnte das
        Function-Timeout reißen. Jetzt: nur `null`/`undefined` fällt auf den
        Default; ein Budget ≤ 0 bricht sofort ab. */
-    const budget = timeoutMs == null ? MISTRAL_TIMEOUT_MS : timeoutMs;
+    /* BUG-2026-08-17-01: Die Obergrenze ist jetzt pro Aufruf setzbar. Die
+       allgemeinen 90 s passen zu den kurzen Aufrufen (describe, beast-ads);
+       der Single-Large-Call schreibt zwei vollstaendige Profile in EINEM Zug
+       und bekommt deshalb sein eigenes, gemessenes Budget mit. Ohne
+       `timeoutCapMs` bleibt alles exakt wie vorher. */
+    const cap = timeoutCapMs == null ? MISTRAL_TIMEOUT_MS : timeoutCapMs;
+    const budget = timeoutMs == null ? cap : timeoutMs;
     if (budget <= 0) {
       const err = new Error("Mistral-Budget erschoepft");
       err.code = "timeout";
       throw err;
     }
-    const effectiveTimeout = Math.min(budget, MISTRAL_TIMEOUT_MS);
+    const effectiveTimeout = Math.min(budget, cap);
     const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
 
     const httpStart = Date.now();
@@ -1040,7 +1049,9 @@ async function tryProfileCall({ model, messages, temperature, mode, remainingBud
    Kosten-Hinweis: alle Tokens landen im teureren Large 2512 statt im billigen
    Small 2603 — Mehrkosten ~+6% gegenüber heutiger Pipeline (siehe CHANGELOG). */
 
-const MISTRAL_SINGLE_LARGE_MAX_TOKENS = 8000;
+/* MISTRAL_SINGLE_LARGE_MAX_TOKENS steht seit v3.3.1 in `config.js`, direkt
+   neben MISTRAL_SINGLE_LARGE_TIMEOUT_MS: Die beiden Werte sind nur gemeinsam
+   richtig, und getrennt aufgestellt sah jeder fuer sich plausibel aus. */
 
 /* ── Marken-Sperre (v2.7) ─────────────────────────────────────────────────
    Mistral folgt Beispielen, nicht Regeln. Solange konkrete Marken im Prompt
@@ -1428,6 +1439,9 @@ async function callSingleLarge(messages, remainingBudget, attemptLabel, cacheKey
       temperature: 0.5 /* Kompromiss zwischen Standard (0.3) und Beast (0.8) */,
       forceJSON: true,
       timeoutMs: budget,
+      /* BUG-2026-08-17-01: eigenes Zeitbudget statt der allgemeinen 90 s —
+         siehe Herleitung an der Konstante in config.js. */
+      timeoutCapMs: MISTRAL_SINGLE_LARGE_TIMEOUT_MS,
       cacheKey,
       /* v3.0 Phase 1: Nur gesetzt, wenn der Worker das Live-Text-Flag an hat.
          Ohne Callback bleibt der Request bitgenau der heutige (kein stream). */
@@ -1457,12 +1471,28 @@ async function callSingleLarge(messages, remainingBudget, attemptLabel, cacheKey
     );
     return parsed;
   } catch (err) {
-    console.log(
+    /* BUG-2026-08-17-06: console.error statt console.log — das ergibt severity
+       ERROR in Cloud Logging und faellt damit unter die bestehende
+       Alarm-Policy (dieselbe Begruendung wie OPS-004 beim Werbe-Ersatzaufruf).
+
+       Vorher war die Lage absurd herum: Der NEBENSAECHLICHE Ersatzaufruf fuer
+       die Werbeliste schlug Alarm, waehrend die Analyse selbst still starb.
+       Zwei abgebrochene Laeufe (11.08. und 14.08.2026) haben so niemanden
+       erreicht — gefunden wurden sie erst, weil ein Nutzer sich beschwerte.
+       Genau das ist die Frage aus KERN 4: Wer wuerde es merken, wenn das hier
+       falsch waere? Bis hierher: niemand. */
+    console.error(
       JSON.stringify({
+        severity: "ERROR",
+        alert: "single-large-failed",
         step: "mistral-single-large",
         attempt: attemptLabel,
         status: "error",
         error: err.message,
+        /* `timeout` trennt „das Modell war zu langsam" von „die API war weg" —
+           ohne diese Unterscheidung ist am Alarm nicht zu erkennen, ob eine
+           Zeitgrenze zu knapp sitzt oder Mistral eine Stoerung hat. */
+        errorCode: err.code || null,
       })
     );
     if (isRateLimitError(err)) {

--- a/public/__tests__/error-logger-puffer.test.js
+++ b/public/__tests__/error-logger-puffer.test.js
@@ -1,0 +1,166 @@
+/**
+ * error-logger-puffer.test.js — Fehlermeldungen gehen nicht mehr verloren
+ * (v3.3.1, BUG-2026-08-17-04).
+ *
+ * Die Zusage lautet: alle Fehler abfangen, speichern und melden. Sie war an
+ * einer Stelle gebrochen, die harmlos aussah — eine misslungene Meldung wurde
+ * still verschluckt. Das traf ausgerechnet die haeufigste Fehlerklasse: Eine
+ * Meldung ueber eine abgerissene Verbindung braucht dieselbe Verbindung.
+ *
+ * Belegt an echten Daten: 2 Client-Fehler in 30 Tagen, obwohl im selben
+ * Zeitraum mehrere Fehler gemeldet wurden.
+ *
+ * ZWEITE ZUSAGE, die hier mitgeprueft wird: Die Warteschlange liegt
+ * ausschliesslich im Arbeitsspeicher. Die Datenschutzerklaerung zaehlt
+ * abschliessend auf, was im Browser abgelegt wird — diese Funktion legt dort
+ * NICHTS ab. Der letzte Test unten wird rot, wenn das jemand aendert.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../js/client-context.js", () => ({
+  collectClientContext: () => ({ screen: "small" }),
+  coarseUserAgent: () => "Safari 26 / iOS",
+  generateTraceId: () => "trace-test",
+}));
+
+describe("Fehler-Nachsendung", () => {
+  let logClientError, fehlerNachschicken, initFehlerNachsendung, offeneMeldungen;
+
+  beforeEach(async () => {
+    sessionStorage.clear();
+    localStorage.clear();
+    vi.resetModules();
+    ({ logClientError, fehlerNachschicken, initFehlerNachsendung, offeneMeldungen } =
+      await import("../js/error-logger.js"));
+    Object.defineProperty(navigator, "onLine", { value: true, configurable: true, writable: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  it("stellt eine Meldung zurueck, wenn das Senden scheitert", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Load failed"));
+
+    logClientError(new Error("queue_failed"), { phase: "queue-poll" });
+    await vi.waitFor(() => expect(offeneMeldungen()).toHaveLength(1));
+
+    expect(offeneMeldungen()[0].errorMessage).toBe("queue_failed");
+    expect(offeneMeldungen()[0].phase).toBe("queue-poll");
+  });
+
+  it("sendet gar nicht erst, wenn das Geraet offline ist — direkt in die Warteschlange", () => {
+    Object.defineProperty(navigator, "onLine", { value: false, configurable: true, writable: true });
+    const f = vi.spyOn(globalThis, "fetch");
+
+    logClientError(new Error("offline_fall"), { phase: "queue-network" });
+
+    expect(f).not.toHaveBeenCalled();
+    expect(offeneMeldungen()).toHaveLength(1);
+  });
+
+  it("schickt Zurueckgestelltes beim naechsten Anlauf nach", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Load failed"));
+    logClientError(new Error("erster"), { phase: "queue-poll" });
+    logClientError(new Error("zweiter"), { phase: "queue-network" });
+    await vi.waitFor(() => expect(offeneMeldungen()).toHaveLength(2));
+
+    const f = vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true, status: 204 });
+    /* Derselbe Spion wie oben — sonst zaehlten die zwei gescheiterten
+       Erstversuche mit und der Test misste etwas anderes, als er behauptet. */
+    f.mockClear();
+    const zugestellt = await fehlerNachschicken();
+
+    expect(zugestellt).toBe(2);
+    expect(f).toHaveBeenCalledTimes(2);
+    expect(offeneMeldungen()).toHaveLength(0);
+  });
+
+  it("das Ereignis 'wieder online' loest die Nachsendung aus", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Load failed"));
+    logClientError(new Error("haengt"), { phase: "queue-network" });
+    await vi.waitFor(() => expect(offeneMeldungen()).toHaveLength(1));
+
+    initFehlerNachsendung();
+    const f = vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true, status: 204 });
+
+    window.dispatchEvent(new Event("online"));
+    await vi.waitFor(() => expect(offeneMeldungen()).toHaveLength(0));
+
+    expect(f).toHaveBeenCalled();
+  });
+
+  it("beim Verlassen der Seite wird ein letzter Versuch unternommen", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Load failed"));
+    logClientError(new Error("letzter_versuch"), { phase: "queue-network" });
+    await vi.waitFor(() => expect(offeneMeldungen()).toHaveLength(1));
+
+    initFehlerNachsendung();
+    const f = vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true, status: 204 });
+
+    window.dispatchEvent(new Event("pagehide"));
+    await vi.waitFor(() => expect(offeneMeldungen()).toHaveLength(0));
+
+    expect(f).toHaveBeenCalled();
+  });
+
+  it("ein misslungener Nachsendeversuch verliert die Meldung nicht", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Load failed"));
+    logClientError(new Error("bleibt"), { phase: "queue-network" });
+    await vi.waitFor(() => expect(offeneMeldungen()).toHaveLength(1));
+
+    /* Zweiter Anlauf, wieder kein Netz — die Warteschlange darf jetzt nicht
+       leer sein. Genau hier lag die Falle: Wer sie vor dem Senden leert und
+       den Fehlschlag nicht zuruecklegt, verliert die Meldung beim
+       Rettungsversuch. */
+    const zugestellt = await fehlerNachschicken();
+
+    expect(zugestellt).toBe(0);
+    expect(offeneMeldungen()).toHaveLength(1);
+    expect(offeneMeldungen()[0].errorMessage).toBe("bleibt");
+  });
+
+  it("ein 4xx wird NICHT erneut versucht — der Server will diese Meldung nicht", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: false, status: 400 });
+
+    logClientError(new Error("unbrauchbar"), { phase: "queue-poll" });
+    await vi.waitFor(() => expect(offeneMeldungen()).toHaveLength(0));
+  });
+
+  it("ein 5xx wird aufgehoben — das ist voruebergehend", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: false, status: 503 });
+
+    logClientError(new Error("serverproblem"), { phase: "queue-poll" });
+    await vi.waitFor(() => expect(offeneMeldungen()).toHaveLength(1));
+  });
+
+  it("die Warteschlange waechst nicht endlos", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Load failed"));
+
+    for (let i = 0; i < 25; i++) logClientError(new Error(`fehler-${i}`), { phase: "queue-network" });
+    await vi.waitFor(() => expect(offeneMeldungen().length).toBeGreaterThan(0));
+
+    const liste = offeneMeldungen();
+    expect(liste.length).toBeLessThanOrEqual(10);
+    /* Die juengsten ueberleben — sie passen zum aktuellen Zustand. */
+    expect(liste[liste.length - 1].errorMessage).toBe("fehler-24");
+  });
+
+  it("DATENSCHUTZ: die Fehlererfassung legt NICHTS im Browser ab", async () => {
+    /* Die Datenschutzerklaerung zaehlt abschliessend auf, was in sessionStorage
+       und localStorage liegt. Diese Funktion darf diese Liste nicht erweitern —
+       der Rechtstext ist die Vorgabe, nicht der Code. Ein erster Entwurf legte
+       misslungene Meldungen in den sessionStorage; dieser Test haelt fest, dass
+       das nicht zurueckkommt. */
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Load failed"));
+
+    logClientError(new Error("darf_nirgends_landen"), { phase: "queue-network" });
+    await vi.waitFor(() => expect(offeneMeldungen()).toHaveLength(1));
+
+    expect(sessionStorage.length).toBe(0);
+    expect(localStorage.length).toBe(0);
+  });
+});

--- a/public/__tests__/error-logger-puffer.test.js
+++ b/public/__tests__/error-logger-puffer.test.js
@@ -152,9 +152,9 @@ describe("Fehler-Nachsendung", () => {
   it("DATENSCHUTZ: die Fehlererfassung legt NICHTS im Browser ab", async () => {
     /* Die Datenschutzerklaerung zaehlt abschliessend auf, was in sessionStorage
        und localStorage liegt. Diese Funktion darf diese Liste nicht erweitern —
-       der Rechtstext ist die Vorgabe, nicht der Code. Ein erster Entwurf legte
-       misslungene Meldungen in den sessionStorage; dieser Test haelt fest, dass
-       das nicht zurueckkommt. */
+       der Rechtstext ist die Vorgabe, nicht der Code. Der naheliegende
+       „Verbesserungsvorschlag", die Warteschlange haltbar zu machen, scheitert
+       genau hier. */
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Load failed"));
 
     logClientError(new Error("darf_nirgends_landen"), { phase: "queue-network" });

--- a/public/__tests__/i18n-linksprache.test.js
+++ b/public/__tests__/i18n-linksprache.test.js
@@ -1,0 +1,139 @@
+/**
+ * i18n-linksprache.test.js — Die Sprache reist in einen neuen Tab mit
+ * (v3.3.1).
+ *
+ * ANLASS: Die Sprachwahl liegt bewusst im `sessionStorage`, also pro Tab —
+ * damit ein weitergereichtes Workshop-Gerät wieder in der Gerätesprache
+ * startet. Ein mit `target="_blank"` geöffneter Tab bekommt aber einen LEEREN
+ * sessionStorage. Von der englischen Startseite führte deshalb JEDER Weg nach
+ * draußen zurück in die Gerätesprache: Alle sechs Links der Startseite öffnen
+ * einen neuen Tab.
+ *
+ * Die Lösung braucht weder Speicher noch Schnittstelle — die Sprache steht in
+ * der Adresse, und `i18n.js` liest sie beim Start als Erstes (`?lang=` schlägt
+ * alles andere).
+ *
+ * Gemessen am Bestand: 6 interne Links mit `target="_blank"` (alle auf der
+ * Startseite), 28 im selben Tab (auf den Unterseiten).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const MANIFEST = { languages: ["de", "en"], default: "de" };
+const TEXTE = {
+  de: {
+    "footer.stats": "Zahlen",
+    "upload.privacyHint": 'Details in der <a href="/datenschutz" target="_blank">Erklärung</a>.',
+  },
+  en: {
+    "footer.stats": "Numbers",
+    "upload.privacyHint": 'Details in the <a href="/datenschutz" target="_blank">policy</a>.',
+  },
+};
+
+function mockeSprachdateien() {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+    const pfad = String(url);
+    /* `ok: true` ist Pflicht, nicht Deko: setLanguage bricht bei !res.ok ab
+       und meldet false. Ohne dieses Feld schlug der Wechsel still fehl und der
+       Test prüfte die alte Sprache gegen die alte Sprache. */
+    if (pfad.includes("manifest.json")) return { ok: true, json: async () => MANIFEST };
+    const code = pfad.includes("/en.json") ? "en" : "de";
+    return { ok: true, json: async () => TEXTE[code] };
+  });
+}
+
+function baueSeite() {
+  document.body.innerHTML = `
+    <a id="stats" href="/stats" target="_blank" rel="noopener" data-i18n="footer.stats">Zahlen</a>
+    <a id="impressum" href="/impressum" target="_blank" rel="noopener">Impressum</a>
+    <a id="gleicherTab" href="/datenschutz">Datenschutz</a>
+    <a id="extern" href="https://malziland.at" target="_blank" rel="noopener">malziland</a>
+    <p id="hinweis" data-i18n-html="upload.privacyHint"></p>
+  `;
+}
+
+function href(id) {
+  return document.getElementById(id).getAttribute("href");
+}
+
+describe("Sprache als Übergabewert in der Adresse", () => {
+  let i18n;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockeSprachdateien();
+    sessionStorage.clear();
+    window.history.replaceState({}, "", "/");
+    /* jsdom meldet als Gerätesprache „en-US". Ohne diese Zeile startete jeder
+       Test englisch, und die deutschen Erwartungen unten prüften nichts —
+       schlimmer noch, sie wären grün gewesen, wenn das Stempeln gar nicht
+       liefe und die Adresse zufällig schon gestimmt hätte. */
+    Object.defineProperty(navigator, "language", { value: "de-DE", configurable: true });
+    baueSeite();
+    i18n = await import("../js/i18n.js");
+  });
+
+  it("Links in einen neuen Tab tragen die Sprache — auch auf Deutsch", async () => {
+    await i18n.initI18n();
+    i18n.applyTranslations();
+
+    /* Bewusst BEIDE Sprachen stempeln: Steht das Gerät auf Englisch und jemand
+       hat die Seite auf Deutsch gestellt, wäre ein fehlender Wert genauso
+       falsch herum wie umgekehrt. */
+    expect(href("stats")).toBe("/stats?lang=de");
+    expect(href("impressum")).toBe("/impressum?lang=de");
+  });
+
+  it("nach dem Wechsel auf Englisch tragen sie en", async () => {
+    await i18n.initI18n();
+    i18n.applyTranslations();
+    await i18n.setLanguage("en");
+
+    expect(href("stats")).toBe("/stats?lang=en");
+    expect(href("impressum")).toBe("/impressum?lang=en");
+  });
+
+  it("Links im SELBEN Tab bleiben unangetastet", () => {
+    /* Dort trägt der sessionStorage die Wahl bereits — ein Anhängsel wäre
+       Ballast in der Adressleiste ohne jeden Nutzen. */
+    i18n.applyTranslations();
+    expect(href("gleicherTab")).toBe("/datenschutz");
+  });
+
+  it("externe Links werden nicht angefasst", () => {
+    i18n.applyTranslations();
+    expect(href("extern")).toBe("https://malziland.at");
+  });
+
+  it("auch ein Link INNERHALB eines übersetzten Textblocks wird gestempelt", async () => {
+    /* Der eigentliche Stolperstein: `data-i18n-html` ersetzt ganze
+       innerHTML-Bereiche und wirft dabei zuvor gesetzte Adressen weg. Deshalb
+       stempelt applyTranslations() als LETZTES. Ohne diese Reihenfolge wäre
+       genau dieser Link stumm falsch. */
+    await i18n.initI18n();
+    await i18n.setLanguage("en");
+
+    const drin = document.querySelector("#hinweis a");
+    expect(drin).not.toBeNull();
+    expect(drin.getAttribute("href")).toBe("/datenschutz?lang=en");
+  });
+
+  it("mehrfaches Anwenden hängt nichts an", async () => {
+    await i18n.initI18n();
+    i18n.applyTranslations();
+    i18n.applyTranslations();
+    i18n.applyTranslations();
+
+    expect(href("stats")).toBe("/stats?lang=de");
+  });
+
+  it("ein vorhandenes anderes Anhängsel bleibt erhalten", () => {
+    document.getElementById("stats").setAttribute("href", "/stats?von=fussleiste");
+    i18n.applyTranslations();
+
+    const ziel = new URL(href("stats"), "https://malzi.me");
+    expect(ziel.searchParams.get("von")).toBe("fussleiste");
+    expect(ziel.searchParams.get("lang")).toBe("de");
+  });
+});

--- a/public/__tests__/live-anzeige-pause.test.js
+++ b/public/__tests__/live-anzeige-pause.test.js
@@ -1,0 +1,146 @@
+/**
+ * live-anzeige-pause.test.js — Die Zusicherung beim Verbindungsabbruch (v3.3.1).
+ *
+ * Der Nutzer hat sie woertlich verlangt, in zwei Teilen:
+ *   1. Der bereits geschriebene Text BLEIBT — und er wird nicht veraendert,
+ *      wenn es weitergeht.
+ *   2. Es geht auch wirklich weiter — nicht nur „wird fortgesetzt" und dann
+ *      passiert nichts.
+ *
+ * Beides steht hier als Pruefung, nicht als Vorsatz. Vorher raeumte
+ * `abbrechen()` bei jedem Fehler Karte und Text weg; das sah nach Datenverlust
+ * aus, obwohl serverseitig nichts verloren war.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setupDOM } from "./setup.js";
+
+vi.mock("../js/i18n.js", () => ({
+  t: (key) => (key === "live.warten" ? ["live.warten.0", "live.warten.1", "live.warten.2"] : key),
+  getLanguage: () => "de",
+  initI18n: () => Promise.resolve(),
+  applyTranslations: () => {},
+}));
+
+vi.mock("../js/klang.js", () => ({
+  klangAktivieren: vi.fn(),
+  tippTon: vi.fn(),
+  popTon: vi.fn(),
+}));
+
+describe("Live-Anzeige: Pause und Fortsetzung beim Verbindungsabbruch", () => {
+  let liveAnzeige, elements;
+  let echteMatchMedia;
+
+  beforeEach(async () => {
+    setupDOM();
+    vi.useFakeTimers();
+    liveAnzeige = await import("../js/live-anzeige.js");
+    ({ elements } = await import("../js/dom.js"));
+    liveAnzeige.zuruecksetzen();
+    elements.liveKarte.className = "";
+    elements.liveTextFest.textContent = "";
+    elements.liveTextRausch.textContent = "";
+    elements.biasSwitch.checked = false;
+
+    /* Volle Bewegung — sonst greift der Sofort-Pfad fuer reduzierte Bewegung
+       und es wird nie Zeichen fuer Zeichen getippt. */
+    echteMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn(() => ({ matches: false, addEventListener() {}, removeEventListener() {} }));
+  });
+
+  afterEach(() => {
+    liveAnzeige.zuruecksetzen();
+    window.matchMedia = echteMatchMedia;
+    vi.useRealTimers();
+  });
+
+  /** Tippt so lange, bis mindestens `mindestens` Zeichen sichtbar sind. */
+  async function tippenBis(mindestens) {
+    for (let i = 0; i < 400 && elements.liveTextFest.textContent.length < mindestens; i++) {
+      await vi.advanceTimersByTimeAsync(80);
+    }
+    return elements.liveTextFest.textContent;
+  }
+
+  it("pausieren() laesst Karte UND bereits getippten Text stehen", async () => {
+    liveAnzeige.welle({ standard: "Du bist 34 Jahre alt und arbeitest vermutlich im Handel.", beast: null });
+    const sichtbarVorher = await tippenBis(8);
+    expect(sichtbarVorher.length).toBeGreaterThanOrEqual(8);
+    expect(elements.liveKarte.classList.contains("active")).toBe(true);
+
+    expect(liveAnzeige.pausieren()).toBe(true);
+    await vi.advanceTimersByTimeAsync(3000);
+
+    /* Der Kern der Zusage: Nichts ist verschwunden, nichts hat sich geaendert. */
+    expect(elements.liveKarte.classList.contains("active")).toBe(true);
+    expect(elements.liveTextFest.textContent).toBe(sichtbarVorher);
+    expect(liveAnzeige.istPausiert()).toBe(true);
+    /* Gedaempft, damit der Stillstand sichtbar begruendet ist. */
+    expect(elements.liveKarte.classList.contains("live-karte--pausiert")).toBe(true);
+    /* Kein Rausch-Schweif: Er waere Bewegung ohne Fortschritt. */
+    expect(elements.liveTextRausch.textContent).toBe("");
+  });
+
+  it("fortsetzen() tippt an derselben Stelle weiter — das Gelesene bleibt der Anfang", async () => {
+    liveAnzeige.welle({ standard: "Du bist 34 Jahre alt und arbeitest vermutlich im Handel.", beast: null });
+    await tippenBis(8);
+    liveAnzeige.pausieren();
+    const beimAbbruchGelesen = elements.liveTextFest.textContent;
+
+    expect(liveAnzeige.fortsetzen()).toBe(true);
+    expect(liveAnzeige.istPausiert()).toBe(false);
+    expect(elements.liveKarte.classList.contains("live-karte--pausiert")).toBe(false);
+
+    const nachher = await tippenBis(beimAbbruchGelesen.length + 6);
+
+    /* Zwei Zusicherungen in zwei Zeilen: es ging weiter UND das Gelesene ist
+       unveraendert der Anfang des Neuen. */
+    expect(nachher.length).toBeGreaterThan(beimAbbruchGelesen.length);
+    expect(nachher.startsWith(beimAbbruchGelesen)).toBe(true);
+  });
+
+  it("eine Welle darf bereits Gelesenes niemals umschreiben", async () => {
+    liveAnzeige.welle({ standard: "Du bist 34 Jahre alt", beast: null });
+    const gelesen = await tippenBis(10);
+
+    /* Ein abweichender Stand — so etwas darf die Anzeige nie uebernehmen,
+       sonst aendert sich Text vor den Augen des Nutzers. */
+    liveAnzeige.welle({ standard: "VOELLIG ANDERER TEXT, der auch laenger ist als der bisherige.", beast: null });
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(elements.liveTextFest.textContent.startsWith(gelesen)).toBe(true);
+    expect(elements.liveTextFest.textContent).not.toContain("VOELLIG ANDERER TEXT");
+  });
+
+  it("eine kuerzere (verspaetete) Welle setzt den Text nicht zurueck", async () => {
+    liveAnzeige.welle({ standard: "Du bist 34 Jahre alt und arbeitest im Handel.", beast: null });
+    const gelesen = await tippenBis(12);
+
+    liveAnzeige.welle({ standard: "Du bist 34", beast: null });
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(elements.liveTextFest.textContent.length).toBeGreaterThanOrEqual(gelesen.length);
+    expect(elements.liveTextFest.textContent.startsWith(gelesen)).toBe(true);
+  });
+
+  it("pausieren() ohne laufenden Live-Text ist ein No-Op und meldet das ehrlich", () => {
+    expect(liveAnzeige.pausieren()).toBe(false);
+    expect(liveAnzeige.istPausiert()).toBe(false);
+    /* Wichtig fuer api.js: Nur an dieser Rueckmeldung erkennt der Aufrufer,
+       ob er stattdessen die Scan-Animation zeigen muss. */
+    expect(liveAnzeige.fortsetzen()).toBe(false);
+  });
+
+  it("abbrechen() raeumt auch aus der Pause heraus restlos auf", async () => {
+    liveAnzeige.welle({ standard: "Du bist 34 Jahre alt und arbeitest im Handel.", beast: null });
+    await tippenBis(8);
+    liveAnzeige.pausieren();
+
+    liveAnzeige.abbrechen();
+
+    expect(liveAnzeige.istPausiert()).toBe(false);
+    expect(elements.liveKarte.classList.contains("live-karte--pausiert")).toBe(false);
+    expect(elements.liveKarte.classList.contains("active")).toBe(false);
+  });
+});

--- a/public/__tests__/queue-livetext.test.js
+++ b/public/__tests__/queue-livetext.test.js
@@ -38,6 +38,10 @@ vi.mock("../js/live-anzeige.js", () => ({
   enthuellungAbkuerzen: vi.fn(),
   abbrechen: vi.fn(),
   zuruecksetzen: vi.fn(),
+  /* v3.3.1: Pause statt Wegräumen beim Verbindungsabbruch. */
+  pausieren: vi.fn(() => true),
+  fortsetzen: vi.fn(() => true),
+  istPausiert: vi.fn(() => false),
   /* v3.0.3 Blick-Führung: api.js ruft beides beim Analyse-Beginn. */
   fuehrungStarten: vi.fn(),
   augeInsBild: vi.fn(),

--- a/public/__tests__/queue-verbindungsabbruch.test.js
+++ b/public/__tests__/queue-verbindungsabbruch.test.js
@@ -1,0 +1,225 @@
+/**
+ * queue-verbindungsabbruch.test.js — Was passiert, wenn mitten im Schreiben
+ * die Verbindung abreisst (v3.3.1).
+ *
+ * HINTERGRUND: Ein Nutzer meldete, der Text sei waehrend des Schreibens
+ * verschwunden und danach habe ein Netzwerkfehler dagestanden. Beides war so
+ * gebaut. Zusaetzlich sagte die Meldung zu, die Analyse erscheine automatisch,
+ * sobald man wieder online sei — dafuer gab es keinen Mechanismus: Es lauschte
+ * niemand auf „online", und die Wiederaufnahme warf die Job-Nummer weg.
+ *
+ * Dieser Test haelt die drei Zusagen fest:
+ *   1. Bei Verbindungsabbruch wird pausiert, nicht abgeraeumt.
+ *   2. Die Job-Nummer ueberlebt — sie ist der einzige Weg zum fertigen Profil.
+ *   3. „Wieder online" loest die Wiederaufnahme tatsaechlich aus.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setupDOM } from "./setup.js";
+
+vi.mock("../js/i18n.js", () => ({
+  t: (key) => key,
+  getLanguage: () => "de",
+  initI18n: () => Promise.resolve(),
+  applyTranslations: () => {},
+}));
+
+vi.mock("../js/exif.js", () => ({
+  prepareImage: vi.fn().mockResolvedValue({
+    imageBase64: "QUFB",
+    exif: { make: "Apple", model: "iPhone" },
+    gps: null,
+    dateTimeOriginal: null,
+  }),
+}));
+
+vi.mock("../js/geocoding.js", () => ({
+  startGeocoding: vi.fn(),
+}));
+
+vi.mock("../js/render.js", () => ({
+  renderCurrentMode: vi.fn(),
+}));
+
+vi.mock("../js/live-anzeige.js", () => ({
+  welle: vi.fn(),
+  modusWechsel: vi.fn(),
+  hatLiveGelaufen: vi.fn(() => false),
+  schnellVorlauf: vi.fn(() => Promise.resolve()),
+  starteEnthuellung: vi.fn(),
+  enthuellungAbkuerzen: vi.fn(),
+  abbrechen: vi.fn(),
+  zuruecksetzen: vi.fn(),
+  pausieren: vi.fn(() => true),
+  fortsetzen: vi.fn(() => true),
+  istPausiert: vi.fn(() => false),
+  fuehrungStarten: vi.fn(),
+  augeInsBild: vi.fn(),
+}));
+
+const DONE_RESULT = {
+  profiles: { normal: { categories: { a: {} }, ad_targeting: [], manipulation_triggers: [], profileText: "T" } },
+  privacyRisks: [],
+  exif: {},
+  meta: { mode: "multimodal", subject: "HUMAN" },
+};
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    clone() {
+      return this;
+    },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  };
+}
+
+const JOB_ID_KEY = "malzime.queueJobId";
+
+describe("Verbindungsabbruch mitten im Live-Text", () => {
+  let apiMod, state, liveAnzeige;
+
+  beforeEach(async () => {
+    setupDOM();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(Date.now() + 10000);
+    sessionStorage.clear();
+
+    apiMod = await import("../js/api.js");
+    ({ state } = await import("../js/state.js"));
+    liveAnzeige = await import("../js/live-anzeige.js");
+
+    state.isAnalyzing = false;
+    state.requestId = 0;
+    state.uploadLaeuft = false;
+    state.wartetAufVerbindung = false;
+    state.lastPrepared = null;
+    state.lastData = null;
+    state.lastFile = new File(["test"], "test.jpg", { type: "image/jpeg" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  /** enqueue klappt, danach faellt jede Statusabfrage aus (Netz weg). */
+  function mockeAbbruchNachErstemPoll() {
+    let poll = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (String(url).includes("/api/enqueue")) return jsonResponse({ jobId: "job-abbruch", resultToken: "tok-1" });
+      if (!String(url).includes("job-status")) return jsonResponse({ ok: true });
+      poll += 1;
+      if (poll === 1) return jsonResponse({ status: "processing", liveText: "Du bist 34 Jahre alt" });
+      throw new TypeError("Load failed");
+    });
+  }
+
+  it("pausiert den Live-Text, statt ihn wegzuraeumen", async () => {
+    mockeAbbruchNachErstemPoll();
+
+    const p = apiMod.analyzeImage();
+    await vi.advanceTimersByTimeAsync(60000);
+    await p;
+
+    expect(liveAnzeige.pausieren).toHaveBeenCalled();
+    expect(liveAnzeige.abbrechen).not.toHaveBeenCalled();
+  });
+
+  it("behaelt die Job-Nummer — sonst ist das fertige Profil unerreichbar", async () => {
+    mockeAbbruchNachErstemPoll();
+
+    const p = apiMod.analyzeImage();
+    await vi.advanceTimersByTimeAsync(60000);
+    await p;
+
+    expect(sessionStorage.getItem(JOB_ID_KEY)).toBe("job-abbruch");
+  });
+
+  it("merkt sich, dass ein Durchgang auf die Verbindung wartet", async () => {
+    mockeAbbruchNachErstemPoll();
+
+    const p = apiMod.analyzeImage();
+    await vi.advanceTimersByTimeAsync(60000);
+    await p;
+
+    /* isAnalyzing ist bewusst wieder false (der Nutzer darf ein neues Foto
+       waehlen) — der Anker fuer die Wiederaufnahme haengt deshalb hier. */
+    expect(state.isAnalyzing).toBe(false);
+    expect(state.wartetAufVerbindung).toBe(true);
+  });
+
+  it("das Ereignis 'wieder online' loest die Wiederaufnahme aus und liefert das Ergebnis nach", async () => {
+    mockeAbbruchNachErstemPoll();
+    apiMod.initHintergrundWiederaufnahme();
+
+    const p = apiMod.analyzeImage();
+    await vi.advanceTimersByTimeAsync(60000);
+    await p;
+    expect(state.wartetAufVerbindung).toBe(true);
+
+    /* Netz ist zurueck: Ab jetzt antwortet die Statusabfrage wieder. */
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (String(url).includes("job-status")) return jsonResponse({ status: "done", result: DONE_RESULT });
+      return jsonResponse({ ok: true });
+    });
+
+    window.dispatchEvent(new Event("online"));
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const renderMod = await import("../js/render.js");
+    expect(renderMod.renderCurrentMode).toHaveBeenCalled();
+  });
+
+  it("setzt den Live-Text fort, wenn er nur pausiert war (kein Zuruecksetzen)", async () => {
+    sessionStorage.setItem(JOB_ID_KEY, "job-abbruch");
+    liveAnzeige.istPausiert.mockReturnValue(true);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (String(url).includes("job-status")) return jsonResponse({ status: "done", result: DONE_RESULT });
+      return jsonResponse({ ok: true });
+    });
+
+    await apiMod.resumeQueueJob({ force: true });
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(liveAnzeige.fortsetzen).toHaveBeenCalled();
+    /* Genau das war der Fehler bis v3.3.0: Die Wiederaufnahme setzte den Lauf
+       zurueck und liess den Text damit fallen. */
+    expect(liveAnzeige.zuruecksetzen).not.toHaveBeenCalled();
+  });
+
+  it("nach einem Neuladen (kein pausierter Lauf) bleibt es beim bisherigen Verhalten", async () => {
+    sessionStorage.setItem(JOB_ID_KEY, "job-abbruch");
+    liveAnzeige.istPausiert.mockReturnValue(false);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (String(url).includes("job-status")) return jsonResponse({ status: "done", result: DONE_RESULT });
+      return jsonResponse({ ok: true });
+    });
+
+    await apiMod.resumeQueueJob({ force: true });
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(liveAnzeige.zuruecksetzen).toHaveBeenCalled();
+    expect(liveAnzeige.fortsetzen).not.toHaveBeenCalled();
+  });
+
+  it("ein zweiter Abbruch waehrend der Wiederaufnahme wirft die Job-Nummer NICHT weg", async () => {
+    sessionStorage.setItem(JOB_ID_KEY, "job-abbruch");
+    liveAnzeige.istPausiert.mockReturnValue(true);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (String(url).includes("job-status")) throw new TypeError("Load failed");
+      return jsonResponse({ ok: true });
+    });
+
+    const p = apiMod.resumeQueueJob({ force: true });
+    await vi.advanceTimersByTimeAsync(60000);
+    await p;
+
+    expect(sessionStorage.getItem(JOB_ID_KEY)).toBe("job-abbruch");
+    expect(state.wartetAufVerbindung).toBe(true);
+  });
+});

--- a/public/__tests__/sprachumschalter.test.js
+++ b/public/__tests__/sprachumschalter.test.js
@@ -94,12 +94,11 @@ describe("Sprachumschalter — Merkmals-Schloss", () => {
     });
   });
 
-  it("die Konsolen-Tür steht auch ohne Merkmal offen und baut auf Zuruf", () => {
-    expect(typeof window.malziME.sprachumschalter).toBe("function");
-    window.malziME.sprachumschalter();
-    expect(pille()).not.toBeNull();
-    window.malziME.sprachumschalter(false);
-    expect(pille()).toBeNull();
+  it("es gibt keine Konsolen-Tür mehr (v3.3.1)", () => {
+    /* Sie war fuer die Zeit vor der Freischaltung gedacht. Seit der Umschalter
+       live ist, fuehrt sie an einem offenen Zimmer vorbei — und ihre Spur lag
+       im localStorage, was der Datenschutzerklaerung widersprach. */
+    expect(window.malziME && window.malziME.sprachumschalter).toBeUndefined();
   });
 
   it("Aushängen lässt nichts zurück", () => {
@@ -328,9 +327,9 @@ describe("Sprachumschalter — Barrierefreiheit", () => {
   });
 });
 
-describe("Sprachumschalter — Tür über die Adresse", () => {
+describe("Sprachumschalter — die Erprobungs-Tür ist entfernt (v3.3.1)", () => {
   /* jsdom laesst window.location nicht ohne Weiteres umschreiben; die Adresse
-     wird deshalb ueber history.replaceState gesetzt — genau das liest
+     wird deshalb ueber history.replaceState gesetzt — genau das las frueher
      URLSearchParams. */
   function adresse(suche) {
     window.history.replaceState({}, "", suche || "/");
@@ -338,81 +337,42 @@ describe("Sprachumschalter — Tür über die Adresse", () => {
 
   afterEach(() => {
     adresse("/");
-    try {
-      localStorage.removeItem("malzime-tuer-sprachumschalter");
-    } catch {
-      /* jsdom ohne Speicher */
-    }
-  });
-
-  it("?sprachumschalter=1 blendet ihn ein, ohne Merkmal und ohne Konsole", () => {
-    adresse("/?sprachumschalter=1");
-    initSprachumschalter({ analysiere: () => {} });
-    expect(pille()).not.toBeNull();
-  });
-
-  it("die Tür bleibt offen — auch ohne Anhängsel und in einem neuen Tab", () => {
-    /* Der eigentliche Grund für den geräteweiten Speicher: Die Rechtsseiten
-       öffnen mit target="_blank" rel="noopener" (index.html:348), und ein so
-       geöffneter Tab bekommt einen LEEREN sessionStorage. Die erste Fassung
-       legte die Spur dort ab — sie kam nie an. */
-    adresse("/?sprachumschalter=1");
-    initSprachumschalter({ analysiere: () => {} });
-    expect(pille()).not.toBeNull();
-
-    zeigeSprachumschalter(false);
-    baueSeite();
-    adresse("/");
-    initSprachumschalter({ analysiere: () => {} });
-    expect(pille()).toBeNull(); // aushängen schliesst die Tür ausdrücklich
-  });
-
-  it("?sprachumschalter=0 schliesst die Tür wieder", () => {
-    adresse("/?sprachumschalter=1");
-    initSprachumschalter({ analysiere: () => {} });
-    expect(pille()).not.toBeNull();
-
-    baueSeite();
-    adresse("/?sprachumschalter=0");
-    initSprachumschalter({ analysiere: () => {} });
-    expect(pille()).toBeNull();
-  });
-
-  it("einmal geöffnet, gilt sie auch beim nächsten Aufruf ohne Anhängsel", async () => {
-    adresse("/?sprachumschalter=1");
-    initSprachumschalter({ analysiere: () => {} });
-    expect(pille()).not.toBeNull();
-
-    /* Ein echter neuer Seitenaufruf: frisches Modul, frisches DOM, kein
-       Anhängsel mehr in der Adresse. Ohne vi.resetModules() glaubt das Modul,
-       es sei noch eingehängt, und der Test bewiese nichts. */
-    vi.resetModules();
-    baueSeite();
-    adresse("/datenschutz");
-    const frisch = await import("../js/sprachumschalter.js");
-    frisch.initSprachumschalter({ analysiere: () => {} });
-
-    /* Der Schalter muss da sein — sonst ist er beim ersten Klick in die
-       Fußleiste wieder weg, und genau das war der gemeldete Fehler. */
-    expect(pille()).not.toBeNull();
   });
 
   it.each([
+    ["1", "/?sprachumschalter=1"],
     ["0", "/?sprachumschalter=0"],
-    ["false", "/?sprachumschalter=false"],
-    ["leer", "/?sprachumschalter="],
-    ["ganz ohne", "/"],
-  ])("der Wert %s blendet ihn NICHT ein", (_name, suche) => {
-    /* Streng, damit ein Tippfehler in einem herumgereichten Link kein
-         Bedienelement vor ein Workshop-Publikum stellt. */
+    ["mit lang=en", "/?lang=en&sprachumschalter=1"],
+  ])("das Anhängsel %s hat keine Wirkung mehr", (_name, suche) => {
     adresse(suche);
     initSprachumschalter({ analysiere: () => {} });
+    /* Ob der Umschalter entsteht, entscheidet jetzt allein das
+       Merkmals-Schloss ueber merkmalUebernehmen(). */
     expect(pille()).toBeNull();
   });
 
-  it("die Adresse verträgt sich mit ?lang=en", () => {
-    adresse("/?lang=en&sprachumschalter=1");
+  it("DATENSCHUTZ: der Umschalter legt NICHTS dauerhaft im Browser ab", () => {
+    /* Der Kern des Rueckbaus. Bis v3.3.0 schrieb merkmalUebernehmen() den
+       Schluessel `malzime-umschalter-aktiv` in den localStorage — bei JEDEM
+       Besucher, waehrend die Datenschutzerklaerung zusagt, dort nichts
+       abzulegen. Dieser Test wird rot, wenn das zurueckkommt. */
+    localStorage.clear();
+
+    adresse("/?sprachumschalter=1");
     initSprachumschalter({ analysiere: () => {} });
+    zeigeSprachumschalter(true);
+    expect(pille()).not.toBeNull();
+    zeigeSprachumschalter(false);
+
+    expect(localStorage.length).toBe(0);
+  });
+
+  it("Positivkontrolle: ueber das Merkmals-Schloss entsteht er sehr wohl", () => {
+    adresse("/");
+    initSprachumschalter({ analysiere: () => {} });
+    expect(pille()).toBeNull();
+
+    zeigeSprachumschalter(true);
     expect(pille()).not.toBeNull();
   });
 });

--- a/public/__tests__/strukturdaten-bilder.test.js
+++ b/public/__tests__/strukturdaten-bilder.test.js
@@ -1,0 +1,85 @@
+/**
+ * strukturdaten-bilder.test.js — Bild-Metadaten fuer die Google-Bildersuche
+ * (v3.3.1).
+ *
+ * ANLASS: Die Google Search Console meldete am 17.08.2026 zwei nicht kritische
+ * Befunde zum Typ „Bild-Metadaten fuer strukturierte Daten": In den drei
+ * ImageObject-Bloecken fehlten `license` und `acquireLicensePage`.
+ *
+ * Der Rest des Satzes (creator, creditText, copyrightNotice,
+ * digitalSourceType) war da — genau deshalb ist eine Dauerpruefung sinnvoll:
+ * Ein unvollstaendiger Satz faellt beim Lesen nicht auf, weil er auf den
+ * ersten Blick vollstaendig wirkt.
+ *
+ * Reine Textanalyse der ausgelieferten Seite — kein Netzwerk.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const INDEX = join(dirname(fileURLToPath(import.meta.url)), "../index.html");
+
+/** Alle JSON-LD-Bloecke der Seite geparst — ungueltiges JSON faellt hier auf. */
+function jsonLdBloecke() {
+  const html = readFileSync(INDEX, "utf8");
+  const treffer = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
+  return treffer.map((m) => JSON.parse(m[1]));
+}
+
+function bildObjekte() {
+  return jsonLdBloecke()
+    .flatMap((b) => (Array.isArray(b) ? b : [b]))
+    .filter((e) => e && e["@type"] === "ImageObject");
+}
+
+describe("Strukturdaten der Demo-Bilder", () => {
+  it("die Seite enthaelt gueltiges JSON-LD", () => {
+    /* Positivkontrolle: Faende der Ausdruck nichts, waeren alle folgenden
+       Pruefungen still gruen — eine leere Menge erfuellt jede Allaussage. */
+    expect(jsonLdBloecke().length).toBeGreaterThan(0);
+  });
+
+  it("es gibt genau drei Demo-Bilder mit Strukturdaten", () => {
+    expect(bildObjekte()).toHaveLength(3);
+  });
+
+  it.each(["license", "acquireLicensePage", "creator", "creditText", "copyrightNotice", "digitalSourceType"])(
+    "jedes Demo-Bild traegt das Feld %s",
+    (feld) => {
+      for (const bild of bildObjekte()) {
+        expect(bild[feld], `${bild.name} ohne ${feld}`).toBeTruthy();
+      }
+    }
+  );
+
+  it("license und acquireLicensePage sind absolute URLs (Google verlangt URLs, keine Texte)", () => {
+    for (const bild of bildObjekte()) {
+      expect(bild.license).toMatch(/^https:\/\//);
+      expect(bild.acquireLicensePage).toMatch(/^https:\/\//);
+    }
+  });
+
+  it("die Lizenzseite auf eigener Domain existiert auch wirklich", () => {
+    /* Ein Verweis auf eine Seite, die es nicht gibt, waere schlimmer als das
+       fehlende Feld: Google und Nutzer landen im Nichts. Geprueft wird die
+       Datei, nicht nur die Zeichenkette. */
+    const seiten = bildObjekte().map((b) => b.acquireLicensePage);
+    for (const url of seiten) {
+      const pfad = new URL(url).pathname.replace(/^\//, "") || "index";
+      const datei = join(dirname(fileURLToPath(import.meta.url)), `../${pfad}.html`);
+      expect(() => readFileSync(datei, "utf8"), `${url} zeigt ins Leere`).not.toThrow();
+    }
+  });
+
+  it("die verlinkte Seite traegt tatsaechlich eine Kontaktmoeglichkeit", () => {
+    /* Google verlangt eine Seite, auf der man erfaehrt, wie man eine Lizenz
+       bekommt. Ohne erreichbaren Kontakt waere das Feld formal erfuellt und
+       inhaltlich eine Leerstelle. Geprueft wird der Inhalt, nicht der Link. */
+    const url = bildObjekte()[0].acquireLicensePage;
+    const pfad = new URL(url).pathname.replace(/^\//, "");
+    const seite = readFileSync(join(dirname(fileURLToPath(import.meta.url)), `../${pfad}.html`), "utf8");
+    expect(seite).toMatch(/mailto:/);
+  });
+});

--- a/public/app.js
+++ b/public/app.js
@@ -17,6 +17,7 @@ import { enthuellungAbkuerzen, modusWechsel } from "./js/live-anzeige.js";
 import * as realitaetsCheck from "./js/realitaets-check.js";
 import { merkeModus, gemerkterModus } from "./js/modus-speicher.js";
 import { initAbsturzWache, merkePhase } from "./js/absturz-wache.js";
+import { initFehlerNachsendung } from "./js/error-logger.js";
 import { initSprachumschalter, merkmalUebernehmen } from "./js/sprachumschalter.js";
 
 /* ── Absturz-Wache: als ALLERERSTES, vor jedem await ──
@@ -44,6 +45,14 @@ resumeQueueJob();
 /* Holt das Ergebnis auch dann nach, wenn das Handy zwischendurch gesperrt war
    und die Abfrage-Schleife dabei steckengeblieben ist. */
 initHintergrundWiederaufnahme();
+
+/* v3.3.1: Fehlermeldungen, die wegen einer abgerissenen Verbindung nicht
+   rausgingen, werden nachgeschickt, sobald die Verbindung zurueck ist (und ein
+   letztes Mal beim Verlassen der Seite). Ohne das bleibt ausgerechnet der
+   haeufigste Fehler unsichtbar — die Meldung darueber braucht ja dieselbe
+   Verbindung. Die Warteschlange liegt nur im Arbeitsspeicher; im Browser wird
+   dafuer nichts abgelegt. */
+initFehlerNachsendung();
 
 /* ── Limit-, Maintenance- und Feature-Flag-Check beim Seitenstart ──
    In state.statsReady abgelegt, damit analyzeImage darauf warten kann, bevor

--- a/public/index.html
+++ b/public/index.html
@@ -98,6 +98,8 @@
       "name": "malziland - learning | training | consulting e.U."
     },
     "copyrightNotice": "MIT-Lizenz, siehe Repository",
+    "license": "https://github.com/malziland/malzime/blob/main/LICENSE",
+    "acquireLicensePage": "https://malzi.me/impressum",
     "digitalSourceType": "https://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
   },
   {
@@ -113,6 +115,8 @@
       "name": "malziland - learning | training | consulting e.U."
     },
     "copyrightNotice": "MIT-Lizenz, siehe Repository",
+    "license": "https://github.com/malziland/malzime/blob/main/LICENSE",
+    "acquireLicensePage": "https://malzi.me/impressum",
     "digitalSourceType": "https://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
   },
   {
@@ -128,6 +132,8 @@
       "name": "malziland - learning | training | consulting e.U."
     },
     "copyrightNotice": "MIT-Lizenz, siehe Repository",
+    "license": "https://github.com/malziland/malzime/blob/main/LICENSE",
+    "acquireLicensePage": "https://malzi.me/impressum",
     "digitalSourceType": "https://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
   }
 ]

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -455,12 +455,35 @@ export function initHintergrundWiederaufnahme() {
        UX-002: Auch nach einer FERTIGEN Analyse nichts tun. Die Job-Nummer
        bleibt dann bewusst stehen (Reload soll das Ergebnis wiederholen), aber
        `isAnalyzing` ist false — ohne diese Bedingung loeste jeder Tab-Wechsel
-       eine volle Wiederaufnahme samt Sprung an den Seitenanfang aus. */
-    if (!state.isAnalyzing) return;
+       eine volle Wiederaufnahme samt Sprung an den Seitenanfang aus.
+       v3.3.1: Ein wegen Verbindungsabbruch pausierter Durchgang zaehlt hier
+       mit — dort ist `isAnalyzing` bereits false, das Ergebnis aber offen. */
+    if (!state.isAnalyzing && !state.wartetAufVerbindung) return;
 
     const stillSeit = Date.now() - (state.lastPollOk || 0);
     if (stillSeit < STECKENGEBLIEBEN_MS) return;
 
+    resumeQueueJob({ force: true });
+  });
+
+  /* ── „Wieder online" (v3.3.1) ──────────────────────────────────────────
+     BUG-2026-08-17-02. Bei Verbindungsabbruch sagt die Meldung zu, die
+     Analyse erscheine automatisch, sobald man wieder online ist. Diese Zusage
+     war bis v3.3.0 ungedeckt: Die Wiederaufnahme hing allein am Tab-Wechsel
+     und am Neuladen. Wer einfach sitzen blieb, bis das Netz zurueckkam,
+     wartete vergeblich — die Seite tat nichts.
+
+     Kein STECKENGEBLIEBEN_MS-Vorlauf wie oben: Dort ist offen, ob die
+     Schleife noch lebt; hier ist der Ausloeser eindeutig, und jede Sekunde
+     Zoegern ist eine Sekunde vor einer toten Seite. */
+  window.addEventListener("online", () => {
+    if (state.uploadLaeuft) return;
+    if (!getStoredJobId()) return;
+    /* `wartetAufVerbindung` ist hier der eigentliche Fall: Der Durchgang hat
+       aufgegeben, `isAnalyzing` steht deshalb schon auf false. Ohne dieses
+       Feld wuerde der Lauscher genau in der Lage nichts tun, fuer die er
+       gebaut ist (siehe state.js). */
+    if (!state.isAnalyzing && !state.wartetAufVerbindung) return;
     resumeQueueJob({ force: true });
   });
 }
@@ -548,6 +571,22 @@ async function renderQueueResult(data, myId, traceId, timings) {
       if (elements.resultsPanel) elements.resultsPanel.focus({ preventScroll: true });
     }, 300);
     const meta = data.meta || {};
+    /* BUG-2026-08-17-05: Ein `blocked`-Ergebnis IST ein Fehler — der Nutzer
+       sieht die Karte „technischer Fehler", nicht sein Profil. Bis v3.3.0 lief
+       genau dieser Fall ausschliesslich als `analyze-success` durch die
+       Telemetrie und loeste keine einzige Fehlermeldung aus. Die
+       Fehlererfassung sah dadurch sauberer aus, als die Anwendung war: Der
+       sichtbarste Fehler war der einzige, der nirgends als Fehler gezaehlt
+       wurde. Der Grund steht in `blockedReason` und wird mitgeschickt. */
+    if (meta.mode === "blocked") {
+      logClientError(new Error(data.blockedReason || "blocked.generic"), {
+        phase: "analyse-blockiert",
+        durationMs: timings.totalMs,
+        requestId: String(myId),
+        traceId,
+        wakeLock: wakeLockStatus,
+      });
+    }
     logTelemetry("analyze-success", {
       traceId,
       durationMs: timings.totalMs,
@@ -572,6 +611,10 @@ async function renderQueueResult(data, myId, traceId, timings) {
 
 async function analyzeImageQueued() {
   state.isAnalyzing = true;
+  /* v3.3.1: Ein neuer Anlauf loescht den Verbindungs-Anker. Scheitert er
+     erneut an der Verbindung, setzt ihn der Fehlerpfad wieder — so bleibt
+     der Anker immer die Lage von JETZT und nicht die von vorhin. */
+  state.wartetAufVerbindung = false;
   /* UX-001 (Audit 2026-08-10): Ab hier gehoert der Bildschirm dem NEUEN Foto.
      Die Job-Nummer des vorigen Durchgangs bleibt nach einem Erfolg bewusst
      stehen (damit ein Reload das Ergebnis wiederholen kann) — sie darf aber
@@ -756,8 +799,16 @@ async function analyzeImageQueued() {
       return;
     }
     if (outcome.error) {
-      /* v3.0: dito — der Fehler gehört auf den heutigen, ungestörten Weg. */
-      liveAnzeige.abbrechen();
+      /* v3.3.1: Beim VERBINDUNGSABBRUCH bleibt der bereits geschriebene Text
+         stehen (pausieren statt abbrechen). Er ist echt, er stammt vom Modell,
+         und der Job läuft serverseitig weiter — ihn wegzuräumen sah nach
+         Datenverlust aus, obwohl nichts verloren war. Bei jedem anderen Fehler
+         (Job weg, fehlgeschlagen, 404) ist der Text gegenstandslos und wird
+         wie bisher restlos abgeräumt. */
+      if (outcome.transient) liveAnzeige.pausieren();
+      else liveAnzeige.abbrechen();
+      /* Anker fuer die Wiederaufnahme — siehe state.js. */
+      state.wartetAufVerbindung = Boolean(outcome.transient);
       /* Nur aufräumen, wenn der Job WIRKLICH weg ist (404, failed, abgelaufen).
          Bei einem Verbindungsabbruch bleibt die Nummer stehen: Sie ist der
          einzige Weg zurück zum fertigen Ergebnis — über die automatische
@@ -851,6 +902,10 @@ export async function resumeQueueJob({ force = false } = {}) {
   const resultToken = getStoredResultToken();
 
   state.isAnalyzing = true;
+  /* v3.3.1: Ein neuer Anlauf loescht den Verbindungs-Anker. Scheitert er
+     erneut an der Verbindung, setzt ihn der Fehlerpfad wieder — so bleibt
+     der Anker immer die Lage von JETZT und nicht die von vorhin. */
+  state.wartetAufVerbindung = false;
   const myId = ++state.requestId;
   const traceId = generateTraceId();
   const startTime = Date.now();
@@ -858,28 +913,63 @@ export async function resumeQueueJob({ force = false } = {}) {
   /* state.lastPrepared ist nach einem Reload leer — GPS kann nicht mehr
      injiziert werden (verlässt den Browser ohnehin nie). Das Profil selbst
      liegt vollständig serverseitig. */
-  /* v3.0: Die Wiederaufnahme bleibt bewusst beim heutigen Bild (Scan-Animation
-     bis zum fertigen Ergebnis). Ein eventuell mitten im Tippen eingefrorener
-     Live-Lauf wird hier restlos weggeräumt — nie halben Text stehen lassen. */
-  liveAnzeige.zuruecksetzen();
-  resetQueueWaiting();
-  startScanAnim(false);
-  /* FIX 1 (v3.0.1): Auch die Wiederaufnahme startet nie mit leerem Text. */
-  elements.scanText.textContent = t("scan.resume");
+  /* v3.3.1: ZWEI Wiederaufnahmen, die sich grundlegend unterscheiden.
+
+     (a) Ein pausierter Live-Lauf steht noch im Fenster — der Verbindungs-
+         abbruch hat ihn angehalten, nicht zerstoert. Puffer und Tipp-Stand
+         sind unberuehrt. Hier wird NICHTS zurueckgesetzt: Der Text bleibt
+         genau stehen, wie der Nutzer ihn zuletzt gesehen hat, und die Schleife
+         tippt an derselben Stelle weiter. Genau das ist die Zusage hinter
+         „erscheint automatisch, sobald du wieder online bist" — sie war bis
+         v3.3.0 nicht gedeckt, weil hier zurueckgesetzt und ohne Live-Text
+         weitergefragt wurde.
+
+     (b) Nach einem Neuladen ist der Lauf weg (der Speicher ist leer). Dann
+         bleibt es beim bisherigen Verhalten: Scan-Animation bis zum fertigen
+         Ergebnis. Halben Text aus dem Nichts nachzubauen waere Theater. */
+  const setztLiveTextFort = liveAnzeige.istPausiert();
+
+  if (setztLiveTextFort) {
+    liveAnzeige.fortsetzen();
+    setStatus("");
+  } else {
+    liveAnzeige.zuruecksetzen();
+    resetQueueWaiting();
+    startScanAnim(false);
+    /* FIX 1 (v3.0.1): Auch die Wiederaufnahme startet nie mit leerem Text. */
+    elements.scanText.textContent = t("scan.resume");
+  }
 
   try {
-    /* pollImmediately=true: das fertige Ergebnis sofort holen, ohne 2s-Vorlauf. */
-    const outcome = await pollJob(jobId, myId, resultToken, true);
+    /* pollImmediately=true: das fertige Ergebnis sofort holen, ohne 2s-Vorlauf.
+       liveErlaubt nur im Fall (a): Nur dort gibt es einen Puffer, an den die
+       naechste Welle anschliessen kann. */
+    const outcome = await pollJob(jobId, myId, resultToken, true, setztLiveTextFort);
     if (state.requestId !== myId) return;
 
     stopScanAnim();
     elements.scanText.textContent = "";
+
+    /* BUG-2026-08-17-03: Ein ABGERISSENER Versuch darf die Job-Nummer nicht
+       wegwerfen. Sie ist der einzige Weg zurueck zu einem Ergebnis, das
+       serverseitig rund zwei Stunden bereitliegt. Bis v3.3.0 raeumte die
+       Wiederaufnahme bei JEDEM Fehler auf — solange sie nur beim Seitenstart
+       lief, blieb das folgenlos. Seit sie auch bei „wieder online" mitten im
+       Lauf greift, wuerde ein zweiter Abbruch das fertige Profil endgueltig
+       unerreichbar machen. Also: erneut pausieren, Nummer behalten. */
+    if (outcome && outcome.error && outcome.transient) {
+      if (!liveAnzeige.pausieren()) startScanAnim(false);
+      state.wartetAufVerbindung = true;
+      setStatus(outcome.error, traceId, "error.connectionLost");
+      return;
+    }
 
     /* Resume ist eine stille Hintergrund-Wiederherstellung beim Seitenstart.
        Ist der Job weg oder fehlgeschlagen (abgelaufen / abgebrochen / nach 2 h
        serverseitig gelöscht → 404), den User NICHT mit einer Fehlermeldung
        erschrecken: still aufräumen und die normale Startseite zeigen. */
     if (!outcome || outcome.abandoned || outcome.error) {
+      liveAnzeige.abbrechen();
       clearStoredJobId();
       setStatus("");
       return;

--- a/public/js/error-logger.js
+++ b/public/js/error-logger.js
@@ -22,13 +22,14 @@
  *
  * ── Warum die Warteschlange NUR im Arbeitsspeicher liegt ──
  *
- * Eine erste Fassung legte misslungene Meldungen in den `sessionStorage`. Das
- * war der falsche Weg: Die Datenschutzerklaerung zaehlt abschliessend auf, was
- * dort liegt — ein sechster Eintrag haette bedeutet, den Rechtstext an eine
- * Funktion anzupassen. Die Reihenfolge ist umgekehrt: Der Rechtstext ist die
- * Vorgabe, der Code richtet sich danach.
+ * NICHT im `sessionStorage` und nicht im `localStorage`. Die
+ * Datenschutzerklaerung zaehlt abschliessend auf, was im Browser abgelegt wird;
+ * ein weiterer Eintrag hiesse, den Rechtstext an eine Funktion anzupassen. Die
+ * Reihenfolge ist umgekehrt — der Rechtstext ist die Vorgabe, der Code richtet
+ * sich danach. Wer diese Warteschlange „haltbarer" machen will, aendert also
+ * zuerst nichts hier.
  *
- * Deshalb lebt die Warteschlange als einfaches Array im Modul. Sie hinterlaesst
+ * Sie lebt deshalb als einfaches Array im Modul. Sie hinterlaesst
  * NICHTS im Browser, ueberdauert kein Neuladen und braucht keine Zeile in der
  * Datenschutzerklaerung — der Seite steht ohnehin frei, waehrend ihrer Laufzeit
  * Daten im Arbeitsspeicher zu halten (das Profil selbst liegt genauso dort).

--- a/public/js/error-logger.js
+++ b/public/js/error-logger.js
@@ -4,13 +4,124 @@
  * Sendet strukturierte Fehler-Metadaten an /api/errors. DSGVO: keine PII,
  * keine IP-Speicherung serverseitig, keine Cookies, kein User-Tracking —
  * nur Fehler-Typ, Phase, Dauer, anonyme Hardware-/Netzwerk-Klassen + grober
- * User-Agent. Logging-Fehler werden still geschluckt, damit der User-Flow
- * nie davon abhaengt.
+ * User-Agent.
+ *
+ * ── Warum es hier eine Warteschlange gibt (v3.3.1, BUG-2026-08-17-04) ──
+ *
+ * Bis v3.3.0 ging die Meldung per `fetch` raus und ein Fehler dabei wurde
+ * still verschluckt. Das klingt harmlos, ist aber die Stelle, an der sich die
+ * Fehlererfassung selbst aushebelt: Der haeufigste Fehler dieser Anwendung ist
+ * „Verbindung weg" — und die Meldung darueber muss ueber genau die Verbindung,
+ * die weg ist. Die Fehlerklasse, die am dringendsten sichtbar sein muesste,
+ * war damit die einzige, die systematisch unsichtbar blieb.
+ *
+ * Belegt an echten Daten: Im 30-Tage-Diagnose-Bucket lagen ganze ZWEI
+ * Client-Fehler, obwohl im selben Zeitraum mehrere Nutzer Fehler gemeldet
+ * hatten. Die Statistik sah sauber aus, weil das Messmittel bei genau diesem
+ * Fehler mit ausfiel.
+ *
+ * ── Warum die Warteschlange NUR im Arbeitsspeicher liegt ──
+ *
+ * Eine erste Fassung legte misslungene Meldungen in den `sessionStorage`. Das
+ * war der falsche Weg: Die Datenschutzerklaerung zaehlt abschliessend auf, was
+ * dort liegt — ein sechster Eintrag haette bedeutet, den Rechtstext an eine
+ * Funktion anzupassen. Die Reihenfolge ist umgekehrt: Der Rechtstext ist die
+ * Vorgabe, der Code richtet sich danach.
+ *
+ * Deshalb lebt die Warteschlange als einfaches Array im Modul. Sie hinterlaesst
+ * NICHTS im Browser, ueberdauert kein Neuladen und braucht keine Zeile in der
+ * Datenschutzerklaerung — der Seite steht ohnehin frei, waehrend ihrer Laufzeit
+ * Daten im Arbeitsspeicher zu halten (das Profil selbst liegt genauso dort).
+ *
+ * Was das kostet, ehrlich benannt: Wer den Tab schliesst oder neu laedt,
+ * waehrend das Netz weg ist, dessen Meldung ist verloren. Abgedeckt ist der
+ * Fall, der in den Logs tatsaechlich auftrat — die Verbindung kommt zurueck,
+ * waehrend die Seite noch offen ist.
  */
 
 import { collectClientContext, coarseUserAgent } from "./client-context.js";
 
 const ERROR_ENDPOINT = "/api/errors";
+/* Deckel gegen Endlos-Wachstum: Bei einem laengeren Netzausfall koennte sonst
+   jeder Poll-Durchgang eine Meldung nachlegen. Die aeltesten fliegen zuerst —
+   der juengste Fehler ist der, der zum aktuellen Zustand passt. */
+const WARTESCHLANGE_MAX = 10;
+
+/* Reiner Arbeitsspeicher — bewusst kein sessionStorage, kein localStorage.
+   Siehe Modul-Kommentar. */
+let warteschlange = [];
+
+function zurueckstellen(payload) {
+  warteschlange.push(payload);
+  if (warteschlange.length > WARTESCHLANGE_MAX) {
+    warteschlange = warteschlange.slice(-WARTESCHLANGE_MAX);
+  }
+}
+
+/** Nur fuer Tests und die Selbstpruefung: aktueller Stand der Warteschlange. */
+export function offeneMeldungen() {
+  return warteschlange.slice();
+}
+
+/**
+ * Schickt eine Meldung ab. Gelingt das nicht, wandert sie in die
+ * Warteschlange.
+ *
+ * `keepalive` sorgt dafuer, dass der Beacon auch beim Tab-Schliessen noch
+ * durchgeht. Beachte: `fetch` lehnt einen echten Netzfehler mit einer
+ * abgelehnten Promise ab — ein HTTP-Fehlerstatus dagegen gilt als Erfolg.
+ * Beides wird hier getrennt behandelt, sonst zaehlte ein 500er als zugestellt.
+ */
+function senden(payload) {
+  return fetch(ERROR_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    keepalive: true,
+  })
+    .then((resp) => {
+      /* 4xx bedeutet: Der Server WILL diese Meldung nicht (Whitelist, Format).
+         Sie erneut zu schicken, wuerde nur die Warteschlange verstopfen. 5xx
+         dagegen ist ein voruebergehendes Serverproblem — die heben wir auf. */
+      if (resp && !resp.ok && resp.status >= 500) throw new Error(`HTTP ${resp.status}`);
+      return true;
+    })
+    .catch(() => {
+      zurueckstellen(payload);
+      return false;
+    });
+}
+
+/**
+ * Schickt zurueckgestellte Meldungen nach. Wird beim Ereignis „wieder online"
+ * und beim Verlassen der Seite gerufen.
+ *
+ * Die Warteschlange wird VOR dem Senden geleert und eine misslungene Meldung
+ * von `senden()` wieder zurueckgelegt. Andernfalls koennte ein Fehlschlag
+ * mitten in der Schleife Meldungen doppelt ablegen.
+ *
+ * @returns {Promise<number>} Anzahl der erfolgreich zugestellten Meldungen.
+ */
+export function fehlerNachschicken() {
+  if (warteschlange.length === 0) return Promise.resolve(0);
+  const offen = warteschlange;
+  warteschlange = [];
+  return Promise.all(offen.map((p) => senden(p))).then((ergebnisse) => ergebnisse.filter(Boolean).length);
+}
+
+/** Verdrahtet das Nachschicken. Wird einmal beim Seitenstart gerufen. */
+export function initFehlerNachsendung() {
+  window.addEventListener("online", () => {
+    fehlerNachschicken();
+  });
+  /* Letzter Versuch, bevor die Seite geht. `keepalive` in senden() haelt die
+     Anfrage am Leben, auch wenn das Dokument schon abgebaut wird. Ist das Netz
+     weiterhin weg, ist die Meldung verloren — das ist der bewusst getragene
+     Preis dafuer, nichts im Browser zu hinterlassen. */
+  window.addEventListener("pagehide", () => {
+    fehlerNachschicken();
+  });
+}
 
 export function logClientError(error, context = {}) {
   try {
@@ -36,13 +147,14 @@ export function logClientError(error, context = {}) {
       client: clientCtx,
     };
 
-    /* keepalive: damit der Beacon auch beim Tab-Schliessen durchgeht. */
-    fetch(ERROR_ENDPOINT, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-      keepalive: true,
-    }).catch(() => {});
+    /* Ist das Geraet nachweislich offline, gar nicht erst senden: Der Versuch
+       scheitert ohnehin und die Warteschlange ist der schnellere Weg. */
+    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      zurueckstellen(payload);
+      return;
+    }
+
+    senden(payload);
   } catch (_) {
     /* niemals werfen */
   }

--- a/public/js/i18n.js
+++ b/public/js/i18n.js
@@ -164,4 +164,47 @@ export function applyTranslations() {
     const text = t(key);
     if (text !== key) el.innerHTML = text;
   });
+
+  /* ZULETZT — die Reihenfolge ist wesentlich. Der Block darüber ersetzt ganze
+     innerHTML-Bereiche, und in einem davon steckt ein Link (der Verweis auf die
+     Datenschutzerklärung im Hochlade-Hinweis). Vor dieser Zeile gesetzt, wäre
+     die Sprache dort sofort wieder überschrieben. */
+  spracheAnLinksHaengen();
+}
+
+/**
+ * Hängt die aktuelle Sprache an alle internen Links, die einen NEUEN TAB
+ * öffnen (v3.3.1).
+ *
+ * WARUM: Die Sprachwahl liegt im `sessionStorage` — bewusst pro Tab, damit ein
+ * weitergereichtes Workshop-Gerät wieder in der Gerätesprache startet. Ein mit
+ * `target="_blank"` geöffneter Tab bekommt aber einen LEEREN sessionStorage.
+ * Wer also auf der englischen Startseite die Zahlen-Seite anklickte, landete
+ * dort auf Deutsch — die Wahl blieb im alten Tab zurück.
+ *
+ * Betroffen sind genau die sechs Links der Startseite; die Unterseiten
+ * verlinken untereinander im selben Tab und brauchen nichts. Gestempelt wird
+ * trotzdem nach Merkmal statt nach Seite: Käme irgendwo ein siebenter Link mit
+ * `target="_blank"` dazu, wäre er von selbst richtig.
+ *
+ * Immer BEIDE Sprachen stempeln, nie nur Englisch: Steht das Gerät auf
+ * Englisch und jemand hat die Seite auf Deutsch gestellt, wäre ein fehlender
+ * Wert genauso falsch herum.
+ *
+ * Kein Speicher, keine Schnittstelle — die Sprache reist sichtbar in der
+ * Adresse mit. `searchParams.set` ist dabei idempotent: Mehrfaches Anwenden
+ * hängt nichts an, es überschreibt.
+ */
+function spracheAnLinksHaengen() {
+  document.querySelectorAll('a[target="_blank"][href^="/"]').forEach((a) => {
+    const roh = a.getAttribute("href");
+    if (!roh) return;
+    try {
+      const ziel = new URL(roh, window.location.origin);
+      ziel.searchParams.set("lang", lang);
+      a.setAttribute("href", ziel.pathname + ziel.search + ziel.hash);
+    } catch (_err) {
+      /* Kaputte Adresse im HTML — dann bleibt der Link, wie er ist. */
+    }
+  });
 }

--- a/public/js/live-anzeige.js
+++ b/public/js/live-anzeige.js
@@ -145,6 +145,11 @@ let enthuellungGestartet = false;
 /* Wurde in diesem Durchgang Live-Text angezeigt? Entscheidet in api.js,
    ob nach dem Rendern die gestaffelte Enthüllung fährt. */
 let liveLief = false;
+/* v3.3.1: Haelt der Lauf gerade wegen eines Verbindungsabbruchs an? Karte und
+   Text bleiben dabei stehen — siehe pausieren(). Getrennt von `lauf.stop`,
+   weil `stop` auch das endgueltige Ende bedeutet und beides sonst nicht
+   unterscheidbar waere. */
+let pausiert = false;
 
 /* Bewegungs-Vorgabe des Systems — bewusst bei jedem Zugriff frisch lesen,
    damit ein Umstellen während der Analyse sofort greift. */
@@ -560,6 +565,31 @@ async function tippSchleife(mein) {
  * ignoriert. `beast` ist null, solange das Modell das Beast-Profil noch
  * nicht begonnen hat (es schreibt sequenziell: Standard zuerst).
  */
+/**
+ * Uebernimmt einen neuen Stand in einen Puffer — oder eben nicht.
+ *
+ * ZWEI BEDINGUNGEN, und die zweite ist eine Zusicherung an den Nutzer
+ * (v3.3.1): Der Text, den er BEREITS GELESEN hat, wird nie wieder angetastet.
+ *
+ *   1. Nur laengere Staende zaehlen. Kuerzere oder gleiche sind alte
+ *      Antworten, die verspaetet eintrudeln.
+ *   2. Der neue Stand muss mit dem bereits GETIPPTEN Teil beginnen. Taete er
+ *      das nicht, wuerde sich Sichtbares vor den Augen des Nutzers aendern —
+ *      genau das, was beim Verbindungsabbruch niemand erleben soll.
+ *
+ * Geprueft wird gegen `fest` (das Getippte), nicht gegen den ganzen Puffer:
+ * Der noch ungetippte Rest ist unsichtbar und darf sich korrigieren, etwa
+ * wenn der Server-Extraktor eine halb angekommene Escape-Sequenz spaeter
+ * sauber aufloest. Gegen den ganzen Puffer geprueft koennte genau so ein
+ * Zwischenstand die Anzeige dauerhaft einfrieren.
+ */
+function uebernehmen(puffer, neu) {
+  if (typeof neu !== "string") return;
+  if (neu.length <= puffer.text.length) return;
+  if (!neu.startsWith(puffer.text.slice(0, puffer.fest))) return;
+  puffer.text = neu;
+}
+
 export function welle(texte) {
   if (!texte || typeof texte.standard !== "string" || texte.standard.length === 0) return;
   /* Späte Wellen nach Beginn der Enthüllung ändern nichts mehr. */
@@ -574,12 +604,8 @@ export function welle(texte) {
      alte Antworten. Ob eine Lieferung „fertig" ist, spielt seit v3.0.2 keine
      Rolle mehr: Das Warte-Auge richtet sich allein danach, ob gerade getippt
      wird oder der Puffer leerläuft. */
-  if (texte.standard.length > lauf.puffer.standard.text.length) {
-    lauf.puffer.standard.text = texte.standard;
-  }
-  if (typeof texte.beast === "string" && texte.beast.length > lauf.puffer.beast.text.length) {
-    lauf.puffer.beast.text = texte.beast;
-  }
+  uebernehmen(lauf.puffer.standard, texte.standard);
+  uebernehmen(lauf.puffer.beast, texte.beast);
 
   if (reduziert()) {
     /* Barrierefreiheit: kein Tippen, kein Rausch — jede Welle erscheint
@@ -912,7 +938,65 @@ export function enthuellungAbkuerzen() {
  * Schleifen gestoppt, Verdecktes wieder sichtbar. Für Fehler/Abbruch mitten
  * im Live-Text und als No-Op-Aufräumer, wenn nie Live-Text lief.
  */
+/**
+ * Haelt das Live-Erlebnis an, OHNE etwas wegzuraeumen (v3.3.1).
+ *
+ * Fuer den Verbindungsabbruch mitten im Schreiben. Bis v3.3.0 rief api.js
+ * hier `abbrechen()` — Karte und Text verschwanden, uebrig blieb eine
+ * Fehlermeldung. Aus Nutzersicht sah das aus, als haette die Seite alles
+ * verloren, obwohl serverseitig nichts verloren war.
+ *
+ * Jetzt bleibt stehen, was schon dasteht: Die Tipp-Schleife haelt an, der
+ * Rausch-Schweif verschwindet (er waere Bewegung ohne Fortschritt), die Karte
+ * wird ueber eine CSS-Klasse gedaempft. Die Begruendung traegt die
+ * Statuszeile, die api.js ohnehin setzt.
+ *
+ * @returns {boolean} true, wenn tatsaechlich ein Lauf angehalten wurde.
+ */
+export function pausieren() {
+  if (!lauf || pausiert) return false;
+  pausiert = true;
+  /* stop beendet die laufende Tipp-Schleife; `lauf` selbst bleibt samt
+     Puffern und `fest`-Staenden erhalten — daran knuepft fortsetzen() an. */
+  lauf.stop = true;
+  lauf.tippt = false;
+  spinnerVerstecken(lauf);
+  if (elements.liveTextRausch) elements.liveTextRausch.textContent = "";
+  if (elements.liveKarte) elements.liveKarte.classList.add("live-karte--pausiert");
+  return true;
+}
+
+/**
+ * Nimmt ein pausiertes Live-Erlebnis wieder auf (v3.3.1).
+ *
+ * Der Puffer und der Stand des bereits Getippten (`fest`) sind unberuehrt
+ * geblieben — die Schleife tippt also exakt dort weiter, wo sie angehalten
+ * hat. Ohne Zeit-Anlauf: Der Nutzer hat gerade eine Pause erlebt, eine zweite
+ * waere Hohn.
+ *
+ * @returns {boolean} true, wenn tatsaechlich fortgesetzt wurde.
+ */
+export function fortsetzen() {
+  if (!lauf || !pausiert) return false;
+  pausiert = false;
+  if (elements.liveKarte) elements.liveKarte.classList.remove("live-karte--pausiert");
+  lauf.stop = false;
+  if (!lauf.tippt) {
+    lauf.tippt = true;
+    lauf.tippStartAb = 0;
+    tippSchleife(lauf);
+  }
+  return true;
+}
+
+/** Laeuft gerade ein pausierter Live-Text? Fuer api.js und die Tests. */
+export function istPausiert() {
+  return pausiert;
+}
+
 export function abbrechen() {
+  pausiert = false;
+  if (elements.liveKarte) elements.liveKarte.classList.remove("live-karte--pausiert");
   if (lauf) {
     lauf.stop = true;
     /* Ein noch aktives Warte-Auge gehört mit aufgeräumt — sonst bliebe die

--- a/public/js/sprachhinweis.js
+++ b/public/js/sprachhinweis.js
@@ -22,13 +22,24 @@
  *    entsteht, die später zurückgebaut werden müsste.
  *
  * Diese Seiten laden sonst KEIN JavaScript und rufen keine Schnittstelle auf.
- * Das bleibt so: Ob der Umschalter erscheint, entscheidet allein die Adresse
- * (`?sprachumschalter=1`) oder eine Spur, die die Startseite im selben Tab
- * hinterlassen hat. Kein Netzweg, kein Merkmals-Abruf auf einer Rechtsseite.
+ * Das bleibt so: kein Netzweg, kein Merkmals-Abruf auf einer Rechtsseite.
+ *
+ * v3.3.1 — die Erprobungs-Tür ist weg, und mit ihr der localStorage.
+ * Bis v3.3.0 entschied hier eine Spur im localStorage (`malzime-tuer-…`,
+ * `malzime-umschalter-aktiv`), ob der Umschalter erscheint. Sie stammte aus der
+ * Zeit vor der Freischaltung, als er sich vorführen lassen musste, ohne dass
+ * ein Workshop-Publikum ihn sieht. Zwei Gründe, warum sie jetzt fort ist:
+ *
+ *   1. Die Datenschutzerklärung sagt zu, im Browser nichts Dauerhaftes
+ *      abzulegen. Der Eintrag entstand bei JEDEM Besucher und widersprach ihr.
+ *      Der Rechtstext ist die Vorgabe, nicht der Code.
+ *   2. Der Umschalter ist seit v3.3.0 live. Eine Tür, die an einem
+ *      freigeschalteten Zimmer vorbeiführt, braucht niemand mehr.
+ *
+ * Der Umschalter erscheint hier deshalb schlicht immer — so lange, bis diese
+ * Übergangsdatei samt den Rechtstexten auf Englisch verschwindet.
  */
 
-const TUER = "malzime-tuer-sprachumschalter";
-const MERKMAL = "malzime-umschalter-aktiv";
 const KREUZ_ZEICHEN = "×";
 
 /* Je EIN Satz pro Sprache. Alles darüber hinaus liest im Workshop niemand
@@ -40,27 +51,6 @@ const TEXTE = {
   schliessen_de: "Schließen",
   schliessen_en: "Close",
 };
-
-/* Dieselbe Tür wie auf der Startseite (js/sprachumschalter.js). Sie liegt im
-   localStorage, weil diese Seiten mit target="_blank" rel="noopener" geöffnet
-   werden: Ein so geöffneter Tab bekommt einen leeren sessionStorage, eine
-   Spur von dort wäre hier nie angekommen. */
-function sichtbar() {
-  let wert = null;
-  try {
-    wert = new URLSearchParams(window.location.search).get("sprachumschalter");
-  } catch (_err) {
-    /* kaputte Adresse */
-  }
-  try {
-    if (wert === "1") localStorage.setItem(TUER, "1");
-    if (wert === "0") localStorage.removeItem(TUER);
-    return localStorage.getItem(TUER) === "1" || localStorage.getItem(MERKMAL) === "1";
-  } catch (_err) {
-    /* Privater Modus: dann gilt nur die Angabe in der Adresse. */
-    return wert === "1";
-  }
-}
 
 /* Wohin der Umschalter gehört, je nach Seitenaufbau:
 
@@ -179,8 +169,6 @@ function baueHinweis() {
 }
 
 function start() {
-  if (!sichtbar()) return;
-
   const { grund, ok, schliessen } = baueHinweis();
   let ausloeser = null;
   /* Eigener Zustand statt `grund.hidden`: Das Verbergen passiert erst nach dem

--- a/public/js/sprachumschalter.js
+++ b/public/js/sprachumschalter.js
@@ -8,14 +8,11 @@
  * überleben kein Neuladen — damit lässt sich die fertige Bedienung auf der
  * ECHTEN Seite durchspielen, ohne dass ein Workshop-Publikum etwas sieht.
  *
- * 1. In der Adresse:  ?sprachumschalter=1
- *
- *    Der wichtigere Weg. Auf iPhone und iPad gibt es keine Konsole, und genau
- *    dort muss der Umschalter erprobt werden: Daumen-Größe und Rückfrage auf
- *    kleinem Schirm sind die kritischen Punkte. Chrome sperrt am Rechner
- *    obendrein das Einfügen in die Konsole.
- *
- * 2. In der Konsole:  malziME.sprachumschalter()   /   (false) zum Entfernen
+ * Ob er entsteht, entscheidet allein das Merkmals-Schloss `useSprachumschalter`
+ * (Firestore, ohne Deploy umlegbar). Die frühere Erprobungs-Tür — Adress-
+ * Anhängsel und Konsolen-Aufruf — ist mit v3.3.1 entfallen: Sie war für die
+ * Zeit vor der Freischaltung gedacht, und ihre Spur im localStorage
+ * widersprach der Datenschutzerklärung. Näheres weiter unten.
  *
  * Der Wechsel selbst ist bewusst einfach gehalten: Es gibt keinen Weg, einem
  * laufenden Auftrag nachträglich eine andere Sprache zu geben. Stattdessen
@@ -35,27 +32,21 @@ import { statusNeuSchreiben } from "./ui.js";
    müssten die Locale-Texte einen Platzhalter bekommen. */
 const SPRACHEN = ["de", "en"];
 const SPEICHER_SCHLUESSEL = "malzime-sprache";
-/* Spur der Erprobungs-Tür. Sie liegt im localStorage, NICHT im
-   sessionStorage: Die Rechtsseiten öffnen mit target="_blank" rel="noopener"
-   (index.html:348), und ein so geöffneter Tab bekommt einen leeren
-   sessionStorage. Die Spur wäre dort nie angekommen — genau daran ist die
-   erste Fassung gescheitert.
+/* v3.3.1 — die Erprobungs-Tür ist ersatzlos entfernt, samt ihrer beiden
+   localStorage-Schlüssel `malzime-tuer-sprachumschalter` und
+   `malzime-umschalter-aktiv`.
 
-   Bewusst geräteweit und dauerhaft: Es ist eine Tür zum Erproben, keine
-   Nutzer-Einstellung. Zu bekommen nur über ?sprachumschalter=1, wieder los
-   über ?sprachumschalter=0 oder malziME.sprachumschalter(false). Der
-   Normalbetrieb hängt weiterhin allein am Merkmals-Schloss. */
-const TUER_SCHLUESSEL = "malzime-tuer-sprachumschalter";
+   Sie stammte aus der Zeit vor der Freischaltung: Der fertige Umschalter
+   sollte sich live vorführen lassen, ohne dass ein Workshop-Publikum ihn
+   sieht. Seit v3.3.0 ist er freigeschaltet — die Tür führt an einem offenen
+   Zimmer vorbei.
 
-/* Zweite Spur, die den Stand des Merkmals spiegelt. Die Rechtsseiten rufen
-   bewusst kein /api/stats auf (eine Rechtsseite soll keinen Netzweg aufmachen)
-   und erfahren nur so, dass der Umschalter im Betrieb an ist. Wird bei JEDEM
-   Aufruf der Startseite neu geschrieben oder geloescht, damit ein Abschalten
-   des Merkmals ankommt.
-
-   Getrennt von der Tuer, weil sonst das ausgeschaltete Merkmal beim naechsten
-   Seitenaufruf die Erprobung wieder zusperren wuerde. */
-const MERKMAL_SCHLUESSEL = "malzime-umschalter-aktiv";
+   Der eigentliche Grund für den Rückbau ist aber ein anderer: Der Schlüssel
+   `malzime-umschalter-aktiv` wurde bei JEDEM Besucher gesetzt, während die
+   Datenschutzerklärung zusagt, im Browser nichts Dauerhaftes abzulegen. Der
+   Rechtstext ist die Vorgabe, nicht der Code. Nebenbei stand in docs/FLAGS.md
+   ohnehin, die Tür „überlebt kein Neuladen" — der localStorage machte daraus
+   geräteweit und dauerhaft. Auch diese Abweichung ist damit weg. */
 
 /* Das Schliess-Kreuz ist ein Zeichen, kein Text: Es wird nie uebersetzt und
    Screenreadern gar nicht vorgelesen — deren Beschriftung kommt aus dem
@@ -429,7 +420,6 @@ function aushaengen() {
   if (!eingehaengt) return;
   modalSchliessen();
   document.removeEventListener("keydown", aufTaste);
-  tuer(false);
   [umschalter, modalFertig, modalLaeuft, ansage].forEach((el) => el && el.remove());
   umschalter = modalFertig = modalLaeuft = ansage = null;
   eingehaengt = false;
@@ -491,48 +481,10 @@ export function initSprachumschalter({ analysiere, zuruecksetze } = {}) {
   neuAnalysieren = analysiere || null;
   zuruecksetzen = zuruecksetze || null;
 
-  window.malziME = window.malziME || {};
-  window.malziME.sprachumschalter = (an = true) => {
-    tuer(an);
-    zeigeSprachumschalter(an);
-    return an ? "Sprachumschalter eingeblendet — gilt jetzt auch auf den Unterseiten." : "Sprachumschalter entfernt.";
-  };
-
-  /* Tür über die Adresse. Bewusst streng: nur genau "1" öffnet, nur genau "0"
-     schliesst. Alles andere lässt den Zustand, wie er ist. */
-  const wunsch = adressWunsch();
-  if (wunsch === true) tuer(true);
-  if (wunsch === false) tuer(false);
-  if (tuerOffen()) einhaengen();
-}
-
-/** "1" → true, "0" → false, sonst null (keine Angabe). */
-function adressWunsch() {
-  try {
-    const wert = new URLSearchParams(window.location.search).get("sprachumschalter");
-    if (wert === "1") return true;
-    if (wert === "0") return false;
-  } catch (_err) {
-    /* Kaputte Adresse — dann eben keine Angabe. */
-  }
-  return null;
-}
-
-function tuerOffen() {
-  try {
-    return localStorage.getItem(TUER_SCHLUESSEL) === "1";
-  } catch (_err) {
-    return false;
-  }
-}
-
-function tuer(auf) {
-  try {
-    if (auf) localStorage.setItem(TUER_SCHLUESSEL, "1");
-    else localStorage.removeItem(TUER_SCHLUESSEL);
-  } catch (_err) {
-    /* Privater Modus — dann gilt die Tür nur für diesen Seitenaufruf. */
-  }
+  /* Ab hier entscheidet allein das Merkmals-Schloss, ob der Umschalter
+     entsteht — app.js ruft merkmalUebernehmen(), sobald /api/stats geantwortet
+     hat. Die frühere Erprobungs-Tür (Adress-Anhängsel und Konsolen-Aufruf) ist
+     mit v3.3.1 entfallen; siehe die Begründung am Kopf der Datei. */
 }
 
 /**
@@ -553,12 +505,16 @@ export function zeigeSprachumschalter(an) {
  * ein Abschalten ankommt.
  */
 export function merkmalUebernehmen(an) {
-  try {
-    if (an) localStorage.setItem(MERKMAL_SCHLUESSEL, "1");
-    else localStorage.removeItem(MERKMAL_SCHLUESSEL);
-  } catch (_err) {
-    /* Privater Modus — dann sehen die Unterseiten den Schalter nicht. */
-  }
+  /* v3.3.1: KEIN localStorage mehr. Der Stand wurde hier hinterlegt, damit die
+     Unterseiten ihn sehen (sie öffnen mit target="_blank" und bekommen einen
+     leeren sessionStorage). Das legte bei JEDEM Besucher einen dauerhaften
+     Eintrag an und widersprach der Datenschutzerklärung.
+
+     Die Unterseiten holen den Stand jetzt selbst bei /api/stats — dieselbe
+     Quelle, aus der auch dieser Aufruf gespeist wird (app.js). Das ist nicht
+     nur datenschutzkonform, sondern auch richtiger: Der hinterlegte Wert
+     veraltete: Wurde das Merkmal abgeschaltet, trug ein Gerät den alten Stand
+     so lange weiter, bis jemand die Startseite erneut aufrief. */
   if (an) einhaengen();
 }
 

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -27,4 +27,15 @@ export const state = {
      verdraengt sie den laufenden Durchgang und rendert das vorige Ergebnis
      neben dem neuen Foto (Audit UX-001). */
   uploadLaeuft: false,
+  /* v3.3.1: Ein Durchgang haengt an einer abgerissenen Verbindung. Der Job
+     laeuft serverseitig weiter, das Ergebnis liegt rund zwei Stunden bereit —
+     nur der Weg dorthin ist gerade zu.
+
+     WARUM EIN EIGENES FELD: `isAnalyzing` wird am Ende jedes Durchgangs
+     zurueckgesetzt, auch nach einem Abbruch — und das ist richtig so, sonst
+     koennte der Nutzer kein neues Foto hochladen. Die Wiederaufnahme braucht
+     aber genau dann noch einen Anker, sonst laeuft die Zusage „erscheint
+     automatisch, sobald du wieder online bist" ins Leere: Der Lauscher fiele
+     auf ein `isAnalyzing === false` und taete nichts. */
+  wartetAufVerbindung: false,
 };

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -125,9 +125,10 @@ async function init() {
 
   /* v3.3: Diese Seite ist übersetzt, also bekommt sie den echten Umschalter.
      Ohne Neuanalyse-Rückruf — hier steht nichts auf dem Spiel, ein Wechsel
-     zeichnet die Zahlen einfach neu. Gezeigt wird er nach denselben Regeln wie
-     auf der Startseite: Merkmals-Schloss aus /api/stats, dazu die beiden
-     Erprobungs-Türen (Adresse und Konsole). */
+     zeichnet die Zahlen einfach neu. Gezeigt wird er nach derselben Regel wie
+     auf der Startseite: allein das Merkmals-Schloss aus /api/stats, das oben
+     bereits gelesen wurde. Die beiden Erprobungs-Türen (Adresse und Konsole)
+     sind mit v3.3.1 entfallen. */
   initSprachumschalter({});
 
   await loadStats();

--- a/public/styles.css
+++ b/public/styles.css
@@ -786,6 +786,24 @@ html[data-has-result] {
   animation: fadeUp 0.35s var(--ease) both;
 }
 
+/* v3.3.1 — Verbindungsabbruch mitten im Schreiben: Die Karte BLEIBT samt
+   Text stehen, sie tritt nur zurück. Vorher verschwand hier alles, was schon
+   geschrieben war; das sah nach Datenverlust aus, obwohl serverseitig nichts
+   verloren war. Gedämpft statt weg — die Begründung trägt die Statuszeile.
+   Bewusst nur Deckkraft und Rahmenfarbe: kein Layout-Sprung, keine Bewegung,
+   damit die Pause auch bei reduzierter Bewegung ruhig wirkt. */
+.live-karte--pausiert {
+  opacity: 0.62;
+  border-left-color: var(--ml-warmgray);
+}
+
+/* Der blinkende Cursor gehört zum Schreiben — steht das Schreiben still,
+   steht auch er still, sonst verspricht er Fortschritt, den es nicht gibt. */
+.live-karte--pausiert .tipp-cursor {
+  animation: none;
+  opacity: 0.35;
+}
+
 /* Die frühere Status-Zeile (.live-status samt Puls-Punkt) ist seit v3.0.2
    ersatzlos weg — Warte-Meldungen trägt das Scan-Auge oberhalb der Karte. */
 


### PR DESCRIPTION
Ausgelöst durch eine Nutzermeldung über abgebrochene Analysen und einen mitten im Schreiben verschwindenden Text, dazu eine Search-Console-Meldung.

## Die Ursachen, alle am Log nachgemessen

**Zwei Grenzen, die nicht zusammenpassten.** Der Single-Large-Aufruf durfte 8000 Token schreiben und hatte 90 s Zeit. Bei gemessenen 47 Token/s (langsamster Lauf 39,4) braucht die erlaubte Menge rund 170 s. Erst seit v3.0.0 biss die Grenze zu: Ohne Stream wird die Uhr schon nach den Antwortkopfzeilen abgeräumt, im Stream bleibt sie scharf bis zum letzten Zeichen.

| Zeitraum | Läufe | technische Fehler | über 90 s |
|---|---|---|---|
| vor v3.0.0 (19.07.–11.08.) | 121 | 0 | 8 — alle wurden fertig |
| nach v3.0.0 (11.08.–16.08.) | 28 | 2 (7,1 %) | 3 |

Jetzt: eigenes Zeitbudget 150 s, Ausgabelänge 5000 Token, beide Werte nebeneinander in `config.js` und **gegeneinander gerechnet** — die Startprüfung wirft, und `mistral-zeitbudget.test.js` wird rot, sobald jemand einen der beiden allein verschiebt.

**Die Fehlererfassung hebelte sich selbst aus.** Die Meldung über eine abgerissene Verbindung ging per `fetch` raus und wurde bei Fehlschlag still verworfen: 30 Tage, zwei Client-Fehler im Bucket, obwohl mehrere gemeldet wurden. Dazu schlug der abgebrochene Lauf keinen Alarm (kein `severity`), während der nebensächliche Ersatz-Werbeaufruf sehr wohl einen auslöste.

**Der Live-Text wurde weggeräumt statt angehalten.** Bei Verbindungsabbruch bleibt er jetzt stehen und wird fortgesetzt. Zwei Zusicherungen als Prüfung: Bereits Gelesenes wird nie umgeschrieben, und es geht wirklich weiter. Dazu der fehlende `online`-Lauscher — die Zusage „erscheint automatisch, sobald du wieder online bist" war ungedeckt.

**Der `localStorage` widersprach der Datenschutzerklärung.** Sie sagt zu, keinen zu nutzen; seit v3.3.0 bekam jeder Besucher `malzime-umschalter-aktiv`. Behoben wurde der Code, nicht der Rechtstext: Beide Erprobungs-Türen des Sprachumschalters sind ersatzlos entfernt. Nachgemessen: **null** `localStorage`-Zugriffe im Frontend, Positivkontrolle findet 23 für `sessionStorage`.

**Die Sprache blieb im alten Tab zurück.** Sechs interne Links öffnen einen neuen Tab, alle auf der Startseite — und ein neuer Tab bekommt einen leeren `sessionStorage`. Die Sprache reist jetzt in der Adresse mit.

**Google Search Console:** `license` und `acquireLicensePage` in den drei `ImageObject`-Blöcken ergänzt. Kein Rechtstext dafür geändert.

## Beweise

```
npm test --prefix functions   -> 49 Suiten, 836 grün, 1 übersprungen
npm run test:frontend         -> 30 Dateien, 406 grün
npx playwright test           -> 76 grün (Rückgabewert 0)
sh scripts/vor-dem-push.sh    -> 13 von 13 grün
```

Rückbauproben rot bestätigt für: die Zeitbudget-Kopplung, die Präfix-Zusicherung des Live-Textes, den `online`-Lauscher, den Sprach-Stempel und dessen Reihenfolge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)