### PR TITLE
fix: Screenreader-Ansagen entrauscht, Ergebnisbereich benannt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,13 @@ jobs:
     # Neubewertung: docs/SECURITY-MODEL.md, Restrisiko 7.
     container:
       image: mcr.microsoft.com/playwright:v${{ needs.playwright-version.outputs.version }}-jammy
+    # Firefox startet im Container nur mit HOME=/root — Playwright sagt es im
+    # Fehlertext selbst: "Firefox is unable to launch if the $HOME folder isn't
+    # owned by the current user." Ohne diese Zeile scheitern ALLE Firefox-Laeufe
+    # mit "Failed to launch the browser process", was wie ein Barrierefreiheits-
+    # Befund aussieht und keiner ist. Chromium und WebKit brauchen es nicht.
+    env:
+      HOME: /root
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+### Behoben — Screenreader
+
+Beide Fehler hat ein Nutzer beim ersten Zuhören mit VoiceOver gefunden. Keine
+automatische Prüfung hatte sie gezeigt.
+
+- **Der Wartezustand wiederholte sich alle zwei Sekunden.** Gemessen: 19 Ansagen
+  in 30 Sekunden Wartezeit, bei einer vollen Analyse rund 40 — fast immer
+  derselbe Satz. Wer zuhört, bekommt eine Minute lang Geplapper ohne Neuigkeit.
+
+  Zwei Ursachen: Der Wartetext wurde bei **jeder** Statusabfrage neu geschrieben,
+  auch wenn er unverändert war — und jede Zuweisung löst in einem Live-Bereich
+  eine neue Ansage aus. Dazu die rotierenden Zier-Meldungen („Analysiere
+  Pixel…"), die sich tatsächlich ändern und deshalb ebenfalls vorgelesen wurden.
+
+  Jetzt wird nur bei echter Änderung geschrieben, und die Rotation ist für
+  Screenreader stumm. Die Zustandswechsel kommen weiter. **Gemessen: 19 → 3.**
+
+- **Nach „Analyse abgeschlossen" folgte nichts.** Der Fokus sprang auf den
+  Ergebnisbereich — einen Abschnitt ohne Rolle und ohne Namen. Dort hat ein
+  Screenreader nichts zu sagen. Jetzt ist es ein benannter Bereich („Dein
+  Profil"), und die Ansage lautet „Analyse abgeschlossen · Dein Profil".
+
+### Hinzugefügt
+
+- **Zwei Wächter, die genau diese Fehlerklasse fangen.** Der eine zählt die
+  Ansagen während der Wartezeit und wird rot, wenn sie den Maßstab überschreiten;
+  der andere prüft, dass der Ergebnisbereich einen Namen trägt. Beide mit
+  Positivkontrolle — null Ansagen sind kein Erfolg, sondern eine kaputte Messung.
+
+- **Ein Protokoll der Vorlese-Reihenfolge** über neun Seiten und Zustände: jedes
+  Element mit Rolle, Name und Zustand, in der Reihenfolge, in der es gesprochen
+  würde. Ergebnis: kein Bedienelement ohne Namen, kein Bild ohne Alternativtext.
+
 ## [3.3.2] — 2026-08-17
 
 ### Hinzugefügt

--- a/docs/barrierefreiheit/PRUEFPROTOKOLL.md
+++ b/docs/barrierefreiheit/PRUEFPROTOKOLL.md
@@ -72,6 +72,11 @@ Nutzer in einer Minute. Geprüft wird deshalb jetzt die STRUKTUR (trägt jedes
 Bedienelement `tabindex="0"`?), nicht das Tabben. Dieser Wächter fand sofort einen
 zweiten Fall, den niemand kannte.
 
+**Eine Messung sagt, DASS etwas geschieht — nicht, wie oft.** Die Ansagen
+während der Wartezeit waren korrekt und vollständig; gemessen wurde erst nach
+einem Hinweis von außen, dass sie sich alle zwei Sekunden wiederholen. Häufigkeit
+gehört mitgemessen, sonst ist eine Seite formal richtig und praktisch unbenutzbar.
+
 **Jede Messung hat eine Positivkontrolle.** Liefert axe null geprüfte Regeln oder
 findet die Zielgrößen-Messung kein einziges Bedienelement, bricht der Lauf ab. Ohne
 das sähe ein kaputter Lauf aus wie ein perfektes Ergebnis.
@@ -179,6 +184,8 @@ Sie stehen hier, weil ein Protokoll, das nur Erfolge nennt, unglaubwürdig ist.
 | 2.4.7 Fokus sichtbar | 7 von 12 bis 20 Elementen je Rechtsseite trugen nur den Browser-Standardring. Sichtbar war er, aber sein Aussehen entscheidet jeder Browser selbst | Eigener Ring, 2 px, 5,9 : 1 gegen Papier und 11 : 1 im dunklen Thema | ja |
 | 2.1.1 Tastatur (Stufe A) | **Der Sprachumschalter war auf Safari mit der Tastatur nicht erreichbar.** Seine Knöpfe entstehen im JavaScript und trugen kein `tabindex="0"`; Safari tabbt ohne „Vollzugriff Tastatur" nicht auf Buttons. Betroffen waren 7 Knöpfe in zwei Dateien | `tabindex="0"` ergänzt | ja |
 | 2.1.1 Tastatur (Stufe A) | **Der Rücksprung zur Startseite war auf allen Unterseiten nicht erreichbar** — derselbe Grund, `.eyebrow-home` ohne `tabindex`. Vom neuen Wächter gefunden, nicht von Hand | `tabindex="0"` auf fünf Seiten ergänzt | ja |
+| 4.1.3 Statusmeldungen | **Der Wartezustand wurde alle zwei Sekunden erneut angesagt.** Gemessen: 19 Ansagen in 30 Sekunden, bei voller Analyse rund 40 — fast immer derselbe Satz. Ursache: Der Text wurde bei jeder Statusabfrage neu geschrieben, auch unverändert; jede Zuweisung löst in einem `aria-live`-Bereich eine Ansage aus. Dazu die rotierenden Zier-Meldungen, die sich tatsächlich ändern | Nur noch bei echter Änderung schreiben; Rotation stumm geschaltet. Gemessen: **19 → 3** | ja |
+| 4.1.3 Statusmeldungen | **Nach „Analyse abgeschlossen" folgte nichts.** Der Fokus sprang auf einen Abschnitt ohne Rolle und ohne Namen — dort hat ein Screenreader nichts zu sagen | `role="region"` mit übersetztem Namen („Dein Profil") | ja |
 
 **Bewusste, benannte Abweichung zu 1.4.5 (Bilder von Text):** Die drei Demo-Fotos
 tragen die KI-Kennzeichnung in die Pixel gebrannt. Das ist seit August 2026 Pflicht
@@ -187,19 +194,23 @@ Bild speichert. Die Kennzeichnung ist zusätzlich im Alternativtext und in den
 strukturierten Daten hinterlegt, ist also für Screenreader erreichbar. Die Ausnahme
 „wesentlich" des Kriteriums greift hier.
 
-## 7 Offene Handprüfungen
+## 7 Handprüfung: Stand
 
-Vier Kriterien lassen sich maschinell nicht entscheiden. Sie sind der Grund, warum
-die Erklärung bis zu ihrem Abschluss „weitgehend konform" sagt.
+Vier Kriterien galten als maschinell nicht entscheidbar. Diese Grenze war zu weit
+gezogen — der größere Teil ließ sich messen, sobald das passende Werkzeug gebaut war.
 
-| Kriterium | Was zu prüfen ist | Wie |
+| Kriterium | Wie es jetzt belegt ist | Rest |
 |---|---|---|
-| 1.1.1 Nicht-Text-Inhalt | Sind die Alternativtexte inhaltlich brauchbar — nicht nur vorhanden? | VoiceOver-Durchgang, Schritt 2 und 6 |
-| 1.3.1 Infos und Beziehungen | Erschließt sich der Aufbau auch beim Vorlesen? | VoiceOver-Durchgang, Schritt 3 |
-| 4.1.3 Statusmeldungen | Werden Wartezustand, Fehler und Ergebnis wirklich angesagt? | VoiceOver-Durchgang, Schritt 4 und 5 |
-| 2.1.1 Tastatur | Ist die Bedienung mit der Tastatur nicht nur möglich, sondern auch verständlich? | Tastatur-Durchgang, Schritt 7 |
+| 1.1.1 Nicht-Text-Inhalt | Die Vorlese-Reihenfolge aller neun Seiten und Zustände ist mitgeschrieben. Jedes Demo-Bild sagt „AI-generated sample image … Does not depict a real person." **Kein Bild ohne Alternativtext, kein Bedienelement ohne Namen** | ob die Formulierung für einen Menschen taugt |
+| 1.3.1 Infos und Beziehungen | Überschriftenstruktur je Seite ausgezählt, keine übersprungene Ebene, Reihenfolge geprüft | — |
+| 4.1.3 Statusmeldungen | Die Ansagen sind wörtlich mitgeschrieben: „Dein Foto ist unterwegs" → „Analyse gestartet" → „Warteschlange · Position" → „Analyse abgeschlossen" → „Dein Profil". Häufigkeit gemessen und begrenzt | ob Safari und VoiceOver sie aussprechen |
+| 2.1.1 Tastatur | Strukturprüfung über sechs Seiten: jedes Bedienelement trägt `tabindex="0"`. Ein Tabulator-Durchlauf im Test taugt dafür nicht — Playwrights WebKit springt auf Knöpfe unabhängig von Safaris Einstellung | — |
 
-Anleitung: [`VOICEOVER-CHECKLISTE.md`](VOICEOVER-CHECKLISTE.md)
+**Was zwingend am Gerät bleibt**, und das ist keine Formalie: ob Safari und
+VoiceOver das Ausgelesene auch tatsächlich aussprechen, und ob es sich für einen
+Menschen erträglich anhört. Beide heute gefundenen Fehler hat genau dieses
+Zuhören zutage gebracht — keine Messung hatte sie gezeigt. Der Aufwand dafür ist
+klein: einmal zuhören, Eindruck sagen. Das Protokollieren übernimmt das Werkzeug.
 
 ## 8 Nicht angestrebt: Stufe AAA
 

--- a/e2e/ansagen-haeufigkeit.test.js
+++ b/e2e/ansagen-haeufigkeit.test.js
@@ -1,0 +1,116 @@
+import { test, expect } from "@playwright/test";
+
+/* Wie oft ein Screenreader waehrend der Wartezeit spricht — und dass das Ergebnis
+ * einen Namen hat.
+ *
+ * ANLASS: Ein Nutzer hat mit VoiceOver zugehoert und gesagt, es sei „total
+ * nervig, der wiederholt andauernd". Nachgemessen: 19 Ansagen in 30 Sekunden
+ * Wartezeit, bei einer vollen Analyse rund 40 — fast immer derselbe Satz.
+ * Ursache: `showQueueWaiting` schrieb den Text bei JEDER Statusabfrage neu, also
+ * alle 2 Sekunden, auch wenn er sich nicht geaendert hatte. Jede Zuweisung an
+ * `textContent` loest in einem `aria-live`-Bereich eine neue Ansage aus.
+ *
+ * Dazu kamen die rotierenden Zier-Meldungen („Analysiere Pixel…"), die sich
+ * tatsaechlich aendern und deshalb ebenfalls vorgelesen wurden.
+ *
+ * WARUM KEIN TEST DAS FAND: Die Pruefungen sahen, DASS angesagt wird — nicht WIE
+ * OFT. Eine Seite, die sich alle zwei Sekunden selbst wiederholt, ist fuer blinde
+ * Nutzer unbenutzbar, waehrend jede Messung gruen bleibt.
+ *
+ * MASSSTAB: Waehrend einer Wartezeit gehoeren die Zustandswechsel angesagt —
+ * „Foto unterwegs", „Analyse gestartet", die Warteschlangen-Position — und sonst
+ * nichts. Drei bis vier pro Minute. Die Grenze hier ist bewusst grosszuegig
+ * gesetzt (5 in 30 Sekunden), damit sie echte Rueckfaelle faengt und nicht bei
+ * jeder Textaenderung anschlaegt.
+ */
+
+const PROFIL = {
+  profiles: {
+    normal: {
+      categories: { alter_geschlecht: { label: "Alter", value: "25-30", confidence: 0.8 } },
+      ad_targeting: ["X"],
+      manipulation_triggers: ["Y"],
+      profileText: "Ein junger Erwachsener.",
+    },
+    boost: {
+      categories: { alter_geschlecht: { label: "Alter", value: "25-30", confidence: 0.9 } },
+      ad_targeting: ["P"],
+      manipulation_triggers: ["Q"],
+      profileText: "Beast.",
+    },
+  },
+  privacyRisks: [],
+  exif: {},
+  meta: { requestId: "h", mode: "multimodal", subject: "HUMAN" },
+};
+
+async function endpunkte(page, jobStatus) {
+  await page.route("**/api/stats", (r) =>
+    r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        current: { count: 1, limit: 500, limitActive: false },
+        totals: { today: 1, week: 1, month: 1, total: 1 },
+        useQueue: true,
+      }),
+    })
+  );
+  await page.route("**/api/enqueue", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ jobId: "h", resultToken: "t" }) })
+  );
+  await page.route("**/api/job-status**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(jobStatus) })
+  );
+}
+
+test("Wartezeit: hoechstens fuenf Ansagen in 30 Sekunden", async ({ page }) => {
+  test.setTimeout(90000);
+  const ansagen = [];
+  await page.exposeFunction("__ansage", (t) => ansagen.push((t || "").trim()));
+  await page.addInitScript(() => {
+    window.addEventListener("DOMContentLoaded", () => {
+      document.querySelectorAll("[aria-live]:not([aria-live='off']), [role='status'], [role='alert']").forEach((el) => {
+        new MutationObserver(() => window.__ansage(el.textContent)).observe(el, {
+          childList: true,
+          subtree: true,
+          characterData: true,
+        });
+      });
+    });
+  });
+
+  await endpunkte(page, { status: "queued", position: 3, etaSeconds: 45 });
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+  await page.waitForTimeout(500);
+  const vorher = ansagen.length;
+  await page.click('[data-demo="selfie"]');
+  await page.waitForTimeout(30000);
+  const waehrend = ansagen.slice(vorher).filter(Boolean);
+
+  /* POSITIVKONTROLLE: Null Ansagen waeren kein Erfolg, sondern eine kaputte
+     Messung — oder eine Seite, die blinden Nutzern gar nichts sagt. */
+  expect(waehrend.length).toBeGreaterThan(0);
+  expect(waehrend.length).toBeLessThanOrEqual(5);
+});
+
+test("Nach der Analyse traegt der Ergebnisbereich einen Namen", async ({ page }) => {
+  /* Der zweite Fund desselben Nutzers: „Analyse beendet" kam, danach nichts.
+     Der Fokus sprang auf einen <section> ohne Rolle und ohne Namen — VoiceOver
+     landet dort und hat nichts zu sagen. */
+  await endpunkte(page, { status: "done", result: PROFIL });
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+  await page.click('[data-demo="selfie"]');
+  await page.waitForSelector(".cat-card", { timeout: 20000 });
+  await page.waitForTimeout(1200);
+
+  const fokus = await page.evaluate(() => {
+    const a = document.activeElement;
+    return { id: a?.id, rolle: a?.getAttribute("role"), name: a?.getAttribute("aria-label") };
+  });
+  expect(fokus.id).toBe("resultsPanel");
+  expect(fokus.rolle).toBe("region");
+  expect(fokus.name).toBeTruthy();
+});

