### PR TITLE
chore: CHANGELOG 3.3.2, Cache-Buster, Buster-Liste bewacht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,87 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [3.3.2] — 2026-08-17
+
+### Hinzugefügt
+
+- **Barrierefreiheitserklärung unter `/barrierefreiheit`.** malziME ist gegen
+  WCAG 2.2 Stufe AA geprüft — messend, nicht behauptend. Von 55 Erfolgskriterien
+  sind 40 nachgewiesen erfüllt, 11 nicht anwendbar, 4 maschinell erfüllt mit
+  offener Handprüfung. Kein Kriterium ist als verletzt festgestellt.
+
+  Die Seite nennt die bekannten Einschränkungen offen: den eingebrannten
+  KI-Hinweis in den Demo-Fotos, die nicht angestrebte Stufe AAA, die fremde
+  Landkarte. Und sie sagt, was **nicht** eingesetzt wird — kein Overlay, kein
+  gekauftes Siegel.
+
+  Drei Rechtsaussagen sind an Primärquellen belegt: die Ausnahme für
+  Kleinstunternehmen nach § 6 Abs. 1 BaFG, das Schlichtungsverfahren beim
+  Sozialministeriumservice (es betrifft das Behindertengleichstellungsrecht,
+  **nicht** das BaFG-Beschwerdeverfahren — die Seite unterscheidet das) und
+  Artikel 50 der EU-KI-Verordnung, gültig seit 2. August 2026.
+
+  Nicht öffentlich, aber vorhanden: das vollständige Prüfprotokoll über alle 55
+  Kriterien mit Prüfweg und Ergebnis je Zeile.
+
+### Behoben — Bedienung mit der Tastatur
+
+- **Der Sprachumschalter war auf Safari mit der Tastatur nicht erreichbar.**
+  WCAG 2.1.1, **Stufe A** — die grundlegendste. Safari springt ohne „Vollzugriff
+  Tastatur" nicht auf Knöpfe; im Projekt gilt deshalb die Regel, dass jedes
+  Bedienelement ein ausdrückliches `tabindex="0"` braucht. Ein Test erzwingt sie
+  seit Langem, aber nur für die statische Startseite. Die Knöpfe des Umschalters
+  entstehen im JavaScript und hatten keines — sieben Stück in zwei Dateien.
+
+  **Warum die Tests das nicht fanden:** Der automatische Tastatur-Durchgang war
+  grün. Playwrights WebKit springt auf Knöpfe unabhängig von Safaris
+  Einstellung — der Test kann diesen Fehler grundsätzlich nicht zeigen. Gefunden
+  hat ihn ein Nutzer in einer Minute.
+
+  Der neue Wächter prüft deshalb die **Struktur** statt das Springen: Trägt jedes
+  sichtbare Bedienelement `tabindex="0"`, nachdem das JavaScript gelaufen ist?
+  Über sechs Seiten, den Umschalter und den geöffneten Dialog.
+
+- **Der Rücksprung zur Startseite war auf allen Unterseiten nicht erreichbar.**
+  Derselbe Grund, fünf Seiten betroffen. Diesen Fall fand der neue Wächter
+  sofort — niemand hatte ihn bemerkt.
+
+### Behoben — Anzeige und Analyse
+
+- **Kein waagrechtes Scrollen mehr bei 320 Pixel** (WCAG 1.4.10). Die
+  Nutzungsbedingungen standen bei 333 Pixel, weil die ODR-Adresse der EU 34
+  Zeichen ohne Leerstelle hat und nicht umbrechen konnte; die Profil-Seite bei
+  324, weil eine Wert-Plakette die Zeile aufschob. Dahinter lag eine dritte
+  Ursache: Die geklebte Umschalt-Leiste zog mit fest verdrahteten 20 Pixeln über
+  den Rand, während die Seitenpolsterung bei schmalen Bildschirmen auf 16 fällt.
+  Beide Werte kommen jetzt aus **einer** Quelle.
+
+- **Jedes Bedienelement hat einen eigenen Fokus-Rahmen.** Auf den Rechtsseiten
+  trugen 7 von 12 bis 20 Elementen nur den Standardrahmen des Browsers. Sichtbar
+  war er, aber sein Aussehen entscheidet jeder Browser selbst.
+
+- **Abkürzungen werden vorgelesen.** EXIF, GPS, DSGVO, KI, IP und PDF tragen nun
+  ihre Langform für Screenreader. Der sichtbare Text ist dabei byte-identisch
+  geblieben — an den Rechtstexten ändert sich optisch nichts.
+
+- **Die eigene KI-Kennzeichnung fließt nicht mehr in die Analyse.** Der Prompt
+  verlangte „jeden sichtbaren Text, auch Bildunterschriften" — die in die
+  Demo-Fotos gebrannte Pflichtkennzeichnung ist eine solche und landete damit in
+  der Profilerstellung. Jetzt zwei Riegel: eine Anweisung im Prompt (deutsch und
+  englisch) und ein Eintrag im bestehenden Wasserzeichen-Filter, der bisher nur
+  fremde Stockfoto-Wasserzeichen kannte.
+
+### Geändert
+
+- **Der Wächter für Barrierefreiheit sah einen ganzen Bildschirmteil nicht.**
+  Sein Testprofil setzte kein `subject`, dadurch erschien der Realitäts-Check
+  nie und wurde nie gemessen.
+
+- **Die Dateiliste des Auslieferungs-Skripts wird gegen die Wirklichkeit
+  geprüft.** Die neue Seite stand nicht darin — ihr Verweis auf das Stilblatt
+  wäre eingefroren, während alle anderen weiterzählen. Zwei feste Listen, die
+  niemand vergleicht, driften gemeinsam ab; jetzt fragt der Test das Dateisystem.
+
 ## [3.3.1] — 2026-08-17
 
 ### Hinzugefügt

