### PR TITLE
chore: Cache-Buster 2026081701, Version 3.3.1 gestempelt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [3.3.1] — 2026-08-17
 
 ### Hinzugefügt
 

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081306" />
+    <link rel="stylesheet" href="./styles.css?v=2026081701" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -177,6 +177,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081306"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081701"></script>
   </body>
 </html>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -44,7 +44,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081306" />
+    <link rel="stylesheet" href="./styles.css?v=2026081701" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -116,6 +116,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081306"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081701"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -82,7 +82,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081306" />
+    <link rel="stylesheet" href="./styles.css?v=2026081701" />
     <script type="application/ld+json">
 [
   {
@@ -312,15 +312,15 @@
         <p class="demo-label" data-i18n="demo.label">Kein Foto zur Hand? Probier ein Beispielbild (mit KI erstellt):</p>
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
-            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081306" data-i18n-src="demo.src.selfie" data-i18n-alt="demo.alt.selfie" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-selfie-thumb.jpg?v=2026081701" data-i18n-src="demo.src.selfie" data-i18n-alt="demo.alt.selfie" alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.selfie">Selfie am Stephansplatz</span>
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
-            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081306" data-i18n-src="demo.src.cafe" data-i18n-alt="demo.alt.cafe" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-cafe-thumb.jpg?v=2026081701" data-i18n-src="demo.src.cafe" data-i18n-alt="demo.alt.cafe" alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.cafe">Im Caf&eacute; in Salzburg</span>
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
-            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081306" data-i18n-src="demo.src.hiker" data-i18n-alt="demo.alt.hiker" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
+            <img src="./img/demo/demo-hiker-thumb.jpg?v=2026081701" data-i18n-src="demo.src.hiker" data-i18n-alt="demo.alt.hiker" alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person." loading="lazy" />
             <span class="demo-caption" data-i18n="demo.hiker">Wanderung bei Hallstatt</span>
           </button>
         </div>
@@ -376,6 +376,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081306"></script>
+    <script type="module" src="./app.js?v=2026081701"></script>
   </body>
 </html>

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -14,7 +14,7 @@ import { logClientError } from "./error-logger.js";
    ausgeschrieben — und wurde vom Deploy prompt selbst überschrieben, weil das
    Muster null Ziffern erlaubte. Beides ist behoben; der Satz nennt das Muster
    trotzdem nicht mehr wörtlich. */
-const DEMO_BUSTER = "?v=2026081306";
+const DEMO_BUSTER = "?v=2026081701";
 
 /* 2026-08-13: Die KI-Kennzeichnung ist in die Pixel gebrannt (Pflicht seit
    08/2026 — ein CSS-Etikett verschwindet, sobald jemand das Bild speichert).

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -16,7 +16,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081306" />
+    <link rel="stylesheet" href="./styles.css?v=2026081701" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -181,6 +181,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081306"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081701"></script>
   </body>
 </html>

--- a/public/stats.html
+++ b/public/stats.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081306" />
+    <link rel="stylesheet" href="./styles.css?v=2026081701" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081306"></script>
+    <script type="module" src="./js/stats.js?v=2026081701"></script>
   </body>
 </html>


### PR DESCRIPTION
Nachtrag zum Deploy vom 17.08.2026.

Der Deploy hat die Cache-Buster gesetzt und ausgeliefert — hier kommen sie in die Historie. Die CHANGELOG-Überschrift wechselt jetzt, nach dem Deployment, von `[Unveröffentlicht]` auf `[3.3.1]`; vorher hätte `release.yml` den Release vor der Auslieferung angelegt.

Live nachgemessen:

```
curl https://malzi.me/ | grep styles.css            -> ?v=2026081701
curl https://malzi.me/ | grep -c acquireLicensePage -> 3
Live-Smoke des Deploy-Skripts                       -> 6 von 6 grün
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)