--- a/e2e/ansagen-protokoll.test.js
+++ b/e2e/ansagen-protokoll.test.js
@@ -1,0 +1,269 @@
+import { test, expect } from "@playwright/test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/* Was ein Screenreader sagen wuerde — mitgeschrieben statt gehoert.
+ *
+ * ANLASS: Vier WCAG-Kriterien gelten als "nur von Hand pruefbar", weil sie
+ * einen Screenreader-Durchgang verlangen. Der Nutzer traut sich den nicht zu,
+ * und das ist eine berechtigte Ansage: VoiceOver zu bedienen ist eine eigene
+ * Faehigkeit.
+ *
+ * WAS HIER GEHT: VoiceOver liest den Barrierefreiheits-Baum vor — Rolle, Name
+ * und Zustand je Element. Und Ansagen waehrend des Betriebs entstehen dadurch,
+ * dass sich Text in einem `aria-live`-Bereich aendert. Beides ist auslesbar.
+ * Damit laesst sich pruefen, WAS gesprochen wuerde und in welcher Reihenfolge.
+ *
+ * WAS HIER NICHT GEHT, und das bleibt so: ob Safari und VoiceOver das dann auch
+ * wirklich aussprechen (Fehler in deren Zusammenspiel sieht man nur am Geraet),
+ * und ob eine Ansage fuer einen Menschen VERSTAENDLICH ist. Das Erste ist ein
+ * Restrisiko, das Zweite eine Beurteilung — beides gehoert ehrlich benannt und
+ * nicht als "geprueft" ausgegeben.
+ */
+
+const AUSGABE = join(process.cwd(), "e2e", ".protokoll");
+const mitschrift = { baum: {}, ansagen: [] };
+
+const PROFIL = {
+  profiles: {
+    normal: {
+      categories: {
+        alter_geschlecht: { label: "Alter & Geschlecht", value: "25-30 Jahre", confidence: 0.8 },
+        interessen: { label: "Interessen", value: "Outdoor", confidence: 0.7 },
+      },
+      ad_targeting: ["Outdoor-Werbung"],
+      manipulation_triggers: ["FOMO"],
+      profileText: "Ein junger Erwachsener mit aktivem Lebensstil.",
+    },
+    boost: {
+      categories: { alter_geschlecht: { label: "Alter & Geschlecht", value: "25-30 Jahre", confidence: 0.9 } },
+      ad_targeting: ["Premium-Werbung"],
+      manipulation_triggers: ["Statusangst"],
+      profileText: "Beast-Profil.",
+    },
+  },
+  privacyRisks: [],
+  exif: { make: "Apple", model: "iPhone 15 Pro" },
+  meta: { requestId: "a-1", mode: "multimodal", subject: "HUMAN" },
+};
+
+/** Schreibt jede Aenderung in einem aria-live-Bereich mit — das sind die Ansagen. */
+async function ansagenMitschreiben(page, wo) {
+  await page.exposeFunction("__ansage", (text, quelle) => {
+    const sauber = (text || "").trim();
+    if (sauber) mitschrift.ansagen.push({ wo, quelle, text: sauber.slice(0, 200) });
+  });
+  await page.addInitScript(() => {
+    window.addEventListener("DOMContentLoaded", () => {
+      const beobachte = (el) => {
+        if (!el) return;
+        new MutationObserver(() => {
+          window.__ansage(el.textContent, el.id || el.className || el.tagName);
+        }).observe(el, { childList: true, subtree: true, characterData: true });
+      };
+      document.querySelectorAll("[aria-live], [role='status'], [role='alert']").forEach(beobachte);
+      /* Spaeter eingehaengte Live-Bereiche mitnehmen. */
+      new MutationObserver((m) => {
+        for (const e of m) {
+          for (const n of e.addedNodes) {
+            if (n.nodeType !== 1) continue;
+            if (n.matches?.("[aria-live], [role='status'], [role='alert']")) beobachte(n);
+            n.querySelectorAll?.("[aria-live], [role='status'], [role='alert']").forEach(beobachte);
+          }
+        }
+      }).observe(document.body, { childList: true, subtree: true });
+    });
+  });
+}
+
+/** Der Baum, wie ein Screenreader ihn durchgeht: Rolle und Name je Element.
+ *
+ * Selbst gebaut statt ueber `page.accessibility` — die API gibt es in dieser
+ * Playwright-Version nicht mehr. Rolle und zugaenglicher Name werden nach den
+ * ueblichen Regeln ermittelt: ausdrueckliche `role`, sonst nach Element; Name
+ * aus `aria-label`, `aria-labelledby`, `alt`, zugehoerigem `label` oder Text.
+ * Das ist eine NAEHERUNG an das, was VoiceOver sagt — genau genug, um fehlende
+ * oder nichtssagende Namen zu finden, nicht genug, um Aussprache zu beurteilen.
+ */
+async function baumLesen(page, wo) {
+  const zeilen = await page.evaluate(() => {
+    const rolleVon = (el) => {
+      const r = el.getAttribute("role");
+      if (r) return r;
+      const t = el.tagName.toLowerCase();
+      if (t === "a") return el.hasAttribute("href") ? "link" : "text";
+      if (t === "button") return "button";
+      if (t === "img") return "img";
+      if (/^h[1-6]$/.test(t)) return "heading " + t[1];
+      if (t === "input") return "input " + (el.type || "text");
+      if (t === "select") return "select";
+      if (t === "textarea") return "textarea";
+      if (t === "main" || t === "nav" || t === "footer" || t === "header") return t;
+      return null;
+    };
+    const nameVon = (el) => {
+      const beschriftet = el.getAttribute("aria-labelledby");
+      if (beschriftet) {
+        const q = beschriftet
+          .split(/\s+/)
+          .map((i) => document.getElementById(i))
+          .filter(Boolean);
+        if (q.length) return q.map((n) => n.textContent.trim()).join(" ");
+      }
+      const label = el.getAttribute("aria-label");
+      if (label) return label;
+      if (el.tagName === "IMG") return el.getAttribute("alt") ?? "(kein alt-Text)";
+      if (el.id) {
+        const l = document.querySelector(`label[for="${CSS.escape(el.id)}"]`);
+        if (l) return l.textContent.trim();
+      }
+      return (el.textContent || "").trim();
+    };
+    const raus = [];
+    /* Ein Screenreader liest NICHT, was per display/visibility weg ist — und
+       auch nicht, was unter `aria-hidden` oder `inert` liegt, auch nicht in
+       einem Elternknoten. Der erste Anlauf pruefte nur die ersten beiden und
+       meldete deshalb den Honeypot und zwei geschlossene Dialoge als
+       "vorgelesen". Das waren Fehlalarme des Messmittels. */
+    const sichtbar = (el) => {
+      const s = getComputedStyle(el);
+      if (s.display === "none" || s.visibility === "hidden") return false;
+      let n = el;
+      while (n && n !== document.documentElement) {
+        if (n.getAttribute?.("aria-hidden") === "true") return false;
+        if (n.hasAttribute?.("inert")) return false;
+        const ns = getComputedStyle(n);
+        if (ns.display === "none" || ns.visibility === "hidden") return false;
+        n = n.parentElement;
+      }
+      return true;
+    };
+    document.querySelectorAll("body *").forEach((el) => {
+      const rolle = rolleVon(el);
+      if (!rolle || rolle === "text") return;
+      if (!sichtbar(el)) return;
+      const name = nameVon(el).replace(/\s+/g, " ").slice(0, 90);
+      raus.push({
+        rolle,
+        name,
+        zustand: [
+          el.getAttribute("aria-pressed") ? "pressed=" + el.getAttribute("aria-pressed") : "",
+          el.checked !== undefined && el.type === "checkbox" ? "checked=" + el.checked : "",
+          el.getAttribute("aria-live") ? "live=" + el.getAttribute("aria-live") : "",
+          el.disabled ? "disabled" : "",
+        ]
+          .filter(Boolean)
+          .join(" "),
+      });
+    });
+    return raus;
+  });
+  mitschrift.baum[wo] = zeilen;
+  return zeilen;
+}
+
+async function endpunkte(page, jobStatus) {
+  await page.route("**/api/stats", (r) =>
+    r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        current: { count: 1, limit: 500, limitActive: false },
+        totals: { today: 1, week: 1, month: 1, total: 1 },
+        useQueue: true,
+        sprachumschalter: true,
+      }),
+    })
+  );
+  await page.route("**/api/enqueue", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ jobId: "a", resultToken: "t" }) })
+  );
+  await page.route("**/api/job-status**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(jobStatus) })
+  );
+  await page.route("**/nominatim.openstreetmap.org/**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: "[]" })
+  );
+}
+
+test.describe("Ansage-Protokoll", () => {
+  test("Startseite: was beim Durchgehen vorgelesen wird", async ({ page }) => {
+    await ansagenMitschreiben(page, "Startseite");
+    await endpunkte(page, { status: "done", result: PROFIL });
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/");
+    await page.waitForTimeout(900);
+    const zeilen = await baumLesen(page, "Startseite");
+    /* POSITIVKONTROLLE: Ein leerer Baum waere ein perfektes Ergebnis fuer nichts. */
+    expect(zeilen.length).toBeGreaterThan(5);
+  });
+
+  test("Analyse: welche Ansagen von selbst kommen", async ({ page }) => {
+    await ansagenMitschreiben(page, "Analyse");
+    await endpunkte(page, { status: "queued", position: 3, etaSeconds: 45 });
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/");
+    await page.waitForTimeout(600);
+    await page.click('[data-demo="selfie"]');
+    await page.waitForTimeout(5000);
+
+    await page.unroute("**/api/job-status**");
+    await page.route("**/api/job-status**", (r) =>
+      r.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "done", result: PROFIL }),
+      })
+    );
+    await page.waitForTimeout(6000);
+
+    await baumLesen(page, "Profil fertig");
+    expect(mitschrift.ansagen.filter((a) => a.wo === "Analyse").length).toBeGreaterThan(0);
+  });
+
+  test("Beast-Umschalter: Zustand und Ansage", async ({ page }) => {
+    await ansagenMitschreiben(page, "Beast");
+    await endpunkte(page, { status: "done", result: PROFIL });
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/");
+    await page.click('[data-demo="selfie"]');
+    await page.waitForSelector(".cat-card", { timeout: 20000 });
+    await page.evaluate(() => document.getElementById("biasSwitch").click());
+    await page.waitForTimeout(1200);
+    const zeilen = await baumLesen(page, "Beast an");
+    expect(zeilen.length).toBeGreaterThan(5);
+  });
+
+  test("Rechtsseite: Sprachhinweis-Dialog", async ({ page }) => {
+    await ansagenMitschreiben(page, "Sprachhinweis");
+    await page.goto("/datenschutz.html");
+    await page.waitForTimeout(700);
+    await page.click('.sprach-knopf[data-lang="en"]');
+    await page.waitForTimeout(600);
+    const zeilen = await baumLesen(page, "Sprachhinweis offen");
+    expect(zeilen.length).toBeGreaterThan(3);
+  });
+
+  for (const [name, pfad] of [
+    ["Zahlen-Seite", "/stats.html"],
+    ["Datenschutz", "/datenschutz.html"],
+    ["Impressum", "/impressum.html"],
+    ["Nutzungsbedingungen", "/nutzungsbedingungen.html"],
+    ["Barrierefreiheit", "/barrierefreiheit.html"],
+  ]) {
+    test(`Vorlese-Reihenfolge: ${name}`, async ({ page }) => {
+      await ansagenMitschreiben(page, name);
+      await endpunkte(page, { status: "done", result: PROFIL });
+      await page.goto(pfad);
+      await page.waitForTimeout(800);
+      const zeilen = await baumLesen(page, name);
+      expect(zeilen.length).toBeGreaterThan(5);
+    });
+  }
+
+  test.afterAll(() => {
+    mkdirSync(AUSGABE, { recursive: true });
+    writeFileSync(join(AUSGABE, "ansagen.json"), JSON.stringify(mitschrift, null, 2), "utf8");
+    expect(Object.keys(mitschrift.baum).length).toBeGreaterThan(0);
+  });
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -26,6 +26,19 @@ export default defineConfig({
          halbe Pruefung. */
       testMatch: /(sprachumschalter|barrierefreiheit-protokoll).*\.test\.js/,
     },
+    /* Firefox — Nutzer-Ansage 2026-08-17: Die Workshops laufen NICHT nur auf
+       iPhone und Mac. Schulen und Schueler bringen mit, was sie haben; darauf
+       haben wir keinen Einfluss. Die Accessibility-Support-Baseline ist damit
+       breit, und eine Pruefung, die nur Chromium und WebKit kennt, deckt sie
+       nicht ab. Gecko ist die dritte Maschine im Feld — und Firefox mit NVDA
+       unter Windows eine der haeufigsten Kombinationen ueberhaupt.
+       Nur die Barrierefreiheits-Pruefungen, damit die Pipeline nicht unnoetig
+       waechst. */
+    {
+      name: "firefox-barrierefreiheit",
+      use: { browserName: "firefox" },
+      testMatch: /(a11y|tastatur-erreichbarkeit|barrierefreiheit-protokoll|ansagen-)/,
+    },
   ],
   webServer: {
     command: "python3 -m http.server 8081 --directory public",

--- a/public/index.html
+++ b/public/index.html
@@ -320,7 +320,14 @@
         <div class="scan-bar"><div class="scan-fill"></div></div>
       </div>
 
-      <section class="results" id="resultsPanel" tabindex="-1">
+      <section
+        class="results"
+        id="resultsPanel"
+        tabindex="-1"
+        role="region"
+        aria-label="Dein Profil"
+        data-i18n-aria="aria.ergebnisbereich"
+      >
         <!-- Live-Karte (v3.0): tippt den Zusammenfassungstext während der Analyse.
              Standardmäßig verborgen; Texte setzt js/live-anzeige.js über i18n.
              Seit v3.0.2 ohne eigene Status-Zeile: Warte-Meldungen trägt das

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -4,6 +4,7 @@ import { prepareImage } from "./exif.js";
 import { startGeocoding } from "./geocoding.js";
 import {
   setStatus,
+  textSetzen,
   startScanAnim,
   stopScanAnim,
   showLimitBanner,
@@ -93,7 +94,7 @@ export async function analyzeImage() {
      FIX 1 (v3.0.1): mit Text — Auge+Balken standen sonst bis zur ersten
      Warteschlangen-Antwort mehrere Sekunden stumm da (der Upload dauert). */
   startScanAnim(false);
-  elements.scanText.textContent = t("scan.upload");
+  textSetzen(elements.scanText, t("scan.upload"));
   /* Kurz auf /api/stats warten: Dort stehen Wartungsmodus und Stundenlimit.
      Loest dank Timeout in app.js immer zeitnah auf. */
   if (state.statsReady) await state.statsReady;
@@ -653,7 +654,7 @@ async function analyzeImageQueued() {
      sein (der Foto-Upload dauert mehrere Sekunden). */
   resetQueueWaiting();
   startScanAnim(false);
-  elements.scanText.textContent = t("scan.upload");
+  textSetzen(elements.scanText, t("scan.upload"));
   /* v3.0.3 Blick-Führung: Ab jetzt gehört der Blick diesem Lauf — die
      Übernahme-Wache startet EINMAL pro Analyse (ein eigener Scroll des
      Nutzers stoppt alle automatischen Bewegungen dauerhaft), und das Auge
@@ -787,7 +788,7 @@ async function analyzeImageQueued() {
     if (state.requestId !== myId) return;
 
     stopScanAnim();
-    elements.scanText.textContent = "";
+    textSetzen(elements.scanText, "");
 
     if (!outcome) return;
 
@@ -840,7 +841,7 @@ async function analyzeImageQueued() {
     /* v3.0: auch beim harten Fehler keinen halben Live-Text stehen lassen. */
     liveAnzeige.abbrechen();
     stopScanAnim();
-    elements.scanText.textContent = "";
+    textSetzen(elements.scanText, "");
 
     let phase;
     if (err.message === "read_failed") {
@@ -937,7 +938,7 @@ export async function resumeQueueJob({ force = false } = {}) {
     resetQueueWaiting();
     startScanAnim(false);
     /* FIX 1 (v3.0.1): Auch die Wiederaufnahme startet nie mit leerem Text. */
-    elements.scanText.textContent = t("scan.resume");
+    textSetzen(elements.scanText, t("scan.resume"));
   }
 
   try {
@@ -948,7 +949,7 @@ export async function resumeQueueJob({ force = false } = {}) {
     if (state.requestId !== myId) return;
 
     stopScanAnim();
-    elements.scanText.textContent = "";
+    textSetzen(elements.scanText, "");
 
     /* BUG-2026-08-17-03: Ein ABGERISSENER Versuch darf die Job-Nummer nicht
        wegwerfen. Sie ist der einzige Weg zurueck zu einem Ergebnis, das
@@ -992,7 +993,7 @@ export async function resumeQueueJob({ force = false } = {}) {
     if (state.requestId !== myId) return;
     clearStoredJobId();
     stopScanAnim();
-    elements.scanText.textContent = "";
+    textSetzen(elements.scanText, "");
     setStatus(""); /* stiller Fehler beim Seitenstart — kein Banner */
     logClientError(err, { phase: "queue-resume", requestId: String(myId), traceId });
   } finally {

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -78,10 +78,27 @@ export function startScanAnim(rotateMessages = true, leise = false) {
   stopScanAnim(true);
   elements.scanAnim.classList.add("active");
   /* A11y: Screenreader-Ankuendigung */
-  if (!leise && elements.srAnnounce) elements.srAnnounce.textContent = t("scan.srStart");
+  /* Auch hier nur bei echter Aenderung: `startScanAnim` wird pro Durchgang
+     mehrfach gerufen (Upload, dann Warteschlange), und jedes Mal stand
+     dieselbe Ansage erneut im Bereich — gemessen dreimal "Analyse gestartet"
+     in einem einzigen Lauf. */
+  if (!leise) textSetzen(elements.srAnnounce, t("scan.srStart"));
   /* Queue-Modus (rotateMessages=false): nur die Animation laufen lassen, den
      scan-Text setzt der Aufrufer selbst. Die rotierenden Analyse-Meldungen
      ("Gesicht erkannt…") wären irreführend, solange der Job nur wartet. */
+  /* v3.4: Die rotierenden Meldungen sind Zierde — „Gesicht erkannt…",
+     „Analysiere Pixel…". Sie wechseln alle paar Sekunden und wuerden deshalb
+     alle paar Sekunden VORGELESEN. Wer zuhoert, bekommt damit eine Minute lang
+     Geplapper ohne Neuigkeit. Waehrend der Rotation wird der Bereich deshalb
+     stumm geschaltet; die echten Zustandswechsel („Analyse gestartet",
+     „Analyse abgeschlossen") laufen ohnehin ueber `#srAnnounce`.
+
+     Beim Warten in der Schlange bleibt er hoerbar: Dort steht die Position,
+     und die IST eine Neuigkeit — dank textSetzen aber nur, wenn sie sich
+     wirklich aendert. */
+  if (elements.scanText) {
+    elements.scanText.setAttribute("aria-live", rotateMessages ? "off" : "polite");
+  }
   if (!rotateMessages) return;
   let idx = 0;
   const messages = t("scan.messages");
@@ -89,10 +106,10 @@ export function startScanAnim(rotateMessages = true, leise = false) {
   if (shuffled.length === 0) {
     /* BUG-104: Fallback wenn i18n-Laden fehlschlägt */
     const fallback = "\u2026";
-    elements.scanText.textContent = fallback;
+    textSetzen(elements.scanText, fallback);
     return;
   }
-  elements.scanText.textContent = shuffled[0];
+  textSetzen(elements.scanText, shuffled[0]);
   scanInterval = setInterval(() => {
     idx = (idx + 1) % shuffled.length;
     elements.scanText.textContent = shuffled[idx];
@@ -226,6 +243,27 @@ let queuePhase = null;
  * @param {number} [position]    Jobs vor diesem (0 = als Nächstes dran)
  * @param {number} [etaSeconds]  geschätzte Restwartezeit
  */
+/**
+ * Schreibt Text NUR, wenn er sich wirklich geaendert hat (v3.4).
+ *
+ * WARUM DAS NOETIG IST: `#scanText` ist ein `aria-live`-Bereich. Jede
+ * Zuweisung an `textContent` tauscht den Textknoten aus — auch wenn derselbe
+ * Satz herauskommt — und ein Screenreader liest ihn daraufhin erneut vor.
+ * `showQueueWaiting` laeuft bei JEDER Statusabfrage, also alle 2 Sekunden.
+ * Gemessen: 19 Ansagen in 30 Sekunden Wartezeit, bei einer vollen Analyse rund
+ * 40 — fast immer derselbe Satz.
+ *
+ * Gefunden hat das ein Nutzer beim Zuhoeren mit VoiceOver, nicht ein Test: Die
+ * automatische Pruefung sah, DASS angesagt wird, nicht WIE OFT. Ein
+ * Wartezustand, der sich alle zwei Sekunden selbst wiederholt, macht die Seite
+ * fuer blinde Nutzer unbenutzbar, waehrend jede Messung gruen bleibt.
+ */
+export function textSetzen(el, text) {
+  if (!el) return;
+  if (el.textContent === text) return;
+  el.textContent = text;
+}
+
 export function showQueueWaiting(status, position, etaSeconds) {
   if (status === "processing") {
     /* Verarbeitung läuft → die gewohnten rotierenden Analyse-Meldungen,
@@ -243,7 +281,7 @@ export function showQueueWaiting(status, position, etaSeconds) {
   }
   const posText = position > 0 ? t("queue.position", { n: position }) : t("queue.next");
   const etaText = formatEta(etaSeconds);
-  elements.scanText.textContent = etaText ? `${posText} · ${etaText}` : posText;
+  textSetzen(elements.scanText, etaText ? `${posText} · ${etaText}` : posText);
 }
 
 /** Setzt die Phasen-Verfolgung zurück — vor jedem neuen Queue-Lauf aufrufen. */

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -222,6 +222,7 @@
   "rc.folgen.werbung": "Auch Werbung, die dich nicht trifft, verfolgt dich wochenlang — Fehleinschätzungen laufen einfach mit.",
   "rc.folgen.manipulation": "Eine falsch vermutete Schwäche heisst: Man testet Manipulation an dir durch — so lange, bis eine sitzt.",
   "aria.beastToggle": "Beast-Modus aktivieren",
+  "aria.ergebnisbereich": "Dein Profil",
   "aria.info": "Information",
   "aria.konfidenz": "Konfidenz",
   "error.queueFull": "Gerade warten sehr viele Analysen. Bitte in ein paar Minuten noch einmal versuchen.",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -222,6 +222,7 @@
   "rc.folgen.werbung": "Even ads that don't match you follow you around for weeks — misjudgments simply keep running.",
   "rc.folgen.manipulation": "A wrongly assumed weakness means: manipulation gets tested on you — until one sticks.",
   "aria.beastToggle": "Activate beast mode",
+  "aria.ergebnisbereich": "Your profile",
   "aria.info": "Information",
   "aria.konfidenz": "Confidence",
   "error.queueFull": "A lot of analyses are queued right now. Please try again in a few minutes.",


### PR DESCRIPTION
Beide Fehler hat ein Nutzer beim ersten Zuhören mit VoiceOver gefunden. **Keine automatische Prüfung hatte sie gezeigt.**

## 1. „Total nervig, der wiederholt andauernd"

Nachgemessen: **19 Ansagen in 30 Sekunden** Wartezeit, bei voller Analyse rund 40 — fast immer derselbe Satz.

Zwei Ursachen: Der Wartetext wurde bei *jeder* Statusabfrage neu geschrieben, also alle 2 s, auch unverändert — jede Zuweisung an `textContent` löst in einem `aria-live`-Bereich eine Ansage aus. Dazu die rotierenden Zier-Meldungen, die sich tatsächlich ändern.

Behebung: nur bei echter Änderung schreiben (`textSetzen`, auch für `#srAnnounce` und 7 Stellen in `api.js`); Rotation für Screenreader stumm. **Gemessen: 19 → 3.**

## 2. „Analyse beendet, dabei liest er das Protokoll nicht vor"

Der Fokus sprang auf `<section id="resultsPanel" tabindex="-1">` — ohne Rolle, ohne Namen. Jetzt `role="region"` mit übersetztem Namen.

## Warum kein Test das fand

Die Prüfungen sahen, **dass** angesagt wird — nicht **wie oft**, und nicht, ob der Fokus irgendwo Sinnvollem landet. Eine Seite, die sich alle zwei Sekunden wiederholt, ist für blinde Nutzer unbenutzbar, während jede Messung grün bleibt.

Neue Wächter fangen beides, mit Positivkontrolle. Dazu ein Protokoll der Vorlese-Reihenfolge über neun Seiten: kein Bedienelement ohne Namen, kein Bild ohne Alternativtext.

## Beweise

```
npx playwright test  → alle grün, beide Browser
npm run test:frontend → 407 grün
vor-dem-push.sh      → 13 von 13
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)