--- a/functions/src/__tests__/deploy-buster-script.test.js
+++ b/functions/src/__tests__/deploy-buster-script.test.js
@@ -85,6 +85,7 @@ describe("deploy.sh — Cache-Buster-Ersetzung", () => {
       "public/datenschutz.html",
       "public/impressum.html",
       "public/nutzungsbedingungen.html",
+      "public/barrierefreiheit.html",
       "public/stats.html",
       "public/js/demo.js",
     ];
@@ -93,5 +94,46 @@ describe("deploy.sh — Cache-Buster-Ersetzung", () => {
       if (!fs.existsSync(p)) continue;
       expect(fs.readFileSync(p, "utf8")).not.toMatch(/`\?v=[0-9]+`/);
     }
+  });
+});
+
+/* ── Vollstaendigkeit der Liste ────────────────────────────────────────────
+   OPS-2026-08-17: Die Seite /barrierefreiheit kam neu dazu und stand NICHT in
+   der Dateiliste von deploy.sh. Folge: Ihr Verweis auf das Stilblatt waere auf
+   der Kennung des Tages ihrer Entstehung eingefroren, waehrend alle anderen
+   Seiten weiterzaehlen — nach der naechsten CSS-Aenderung haette sie ein altes
+   Stilblatt aus dem Zwischenspeicher gezogen.
+
+   Aufgefallen ist es dem Nutzer, nicht diesem Test: Er fuehrte bis dahin eine
+   eigene feste Liste und verglich sie mit nichts. Zwei feste Listen, die
+   niemand gegen die Wirklichkeit haelt, driften gemeinsam ab.
+
+   Jetzt wird die Wirklichkeit gefragt: Jede Datei unter public/, die einen
+   Cache-Buster traegt, MUSS im Skript stehen. */
+describe("Cache-Buster: die Dateiliste ist vollstaendig", () => {
+  const { readdirSync, readFileSync } = require("node:fs");
+  const { join } = require("node:path");
+
+  test("jede Datei mit ?v=NNNN steht in der Liste von deploy.sh", () => {
+    const wurzel = join(__dirname, "..", "..", "..");
+    const skript = readFileSync(join(wurzel, "scripts", "deploy.sh"), "utf8");
+
+    const kandidaten = readdirSync(join(wurzel, "public"))
+      .filter((f) => f.endsWith(".html"))
+      .map((f) => "public/" + f)
+      .concat(["public/js/demo.js"]);
+
+    const traegtBuster = kandidaten.filter((rel) => /\?v=\d{6,}/.test(readFileSync(join(wurzel, rel), "utf8")));
+
+    /* POSITIVKONTROLLE: Faende die Suche gar nichts, waere der Test still
+       gruen und wertlos. */
+    /* Jest kennt keine Botschaft als zweites Argument — anders als Playwright.
+       Der erste Anlauf nutzte sie und scheiterte an sich selbst, nicht an der
+       Sache. */
+    expect(traegtBuster.length).toBeGreaterThan(3);
+
+    const fehlend = traegtBuster.filter((rel) => !skript.includes(rel));
+    /* Leer heisst: deploy.sh kennt jede Datei, die einen Buster traegt. */
+    expect(fehlend).toEqual([]);
   });
 });

--- a/public/barrierefreiheit.html
+++ b/public/barrierefreiheit.html
@@ -22,7 +22,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081701" />
+    <link rel="stylesheet" href="./styles.css?v=2026081702" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -235,6 +235,6 @@
     <!-- Diese Seite liegt nur auf Deutsch vor. Der Sprachumschalter zeigt das
          mit einem zweisprachigen Hinweis an. Verschwindet samt
          js/sprachhinweis.js, sobald die Rechtstexte auch auf Englisch da sind. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081701"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081702"></script>
   </body>
 </html>

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -22,7 +22,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081701" />
+    <link rel="stylesheet" href="./styles.css?v=2026081702" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -390,6 +390,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081701"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081702"></script>
   </body>
 </html>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -47,7 +47,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081701" />
+    <link rel="stylesheet" href="./styles.css?v=2026081702" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -145,6 +145,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081701"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081702"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -100,7 +100,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081701" />
+    <link rel="stylesheet" href="./styles.css?v=2026081702" />
     <script type="application/ld+json">
       [
         {
@@ -417,7 +417,7 @@
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
             <img
-              src="./img/demo/demo-selfie-thumb.jpg?v=2026081701"
+              src="./img/demo/demo-selfie-thumb.jpg?v=2026081702"
               data-i18n-src="demo.src.selfie"
               data-i18n-alt="demo.alt.selfie"
               alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person."
@@ -427,7 +427,7 @@
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
             <img
-              src="./img/demo/demo-cafe-thumb.jpg?v=2026081701"
+              src="./img/demo/demo-cafe-thumb.jpg?v=2026081702"
               data-i18n-src="demo.src.cafe"
               data-i18n-alt="demo.alt.cafe"
               alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person."
@@ -437,7 +437,7 @@
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
             <img
-              src="./img/demo/demo-hiker-thumb.jpg?v=2026081701"
+              src="./img/demo/demo-hiker-thumb.jpg?v=2026081702"
               data-i18n-src="demo.src.hiker"
               data-i18n-alt="demo.alt.hiker"
               alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person."
@@ -542,6 +542,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081701"></script>
+    <script type="module" src="./app.js?v=2026081702"></script>
   </body>
 </html>

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -14,7 +14,7 @@ import { logClientError } from "./error-logger.js";
    ausgeschrieben — und wurde vom Deploy prompt selbst überschrieben, weil das
    Muster null Ziffern erlaubte. Beides ist behoben; der Satz nennt das Muster
    trotzdem nicht mehr wörtlich. */
-const DEMO_BUSTER = "?v=2026081701";
+const DEMO_BUSTER = "?v=2026081702";
 
 /* 2026-08-13: Die KI-Kennzeichnung ist in die Pixel gebrannt (Pflicht seit
    08/2026 — ein CSS-Etikett verschwindet, sobald jemand das Bild speichert).

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -22,7 +22,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081701" />
+    <link rel="stylesheet" href="./styles.css?v=2026081702" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -328,6 +328,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081701"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081702"></script>
   </body>
 </html>

--- a/public/stats.html
+++ b/public/stats.html
@@ -25,7 +25,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081701" />
+    <link rel="stylesheet" href="./styles.css?v=2026081702" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -232,6 +232,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081701"></script>
+    <script type="module" src="./js/stats.js?v=2026081702"></script>
   </body>
 </html>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -172,7 +172,7 @@ echo "Cache-Busting-Version: ?v=$VERSION"
 # Fliesstext; der Kommentar ueber DEMO_BUSTER in public/js/demo.js wurde beim
 # Deploy vom 2026-08-12 stillschweigend verunstaltet. [0-9][0-9]* verlangt
 # mindestens eine Ziffer (BRE, kein + — bash 3.2 auf macOS kennt es nicht).
-for f in public/index.html public/datenschutz.html public/impressum.html public/nutzungsbedingungen.html public/stats.html public/js/demo.js; do
+for f in public/index.html public/datenschutz.html public/impressum.html public/nutzungsbedingungen.html public/barrierefreiheit.html public/stats.html public/js/demo.js; do
   if [ -f "$f" ]; then
     # BUG-009: Cross-platform sed (macOS + Linux)
     if sed --version >/dev/null 2>&1; then


### PR DESCRIPTION
Nachtrag zum Deploy von v3.3.2 (Kennung `2026081702`, live nachgemessen).

**Der CHANGELOG-Eintrag hat beim Deploy gefehlt** — die Konvention verlangt ihn vorher. Hier nachgetragen.

**Zweiter Fund dabei:** `public/barrierefreiheit.html` stand nicht in der Dateiliste von `deploy.sh`. Ihr Stilblatt-Verweis wäre eingefroren, während alle anderen weiterzählen. Der bestehende Wächter führte selbst eine feste Liste und verglich sie mit nichts — jetzt fragt er das Dateisystem.

Rückbauprobe: Seite aus der Liste genommen → Test rot, wieder rein → grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)