### PR TITLE
docs+fix: Prüfbericht nach WCAG-EM 2.0, Abstentionen werden aufgelöst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,25 @@ automatische Prüfung hatte sie gezeigt.
   Screenreader nichts zu sagen. Jetzt ist es ein benannter Bereich („Dein
   Profil"), und die Ansage lautet „Analyse abgeschlossen · Dein Profil".
 
+### Behoben — Barrierefreiheit
+
+- **Das Info-Zeichen neben den beiden Profil-Modi war zu blass.** Es stand auf
+  55 % Deckkraft: gemessen 2,18 : 1, verlangt sind 4,5 : 1 für den Buchstaben
+  und 3 : 1 für den Kreisrand eines Bedienelements. Beim Überfahren mit der Maus
+  wurde es voll deckend — was nichts hilft, wenn man mit der Tastatur oder am
+  Finger arbeitet und gar nicht darüberfährt.
+
+  Die Deckkraft im Ruhezustand ist entfernt, der Aufhell-Effekt läuft jetzt über
+  die Farbe. Gemessen 5,22 : 1 im hellen und 7,85 : 1 im dunklen Erscheinungsbild.
+
+  Gefunden hat den Fehler kein Prüfwerkzeug: axe konnte den Fall nicht
+  entscheiden und meldete ihn als „unprüfbar". Solche Abstentionen wurden bisher
+  notiert und nie aufgelöst. Jetzt löst eine Bildpunkt-Messung jede einzelne auf
+  — das Element wird fotografiert und Punkt für Punkt nachgerechnet.
+
+- **Die Trennpunkte in der Fußzeile werden Screenreadern nicht mehr vorgelesen.**
+  Sie sind reine Zierde und stehen zwischen Links, die ohnehin getrennt sind.
+
 ### Hinzugefügt
 
 - **Zwei Wächter, die genau diese Fehlerklasse fangen.** Der eine zählt die
@@ -199,10 +218,10 @@ automatische Prüfung hatte sie gezeigt.
   zum letzten Zeichen — und schaltete damit eine seit Mai schlafende Grenze zum
   ersten Mal wirksam:
 
-  | Zeitraum | Läufe | technische Fehler | Läufe über 90 s |
-  |---|---|---|---|
-  | vor v3.0.0 (19.07.–11.08.) | 121 | 0 | 8 — **alle wurden fertig** |
-  | nach v3.0.0 (11.08.–16.08.) | 28 | 2 (7,1 %) | 3 |
+  | Zeitraum                    | Läufe | technische Fehler | Läufe über 90 s            |
+  | --------------------------- | ----- | ----------------- | -------------------------- |
+  | vor v3.0.0 (19.07.–11.08.)  | 121   | 0                 | 8 — **alle wurden fertig** |
+  | nach v3.0.0 (11.08.–16.08.) | 28    | 2 (7,1 %)         | 3                          |
 
   Jetzt hat der Single-Large-Aufruf ein eigenes, gemessenes Zeitbudget (150 s
   statt 90 s), und die Textmenge ist auf 5000 Token gesetzt — reichlich über dem
@@ -515,12 +534,14 @@ Server, keine IP-Logs, Firestore nur EU, Löschkette wirkt). Kaputt waren die
 **Wächter** darüber und die **Auslieferungskette**.
 
 ### Der schwerste Fund (P0)
+
 - Der Deploy-Riegel, der vor jeder Auslieferung die EU-Region und „gelöscht heißt
   gelöscht" des Bild-Buckets prüft, **konnte nicht rot werden** — ein
   Index-Verwechsler (`PIPESTATUS[0]` = printf statt `[1]` = python3) machte den
   Fehlerzweig rechnerisch tot. Behoben; der Riegel hat jetzt eine Negativprobe.
 
 ### Die Auslieferungskette (P1)
+
 - **Deploy an keinen geprüften Stand gebunden:** `deploy.sh` lieferte den
   Arbeitsbaum aus und prüfte weniger als die sechs CI-Pflicht-Checks. Jetzt an die
   CI-Freigabe gebunden (sauberer Baum, `HEAD == origin/main`, alle sechs Checks
@@ -533,6 +554,7 @@ Server, keine IP-Logs, Firestore nur EU, Löschkette wirkt). Kaputt waren die
   neue Dateien, Alarmfilter-Abdeckung, CHANGELOG-Parser kennt Code-Zäune.
 
 ### Sicherheit (P2, alle live)
+
 - **Boost-Deckel jetzt atomar** (Transaktion statt offenem get+set) — die einzige
   globale Kostenbremse hält unter gleichzeitigen Aufrufen.
 - **Statusabruf drosselt den Schreibzugriff** (~93 % weniger unauthentifizierte
@@ -543,6 +565,7 @@ Server, keine IP-Logs, Firestore nur EU, Löschkette wirkt). Kaputt waren die
   gezählt; der Wächter über die Wochen-Erinnerung ist nicht mehr blind.
 
 ### Frontend (P2/P3, live)
+
 - **Barrierefreiheit:** vier Bedien-Beschriftungen (Beast-Umschalter, Info,
   Konfidenz-Punkte) sind wieder übersetzbar — ein Rückfall, den ab jetzt ein Test
   verhindert.
@@ -552,6 +575,7 @@ Server, keine IP-Logs, Firestore nur EU, Löschkette wirkt). Kaputt waren die
   dreimal probiert"; ein fehlgeschlagener Demo-Abruf scheitert nicht mehr lautlos.
 
 ### Außentexte (P2/P3, live)
+
 - Formulierungen, die mehr versprachen als das System hält, an ihrem Belegort
   korrigiert: der Analyse-Zähler („Zählwerte je Zeitraum" statt „eine einzige
   Zahl"), die sessionStorage-Ausnahme („einzige" → vier Verwendungen aufgezählt),
@@ -559,6 +583,7 @@ Server, keine IP-Logs, Firestore nur EU, Löschkette wirkt). Kaputt waren die
   neue Sperrlisten-Regeln verhindern den Rückfall.
 
 ### Demo-Bilder auf Englisch gekennzeichnet
+
 - Die KI-Kennzeichnung ist in die Bildpixel gebrannt (Pflicht seit 08/2026 — ein
   Etikett per CSS verschwindet, sobald jemand das Bild speichert oder weitergibt).
   Ein gebranntes Zeichen kann aber nicht mitübersetzen: Bei englischer Oberfläche
@@ -572,6 +597,7 @@ Server, keine IP-Logs, Firestore nur EU, Löschkette wirkt). Kaputt waren die
   deckt beide Sätze automatisch ab (12 statt 6 Bilder geprüft).
 
 ### Weitere Korrekturen
+
 - **Transparenz:** Die Datenschutzerklärung benennt jetzt, dass die KI bewusst
   sensible, dem Aussehen zugeschriebene Merkmale rät (scheinbare Herkunft, Hautton) —
   genau das, was das Werkzeug vorführt.
@@ -877,9 +903,6 @@ fünf Stellen verletzt — sie stand eben nur als Prosa da und lief nirgends als
   überhaupt da ist. Beim nächsten Auftreten steht die Ursache in der Meldung, statt eine
   Stunde zu kosten.
 
-
-
-
 ## [3.0.6] — 2026-08-12
 
 **Erinnerung an die ZDR-Nachprüfung — und die Ursache für ausbleibende
@@ -897,7 +920,7 @@ Handy-Mitteilungen:**
   Fristdefinition — die Frist steht nur an einer Stelle im Code.
 - **Behoben: iOS-Mitteilungen kamen nie an.** Ein selbst betriebener
   Push-Server kann iPhones nur über den Dienst ntfy.sh erreichen. Diese
-  Weiterleitung passiert erst *nach* der Antwort an den Absender — und genau
+  Weiterleitung passiert erst _nach_ der Antwort an den Absender — und genau
   dann entzog die Cloud-Plattform dem Programm standardmäßig die Rechenzeit.
   Die Weiterleitung lief still in eine Zeitüberschreitung: Die Meldung lag auf
   dem Server, aber das Handy erfuhr nichts davon. Mit dauerhaft zugeteilter
@@ -1210,14 +1233,14 @@ Auf einem iPhone erschien wiederholt Safaris Meldung „Auf https://malzi.me/ is
 wiederholt ein Problem aufgetreten". **Sechs Erklärungen wurden geprüft und
 alle sechs ausgeschlossen:**
 
-| Vermutung | Ergebnis |
-|---|---|
-| 2-Stunden-Frist der Aufträge | wird sauber abgefangen, stille Aufräumung |
-| Neulade-Schleife am Stundenlimit | Limit stand bei 0 von 500 |
-| Absturz beim Laden der Sprachdatei | ist abgefangen, läuft mit Ersatztexten weiter |
-| Foto als Speicherfresser | liegt als Verweis im Fenster, nicht als Zeichenkette |
-| Abfrage-Schleife und Wartefunktion | beide sauber begrenzt und aufgeräumt |
-| DNS-Ausfall desselben Tages | zeitlich ausgeschlossen |
+| Vermutung                          | Ergebnis                                             |
+| ---------------------------------- | ---------------------------------------------------- |
+| 2-Stunden-Frist der Aufträge       | wird sauber abgefangen, stille Aufräumung            |
+| Neulade-Schleife am Stundenlimit   | Limit stand bei 0 von 500                            |
+| Absturz beim Laden der Sprachdatei | ist abgefangen, läuft mit Ersatztexten weiter        |
+| Foto als Speicherfresser           | liegt als Verweis im Fenster, nicht als Zeichenkette |
+| Abfrage-Schleife und Wartefunktion | beide sauber begrenzt und aufgeräumt                 |
+| DNS-Ausfall desselben Tages        | zeitlich ausgeschlossen                              |
 
 ### Warum Raten hier nicht weiterführt
 
@@ -1325,11 +1348,11 @@ nicht** — der Schalter steht weiterhin auf der alten Datenbank.
 Betroffen ist **ausschliesslich die Firestore-Datenbank**, nicht die Speicherorte
 insgesamt. Zur Klarstellung, weil das leicht verwechselt wird:
 
-| | Standort | betroffen? |
-|---|---|---|
+|                                     | Standort       | betroffen?                   |
+| ----------------------------------- | -------------- | ---------------------------- |
 | **Fotos** (`malzime-queue-uploads`) | `europe-west1` | nein — lagen immer in Europa |
-| Quellstände der Functions | `europe-west1` | nein |
-| **Firestore-Datenbank** | `nam5` (USA) | **ja — darum geht es hier** |
+| Quellstände der Functions           | `europe-west1` | nein                         |
+| **Firestore-Datenbank**             | `nam5` (USA)   | **ja — darum geht es hier**  |
 
 Die hochgeladenen Bilder haben Europa also zu keinem Zeitpunkt verlassen. Das
 wurde an der Infrastruktur nachgemessen, nicht aus dem Quelltext geschlossen.
@@ -1638,7 +1661,7 @@ Audits sind.
 
 - **Der Kinderschutz-Filter schneidet nicht mehr bei exakt 18.** Er nimmt jetzt die **Untergrenze** der Altersspanne, die das Modell selbst liefert — wer „16-22" sein könnte, gilt als schutzbedürftig — und darauf drei Jahre Sicherheitsabstand. Anlass: Aus rund 5.000 begleiteten Workshop-Analysen ist bekannt, dass Mädchen bis zu sechs Jahre zu alt geschätzt werden. Mit einer harten 18er-Grenze verlor damit ausgerechnet ein zu alt geschätztes vierzehnjähriges Mädchen den Schutz vor Glücksspiel-, Alkohol-, Kredit- und Diätwerbung — im Klassenzimmer, an die Wand projiziert. Der Preis ist bewusst in Kauf genommen: Ein tatsächlich Neunzehn- bis Einundzwanzigjähriger sieht diese Werbung nicht mehr, obwohl sie dort legitimer Lerninhalt wäre. Die Abwägung ist asymmetrisch — eine Vierzehnjährige mit Glücksspielwerbung ist ein Schaden, einem Neunzehnjährigen fehlt ein Beispiel. (`minor-safety.js`)
 
-- **Altersmerkmale für Kinder und Jugendliche, die bei beiden Geschlechtern gleich schnell laufen.** Vorher war die *primäre* Alters-Achse die **Schulterbreite**, dazu kam eine Zusatzregel, die nur für Mädchen galt („Mädchen erreichen diese Spanne oft ohne Akne und Bartflaum"). Beides hängt an der Pubertät, und die beginnt zwischen 8 und 14 Jahren, bei Mädchen im Schnitt zwei Jahre früher. Wer daran das Alter misst, schätzt Mädchen zwangsläufig zu alt und Jungen zu jung — das aus der Praxis berichtete Muster stand also wörtlich in der eigenen Anweisung. Neu sind Augenlinie im Kopf, Zahnstand, Wangenfett, Nasenrücken und Kopf-Körper-Verhältnis; Reifemerkmale sind ausdrücklich als untauglich benannt, mit Begründung. **Kein Ausgleich, keine Korrekturzahl** — nur bessere Merkmale. Bei Erwachsenen gelten fehlende Falten nicht mehr als Beleg für Jugend: Bei Mimik, Make-up oder flachem Gegenlicht entscheiden Hals, Hände und Haaransatz, und die Alters-Skala ist neu geeicht (18-30 / 30-42 / 40-52 / 50-62 / 60+).
+- **Altersmerkmale für Kinder und Jugendliche, die bei beiden Geschlechtern gleich schnell laufen.** Vorher war die _primäre_ Alters-Achse die **Schulterbreite**, dazu kam eine Zusatzregel, die nur für Mädchen galt („Mädchen erreichen diese Spanne oft ohne Akne und Bartflaum"). Beides hängt an der Pubertät, und die beginnt zwischen 8 und 14 Jahren, bei Mädchen im Schnitt zwei Jahre früher. Wer daran das Alter misst, schätzt Mädchen zwangsläufig zu alt und Jungen zu jung — das aus der Praxis berichtete Muster stand also wörtlich in der eigenen Anweisung. Neu sind Augenlinie im Kopf, Zahnstand, Wangenfett, Nasenrücken und Kopf-Körper-Verhältnis; Reifemerkmale sind ausdrücklich als untauglich benannt, mit Begründung. **Kein Ausgleich, keine Korrekturzahl** — nur bessere Merkmale. Bei Erwachsenen gelten fehlende Falten nicht mehr als Beleg für Jugend: Bei Mimik, Make-up oder flachem Gegenlicht entscheiden Hals, Hände und Haaransatz, und die Alters-Skala ist neu geeicht (18-30 / 30-42 / 40-52 / 50-62 / 60+).
 
 - **KI-Kennzeichnung auf den drei Demo-Fotos.** Sie sind KI-generiert (`public/img/demo/LICENSE.md`) und fallen unter die seit August 2026 geltende Kennzeichnungspflicht. Sichtbar in die Pixel gebrannt („KI ERSTELLT", rechts unten), maschinenlesbar über `DigitalSourceType = trainedAlgorithmicMedia` (offizieller IPTC-Wert für vollständig algorithmisch erzeugte Bilder) und für Suchmaschinen über strukturierte Daten, alt-Texte und den Hinweis „(mit KI erstellt)" in beiden Sprachen. Bewusst kein reines CSS-Overlay: Das verschwindet, sobald jemand das Bild speichert oder weitergibt. Werkzeug: `scripts/ki-wasserzeichen.mjs`.
 
@@ -1666,14 +1689,14 @@ Audits sind.
 
 84 Analysen über 14 Fotos, drei Läufe je Bild, gegen die am 2026-08-10 geprüfte und korrigierte Wahrheitsliste:
 
-| Größe | vorher | v2.9.0 |
-|---|---|---|
-| Abweichung Kinder/Jugendliche | 0,8 J | 0,8 J |
-| Abweichung Erwachsene | −7,2 J | −6,5 J |
-| Antworten mit konkretem, zeigbarem Merkmal | 95 % | **100 %** |
-| Antworten mit Leerformel | 43 % | **38 %** |
-| Geschlecht richtig | 85,7 % | 85,7 % |
-| Parse-Fehler / abgeschnittene Antworten | 0 / 0 | 0 / 0 |
+| Größe                                      | vorher | v2.9.0    |
+| ------------------------------------------ | ------ | --------- |
+| Abweichung Kinder/Jugendliche              | 0,8 J  | 0,8 J     |
+| Abweichung Erwachsene                      | −7,2 J | −6,5 J    |
+| Antworten mit konkretem, zeigbarem Merkmal | 95 %   | **100 %** |
+| Antworten mit Leerformel                   | 43 %   | **38 %**  |
+| Geschlecht richtig                         | 85,7 % | 85,7 %    |
+| Parse-Fehler / abgeschnittene Antworten    | 0 / 0  | 0 / 0     |
 
 Der belastbare Gewinn liegt bei den **Begründungen**: statt „kindliche Gesichtszüge und glatte Haut bestätigen diese Altersspanne ohne sichtbare Pubertätsmerkmale" steht dort jetzt „deine Zähne sind bleibend, aber noch etwas groß fürs Gesicht, und die Wangen sind rund ohne sichtbare Wangenknochen". „Schultern" und „Statur" kommen in keiner Antwort mehr vor (vorher in acht). Das ist im Workshop vorlesbar und am Bild zeigbar.
 
@@ -1707,16 +1730,17 @@ Die Alterszahlen selbst sind **kein Beweis**: Im Testset stecken nur sechs Minde
 
 - **Fünf Prompt-Varianten für die Verletzlichkeits-Kopplung im gemeinsamen Aufruf**, je 84 Analysen:
 
-  | Variante | Alters-Trefferquote | Trigger getrennt | Beast-Mechanik | Marken-Überlappung |
-  |---|---|---|---|---|
-  | Live v2.7.0 | Basis | nein (100 %) | ~33 % | ~6,5 % |
-  | Werbung + Trigger | −11,9 Pp | ja (6,5 %) | 54,1 % | 40,1 % |
-  | dieselbe, gestrafft | −11,9 Pp | ja (6,7 %) | 48,6 % | 25,2 % |
-  | nur Trigger | ±0 | ja (9,1 %) | 17,6 % | 15,8 % |
-  | Trigger + Feldreihenfolge | ±0 | ja (14,8 %) | 21,3 % | 11,2 % |
-  | nur Werbung | ±0 | nein | 53,4 % | 12,5 % |
+  | Variante                  | Alters-Trefferquote | Trigger getrennt | Beast-Mechanik | Marken-Überlappung |
+  | ------------------------- | ------------------- | ---------------- | -------------- | ------------------ |
+  | Live v2.7.0               | Basis               | nein (100 %)     | ~33 %          | ~6,5 %             |
+  | Werbung + Trigger         | −11,9 Pp            | ja (6,5 %)       | 54,1 %         | 40,1 %             |
+  | dieselbe, gestrafft       | −11,9 Pp            | ja (6,7 %)       | 48,6 %         | 25,2 %             |
+  | nur Trigger               | ±0                  | ja (9,1 %)       | 17,6 %         | 15,8 %             |
+  | Trigger + Feldreihenfolge | ±0                  | ja (14,8 %)      | 21,3 %         | 11,2 %             |
+  | nur Werbung               | ±0                  | nein             | 53,4 %         | 12,5 %             |
 
   Drei Befunde: (1) Die **Mindestquote hebelt die Marken-Trennung aus** — auf „mindestens 4 Einträge mit Mechanik" antwortet das Modell mit derselben Marke plus „Abo" („Decathlon Riverside 500 Abo", obwohl Decathlon schon im Standard steht). (2) **Zielkonflikt zwischen Werbung und Triggern:** Trennt man nur die Trigger, halbiert sich die Mechanik in der Werbung — das Modell erfüllt die Ausbeutungslogik dann in den Trigger-Texten. (3) Der scheinbare **Alterseinbruch war ein Messartefakt**: Die Trefferquote ist binär (±2 Jahre bei Minderjährigen), die tatsächliche Abweichung blieb mit ±8,3 Jahren unverändert. Die Feldreihenfolge im Schema (`ad_targeting` stand vor `categories`, das Modell konnte sich also gar nicht auf die Verletzlichkeit beziehen) war ebenfalls nicht der Hebel. **Lehre: Jede zusätzliche Pflichtregel im Prompt wird woanders bezahlt.**
+
 - **Prompt um 14 % kürzen** (Werbung und Trigger komplett raus): verändert weder Grundfakten noch Textqualität. Altersabweichung ±8,3 → ±8,2 Jahre, Geschlecht 64 % → 64 %. **Alter und Geschlecht sind keine Prompt-Frage** — über sechs Messungen konstant, unbeeindruckt von jeder Änderung.
 - **Modellwechsel auf Medium 3.5** (vollständiger Lauf, identischer Prompt): 4,6-fache Kosten (19,85 € statt 4,35 € je 1.000 im Workshop), Altersabweichung nur ±7,5 statt ±8,1 Jahre, Geschlecht 66,7 statt 64,3 % — und zwei Kinderschutz-Verstöße, wo Large in 42 Analysen sauber blieb. Textqualität war besser (Hedge-Wörter 2,4 statt 7,1 %), rechtfertigt den Aufpreis aber nicht.
 - **Zweiter Aufruf auf `mistral-small-2603`:** liefert Werbesprüche statt Marken („Luxus-Vitamine", „Dein Like-Count ist dein Spiegel") und ignoriert die Anzahlvorgabe (18 statt 6-8 Einträge).
@@ -1733,7 +1757,7 @@ Die Alterszahlen selbst sind **kein Beweis**: Im Testset stecken nur sechs Minde
 
 - **Beast Mode zeigt jetzt eigene Werbung.** Bisher landete EINE Werbeliste in beiden Modi (`mistral.js`, `ad_targeting: ads`) — der Beast-Text war zynisch und ausbeutend, die Werbung darunter dieselbe brave Liste wie im Standard. Das entwertete genau den Moment, auf den das Tool didaktisch hinarbeitet. Jetzt liefert das Modell **zwei getrennte Listen**: Standard zeigt, was zum sichtbaren Lebensstil passt, Beast zeigt, was die im Beast-Profil benannte Schwachstelle ausbeutet (Abo-Fallen, Ratenzahlung, Statusprodukte über Budget, bei Kindern Sammelzwang- und Quengel-Mechaniken). **Gemessen an 84 Analysen: Marken-Überlappung zwischen den Modi 100 % → 2,8 %, Produkt-Überlappung 100 % → 0,0 %.** Beispiel (14-jähriges Mädchen): Standard „Puma × Stranger Things, Converse Run Star Hike, Spotify Premium Student" — Beast „Zalando Lounge Abo, ASOS Premier Membership, Boohoo Trend-Abo, Wish Mystery Beauty Box". (`locales/de/prompts.js`, `locales/en/prompts.js`, `mistral.js`)
 - **Die immer gleichen Marken sind weg.** Ursache war kein Zufall, sondern der Prompt selbst: Er nannte neun Beispielmarken an vier Stellen, inklusive einer fertig ausgefüllten Liste im JSON-Schema. Mistral folgt Beispielen, nicht Regeln — bei einem Radsport-Foto kamen **alle acht** Marken aus der Beispielliste zurück (Garmin Edge 1040, Rapha, Specialized, Komoot, Wahoo, Red Bull, Ortlieb). Die Beispiele sind jetzt **ersatzlos entfernt** (nur noch Format-Platzhalter wie `‹Marke› ‹Modelllinie›`). **Gemessen: Anteil Werbe-Einträge aus den Prompt-Beispielen 7,5 % → 0,9 %, verschiedene Marken über alle Fotos 95 → 270, Top-3-Konzentration 11,9 % → 6,2 %.** Dasselbe Foto liefert jetzt Evoc, Schwalbe, Tubolito, Lezyne, Deuter, Vaude, Endura, Crankbrothers.
-  - **Warum das diesmal funktioniert:** Der Vielfalt-Umbau vom 29.05. (v2.3.0-Kandidat) hatte Beispielmarken durch *andere* Beispielmarken ersetzt und war durchgefallen — „nintendo switch" wurde einfach zum neuen Anker. Der Unterschied jetzt: gar kein Beispiel mehr zum Abschreiben, plus eine rotierende Sperrliste.
+  - **Warum das diesmal funktioniert:** Der Vielfalt-Umbau vom 29.05. (v2.3.0-Kandidat) hatte Beispielmarken durch _andere_ Beispielmarken ersetzt und war durchgefallen — „nintendo switch" wurde einfach zum neuen Anker. Der Unterschied jetzt: gar kein Beispiel mehr zum Abschreiben, plus eine rotierende Sperrliste.
 - **Rotierende Marken-Sperre** (`BRAND_BLOCKLIST_SETS`, 6 Sets). Sie sitzt bewusst **hinter dem Bild in der user-Message** — dort war nie Cache, die Rotation kostet damit **keinen einzigen Prompt-Cache-Treffer**. Läge sie im `system`-Teil, wechselte der statische Anfang pro Analyse und die Trefferquote fiele auf 0 (die v2.5-Messung ist im Code dokumentiert). Ein Test prüft genau das: gleicher `system`-Inhalt über verschiedene Sperrlisten hinweg. Sichtbare Marken im Foto schlagen die Sperre ausdrücklich. Gemessen: 0 Sperrlisten-Verstöße in 42 Läufen.
 
 ### Behoben
@@ -1745,7 +1769,7 @@ Die Alterszahlen selbst sind **kein Beweis**: Im Testset stecken nur sechs Minde
 
 - **Mehrverbrauch:** Eingabe +8,8 %, Ausgabe +7,1 % pro Analyse. Die Eingabe ist zwischenspeicherbar, die Ausgabe nicht — überschlägig **rund 1 bis 1,50 € mehr pro 1.000 Analysen**. Keine abgeschnittenen Antworten in 42 Läufen, `MAX_TOKENS` bleibt bei 8000.
 - **Qualität gehalten:** Konkretheit der Marken 97,6 % → 100 %, Geschlechtstreffer unverändert 64,3 %, Alterstreffer 35,7 % → 33,3 % (ein Treffer von 42 = Rauschen). 0 Parse-Fehler, 0 Transport-Fehler.
-- **Was die Messung NICHT belegt:** Ob sich bei vielen *ähnlichen* Fotos (echte Schulklasse) weniger wiederholt. Die 14 Testbilder sind maximal verschieden; dort liegt die Marken-Überlappung zwischen Fotos bei beiden Varianten unter 6 %. Genau diese Einschränkung war schon die Lehre aus dem Test vom 29.05. Belegt ist das Ende des Abschreibens aus dem Prompt und die dreifache Markenvielfalt.
+- **Was die Messung NICHT belegt:** Ob sich bei vielen _ähnlichen_ Fotos (echte Schulklasse) weniger wiederholt. Die 14 Testbilder sind maximal verschieden; dort liegt die Marken-Überlappung zwischen Fotos bei beiden Varianten unter 6 %. Genau diese Einschränkung war schon die Lehre aus dem Test vom 29.05. Belegt ist das Ende des Abschreibens aus dem Prompt und die dreifache Markenvielfalt.
 - **Der 3-Call-Fallback-Pfad** (`useSingleLargeCall = false`) liefert weiterhin eine gemeinsame Werbeliste für beide Modi. Er ist Rückfall, nicht aktiver Pfad — bewusst nicht mitgeändert.
 
 ## [2.6.0] — 2026-08-09
@@ -1788,13 +1812,14 @@ Kostensenkung im Live-Pfad: Prompt-Caching bei Mistral, gemessen statt geschätz
 - **Prompt-Caching bei Mistral, hinter dem Flag `usePromptCache` (Standard: aus).** Der statische Anweisungstext macht ~9.500 der ~11.200 Eingabe-Tokens jeder Analyse aus und wurde bisher bei jedem Upload voll bezahlt. Mit gesetztem `prompt_cache_key` berechnet Mistral ihn wieder und kostet dafür nur 10 % des Eingabepreises. **Gemessen unter Produktionsmuster** (20 Anfragen, Parallelität 10, ohne Pause, wechselnde Bilder): **76,4 % aller Eingabe-Tokens aus dem Cache**, Median pro Anfrage 99,8 %, 16 von 20 Anfragen mit klarem Treffer. Das entspricht ~8,10 € → ~4,80 € pro 1000 Analysen. (`functions/src/mistral.js`, `functions/src/feature-flags.js`, `functions/src/handle-process-job.js`)
   - **Der Nachrichten-Aufbau musste dafür umgestellt werden — das ist der eigentliche Kern der Änderung.** An der echten API gemessen, mit wechselnden Bildern:
 
-    | Aufbau | Cache-Treffer |
-    | --- | --- |
-    | `user[ text, bild ]` (Stand bis v2.4) | **0 %** |
-    | `system(text)` + `user[ bild ]` | **82–100 %** |
-    | `user[ text ]` + `user[ bild ]` | **0 %** |
+    | Aufbau                                | Cache-Treffer |
+    | ------------------------------------- | ------------- |
+    | `user[ text, bild ]` (Stand bis v2.4) | **0 %**       |
+    | `system(text)` + `user[ bild ]`       | **82–100 %**  |
+    | `user[ text ]` + `user[ bild ]`       | **0 %**       |
 
     Mistral cacht einen multimodalen `content`-Array offenbar nur als Ganzes; da das Bild pro Anfrage wechselt, fällt der komplette Präfix aus dem Cache. Blosses Auftrennen genügt nicht — der Rollenwechsel nach `system` ist die Bedingung. Der Parameter allein hätte **nichts** gebracht.
+
   - **Qualitätsgegenprobe vor der Umstellung:** drei Demo-Fotos, volle Analysen, beide Aufbauten. Identische `hard_facts` (22/28/22 Jahre, gleiche Spannen und Geschlechter), 0 fehlende Karten in beiden Modi, vergleichbare Ausgabelänge. Die Umstellung verändert die Profile nicht.
   - **Trefferquote ist anbieterseitig nicht garantiert** („erhöht die Chance, garantiert sie nicht", Mistral-Doku). Einzelaufrufe mit Pause treffen unzuverlässig (0–9 %); erst Dauerlast hält den Cache warm. Für den Workshop-Betrieb ist das der Normalfall, für vereinzelte Uploads nicht. Ein Fehlschlag kostet exakt den bisherigen Preis — die Maßnahme kann nicht teurer werden als der Ist-Zustand.
   - **Erfolgskontrolle im Protokoll:** `cachedTokens` steht jetzt in jeder `mistral-single-large`-Zeile. Nach dem ersten Workshop lässt sich die reale Ersparnis damit belegen statt schätzen.
@@ -1866,12 +1891,12 @@ Zwei blockierte Pflicht-Checks gelöst und die Dependabot-Automatik entschärft.
     - `test-exclude` auf `^7.0.1` übersteuert (6.0.0 → 7.0.2, dev) — 6.x hing an `minimatch@3` → `brace-expansion@1`. **Rückbau, sobald `babel-plugin-istanbul` in der installierten `jest`-Version `test-exclude` ≥ 7 anfordert.**
     - Die verbleibende Instanz unter `eslint` (`minimatch@10.2.5` → `brace-expansion@5.0.7`) brauchte keine Übersteuerung — 5.0.8 liegt in deren erlaubtem Bereich.
   - **Produktiv-Oberfläche bewusst unangetastet:** `firebase-functions` (7.2.5), `firebase-admin` (14.1.0), `express` (4.22.2), `google-gax` (5.0.7) und die `@google-cloud/*`-Pakete bleiben exakt auf dem Live-Stand. Ein vollständiger Lockfile-Neuaufbau hätte nebenbei `firebase-functions` 7.3.2 und damit **Express 4 → 5** in den Produktiv-Backend gezogen — eine Verhaltensänderung, die in einen bewusst freigegebenen eigenen Schritt gehört und nicht als Nebenwirkung hier hinein. Stattdessen minimal-invasiv: `npm install` gegen das bestehende Lockfile (ändert nur, was die Übersteuerungen erzwingen) plus gezielte Handkorrektur der drei Versionseinträge.
-  - **macOS-Lockfile-Falle erneut bestätigt und diesmal sauber umschifft:** `npm audit fix`, `npm update --package-lock-only` *und* `npm install` schneiden auf macOS die optionalen Einträge `@emnapi/core`, `@emnapi/runtime` und `@pkgjs/parseargs` aus dem Lockfile — die Linux-CI bricht daraufhin mit `npm ci`-EUSAGE ab (genau so geschehen im ersten Anlauf dieses Zweigs). Die Einträge wurden nach dem Eingriff gezielt zurückgeschrieben. **Verlässliche Vorabprüfung ist `npm ci --dry-run`** — reproduziert den CI-Fehler lokal; eine Textsuche nach „linux" im Lockfile tut das nicht (die betroffenen Pakete tragen kein „linux" im Namen). (`package.json`, `functions/package.json`, beide Lockfiles)
+  - **macOS-Lockfile-Falle erneut bestätigt und diesmal sauber umschifft:** `npm audit fix`, `npm update --package-lock-only` _und_ `npm install` schneiden auf macOS die optionalen Einträge `@emnapi/core`, `@emnapi/runtime` und `@pkgjs/parseargs` aus dem Lockfile — die Linux-CI bricht daraufhin mit `npm ci`-EUSAGE ab (genau so geschehen im ersten Anlauf dieses Zweigs). Die Einträge wurden nach dem Eingriff gezielt zurückgeschrieben. **Verlässliche Vorabprüfung ist `npm ci --dry-run`** — reproduziert den CI-Fehler lokal; eine Textsuche nach „linux" im Lockfile tut das nicht (die betroffenen Pakete tragen kein „linux" im Namen). (`package.json`, `functions/package.json`, beide Lockfiles)
 
 ### Geändert
 
 - **Audit-Gate mit begründeter, ablaufender Ausnahmeliste** (`scripts/audit-gate.mjs` + `.github/audit-allowlist.json`) ersetzt das nackte `npm audit --omit=dev --audit-level=high` im CI-Job `test-backend`. Grund: Das alte Gate war ein Alles-oder-nichts-Schalter — erschien irgendwo tief in einer fremden Abhängigkeitskette ein High-Advisory ohne verfügbare Reparatur, blockierte es **jeden** PR. Genau daran sind am 2026-07-01 alle acht Dependabot-PRs gescheitert (#30–#37, alle an `test-backend`), die deshalb von Hand weggeräumt werden mussten. Neu: High/Critical blockieren weiterhin, eine Ausnahme braucht Begründung **und** Ablaufdatum, danach fällt das Gate von selbst wieder auf rot; ein neues Advisory ist nie automatisch ausgenommen. Das Gate fasst außerdem Ketten korrekt zusammen (6 npm-Meldungen = 1 echte Lücke). Verhalten in allen vier Fällen gemessen: ungedeckt → rot, abgelaufen → rot, gedeckt → grün, verwaist → Hinweis.
-  - **Die Ausnahmeliste ist leer und soll es bleiben.** Sie ist das Ventil für den Fall, dass eine Fremd-Lücke wirklich weder reparierbar noch übersteuerbar ist — nicht der bequeme Weg. Der aktuelle Fall (`brace-expansion`) wurde bewusst *gelöst* statt eingetragen.
+  - **Die Ausnahmeliste ist leer und soll es bleiben.** Sie ist das Ventil für den Fall, dass eine Fremd-Lücke wirklich weder reparierbar noch übersteuerbar ist — nicht der bequeme Weg. Der aktuelle Fall (`brace-expansion`) wurde bewusst _gelöst_ statt eingetragen.
 - **Playwright-Container-Tag kommt jetzt aus dem Lockfile** (neuer CI-Job `playwright-version`, `test-e2e` hängt daran). Vorher stand die Version an zwei Stellen (`package.json` und Image-Tag in `ci.yml`) und musste von Hand synchron gehalten werden — jedes Dependabot-Playwright-Update musste dadurch zwangsläufig scheitern. Von Hand zu pflegen bleibt nur noch der Basis-Name `-jammy`. Ergibt heute unverändert `v1.61.1-jammy`. (`.github/workflows/ci.yml`)
 - **Dependabot bündelt Updates je Bereich zu einem PR** statt einen pro Paket (`applies-to: version-updates`, nur `minor` + `patch`). Am 2026-07-01 waren es acht einzelne PRs — gebündelt wären es drei gewesen, die mit dem bestehenden Auto-Merge ohne Zutun durchlaufen. Major-Updates bleiben bewusst einzeln, weil sie ohnehin eine manuelle Freigabe brauchen und in einem Sammel-PR untergehen würden. (`.github/dependabot.yml`)
 - **Dependabot Security-Updates aktiviert** (Repo-Einstellung, war aus). Bisher meldete Dependabot eine Lücke nur per Mail, ohne einen Reparatur-PR zu öffnen — Nörgeln statt Reparieren, jede Lücke musste von Hand gehoben werden. Security-PRs sind zusätzlich je Bereich gebündelt.
@@ -2240,7 +2265,7 @@ rund 12 %, Job-Latenz um rund 17 %.
 - **Werbemarken und Manipulations-Trigger sind in beiden Modi identisch:** Die zwei Listen werden jetzt nur einmal vom Large-Modell generiert (im selben Footer-Block) und dann modus-übergreifend übernommen. Vorher generierte jeder Profile-Call seine eigene Marken-/Trigger-Liste, was inhaltliche Widersprüche zwischen Modi erzeugte — was nicht die Realität echter Datenbroker abbildet (Algorithmen sehen dich gleich, egal mit welchem Tonfall sie es dir erklären).
 - **Beast-Profil bricht nicht mehr mitten im JSON ab:** Mistral hatte sich im Beast-Modus gelegentlich selbst entschieden, früh aufzuhören — `finishReason: "stop"` bei nur 7 von 13 gelieferten Karten und ohne Verdict-Text. Drei Maßnahmen zusammen lösen das: (1) Antwort-Budget pro Profile-Call von 8.000 auf 16.000 Tokens erhöht (Sicherheitsdeckel, kostenneutral), (2) Im JSON-Output kommt der Verdict-Text jetzt zuerst, dann die Karten — falls Mistral doch früh stoppt, ist wenigstens der Verdict da, (3) Server-seitige Vollständigkeitsprüfung: liefert Mistral weniger als 13 Karten, wird automatisch ein gezielter Retry-Call ausgelöst, der die fehlenden Felder explizit anfordert.
 - **Profil-Karte „Werbeprofil" fehlt nicht mehr im Standard-Modus:** Mistral hatte die letzte Karte gelegentlich weggelassen, vermutlich weil sie ganz am Ende des Schemas stand. Mit der Vollständigkeitsprüfung (siehe oben) und der neuen JSON-Reihenfolge gibt das System keine unvollständigen Profile mehr aus.
-- **Bei „im Bild nicht eindeutig erkennbar"-Fällen wird jetzt eine kurze Begründung mitgeliefert** statt abrupt zu enden. Vorher war „Im Bild nicht erkennbar." ein hartes Ende, das den Lesefluss zerriss; jetzt steht z. B. „Im Bild keine klaren Signale — weder Ehering noch Begleitung sichtbar." Der Workshop-Teilnehmer versteht, *warum* keine Aussage möglich ist.
+- **Bei „im Bild nicht eindeutig erkennbar"-Fällen wird jetzt eine kurze Begründung mitgeliefert** statt abrupt zu enden. Vorher war „Im Bild nicht erkennbar." ein hartes Ende, das den Lesefluss zerriss; jetzt steht z. B. „Im Bild keine klaren Signale — weder Ehering noch Begleitung sichtbar." Der Workshop-Teilnehmer versteht, _warum_ keine Aussage möglich ist.
 
 ### Geändert
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 827/828 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 235a794, 2026-08-13 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 369/369 grün — `scripts/pruefstand.sh`, Commit 235a794, 2026-08-13 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 66/66 grün — `scripts/pruefstand.sh`, Commit 235a794, 2026-08-13 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 844/845 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit ebbbb5b, 2026-08-17 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 407/407 grün — `scripts/pruefstand.sh`, Commit ebbbb5b, 2026-08-17 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 157/157 grün — `scripts/pruefstand.sh`, Commit ebbbb5b, 2026-08-17 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/docs/barrierefreiheit/ERKLAERUNG-ENTWURF.md
+++ b/docs/barrierefreiheit/ERKLAERUNG-ENTWURF.md
@@ -37,7 +37,7 @@ Video- oder Tonbeiträge, keine Anmeldung, keine Zeitbegrenzung und kein Formula
 personenbezogenen Daten enthält. Vier weitere Kriterien sind messtechnisch erfüllt und
 werden derzeit zusätzlich von Hand mit einem Screenreader geprüft.⟩
 
-⟨*Nach Abschluss der Handprüfung wird dieser Absatz ersetzt durch:* „Diese Seite ist
+⟨_Nach Abschluss der Handprüfung wird dieser Absatz ersetzt durch:_ „Diese Seite ist
 konform mit WCAG 2.2 Stufe AA."⟩
 
 ### Was wir geprüft haben — und wie
@@ -134,12 +134,12 @@ bei jeder Auslieferung automatisch mit.
 
 ## Belegte Grundlagen
 
-| Aussage | Beleg |
-|---|---|
-| BaFG nimmt Kleinstunternehmen bei Dienstleistungen aus (§ 6 Abs. 1); < 10 Beschäftigte und ≤ 2 Mio. € | [Sozialministeriumservice](https://www.sozialministeriumservice.gv.at/Marktueberwachung_digitale_Barrierefreiheit/Informationen_fuer_Unternehmen/Ausnahme_Kleinstunternehmen/Ausnahmen-fuer-Kleinstunternehmen.de.html), [WKO](https://www.wko.at/ce-kennzeichnung-normen/informationen-zum-barrierefreiheitsgesetz) |
-| Schlichtung: durch Schlichtungsreferent:innen des Sozialministeriumservice, kostenfrei und formlos, Dolmetschkosten getragen, vor Gericht verpflichtend. **Betrifft Diskriminierung nach Behindertengleichstellungsrecht, nicht das BaFG-Beschwerdeverfahren** | [Primärquelle Sozialministeriumservice](https://www.sozialministeriumservice.gv.at/Menschen_mit_Behinderung/Gleichstellung/Schlichtung/Schlichtung.de.html), abgerufen 17.08.2026 |
-| Artikel 50 EU-KI-Verordnung gilt ab 2. August 2026; Betreiber müssen künstlich erzeugte Bildinhalte offenlegen, auch Bilder nicht existierender Personen; keine Ausnahme für kleine Unternehmen | [Artikeltext AI Act](https://artificialintelligenceact.eu/article/50/), abgerufen 17.08.2026 |
-| `malzi.me` nimmt Mail an (MX bei IONOS) | `dig +short MX malzi.me` → `mx00.ionos.de`, `mx01.ionos.de` |
+| Aussage                                                                                                                                                                                                                                                        | Beleg                                                                                                                                                                                                                                                                                                                |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BaFG nimmt Kleinstunternehmen bei Dienstleistungen aus (§ 6 Abs. 1); < 10 Beschäftigte und ≤ 2 Mio. €                                                                                                                                                          | [Sozialministeriumservice](https://www.sozialministeriumservice.gv.at/Marktueberwachung_digitale_Barrierefreiheit/Informationen_fuer_Unternehmen/Ausnahme_Kleinstunternehmen/Ausnahmen-fuer-Kleinstunternehmen.de.html), [WKO](https://www.wko.at/ce-kennzeichnung-normen/informationen-zum-barrierefreiheitsgesetz) |
+| Schlichtung: durch Schlichtungsreferent:innen des Sozialministeriumservice, kostenfrei und formlos, Dolmetschkosten getragen, vor Gericht verpflichtend. **Betrifft Diskriminierung nach Behindertengleichstellungsrecht, nicht das BaFG-Beschwerdeverfahren** | [Primärquelle Sozialministeriumservice](https://www.sozialministeriumservice.gv.at/Menschen_mit_Behinderung/Gleichstellung/Schlichtung/Schlichtung.de.html), abgerufen 17.08.2026                                                                                                                                    |
+| Artikel 50 EU-KI-Verordnung gilt ab 2. August 2026; Betreiber müssen künstlich erzeugte Bildinhalte offenlegen, auch Bilder nicht existierender Personen; keine Ausnahme für kleine Unternehmen                                                                | [Artikeltext AI Act](https://artificialintelligenceact.eu/article/50/), abgerufen 17.08.2026                                                                                                                                                                                                                         |
+| `malzi.me` nimmt Mail an (MX bei IONOS)                                                                                                                                                                                                                        | `dig +short MX malzi.me` → `mx00.ionos.de`, `mx01.ionos.de`                                                                                                                                                                                                                                                          |
 
 ## Was vor der Veröffentlichung noch von Christoph zu entscheiden ist
 

--- a/docs/barrierefreiheit/PRUEFBERICHT-WCAG-EM.md
+++ b/docs/barrierefreiheit/PRUEFBERICHT-WCAG-EM.md
@@ -12,13 +12,13 @@ Bewertung der Konformität mit den Web Content Accessibility Guidelines.
 
 ## Angaben zur Prüfung (WCAG-EM Schritt 5.1)
 
-| | |
-|---|---|
-| **Prüfer** | malziland - learning \| training \| consulting e.U., Inhaber Christoph Krieger |
-| **Auftraggeber** | Eigenprüfung |
-| **Prüfdatum** | 17. August 2026 |
-| **Geprüfter Stand** | Commit `b83121d`, ausgelieferte Kennung `2026081703` |
-| **Art der Prüfung** | Selbstbewertung, werkzeuggestützt und teilweise manuell |
+|                     |                                                                                |
+| ------------------- | ------------------------------------------------------------------------------ |
+| **Prüfer**          | malziland - learning \| training \| consulting e.U., Inhaber Christoph Krieger |
+| **Auftraggeber**    | Eigenprüfung                                                                   |
+| **Prüfdatum**       | 17. August 2026                                                                |
+| **Geprüfter Stand** | Commit `b83121d`, ausgelieferte Kennung `2026081703`                           |
+| **Art der Prüfung** | Selbstbewertung, werkzeuggestützt und teilweise manuell                        |
 
 ---
 
@@ -50,13 +50,13 @@ Betreiber hat darauf keinen Einfluss und kann keine Kombination ausschließen.
 
 Damit gelten als unterstützt:
 
-| Browser | Hilfsmittel | Betriebssystem |
-|---|---|---|
-| Chrome, Edge (Blink) | NVDA, JAWS, Narrator | Windows |
-| Firefox (Gecko) | NVDA, JAWS | Windows |
-| Safari (WebKit) | VoiceOver | macOS |
-| Safari (WebKit) | VoiceOver | iOS, iPadOS |
-| Chrome (Blink) | TalkBack | Android |
+| Browser              | Hilfsmittel          | Betriebssystem |
+| -------------------- | -------------------- | -------------- |
+| Chrome, Edge (Blink) | NVDA, JAWS, Narrator | Windows        |
+| Firefox (Gecko)      | NVDA, JAWS           | Windows        |
+| Safari (WebKit)      | VoiceOver            | macOS          |
+| Safari (WebKit)      | VoiceOver            | iOS, iPadOS    |
+| Chrome (Blink)       | TalkBack             | Android        |
 
 jeweils in den aktuellen und der jeweils vorangegangenen Hauptversion.
 
@@ -71,8 +71,7 @@ Keine über WCAG 2.2 AA hinaus. Zwei projekteigene Festlegungen wirken mit:
 - **Keine Barrierefreiheits-Overlays.** Sie verschlechtern die Bedienung mit Screenreader
   nachweislich.
 - **Die KI-Kennzeichnung der Beispielfotos bleibt in den Bildpunkten**, auch wenn das
-  „Text in Bildern" bedeutet. Grundlage: Artikel 50 der EU-KI-Verordnung, gültig seit
-  2. August 2026; eine Kennzeichnung neben dem Bild geht beim Weiterschicken verloren.
+  „Text in Bildern" bedeutet. Grundlage: Artikel 50 der EU-KI-Verordnung, gültig seit 2. August 2026; eine Kennzeichnung neben dem Bild geht beim Weiterschicken verloren.
 
 ---
 
@@ -125,16 +124,16 @@ Nutzungsstatistik.
 
 Ausgewählt nach den fünf Kategorien der Methodik:
 
-| Kategorie | Ansicht | Begründung |
-|---|---|---|
-| Gemeinsame Ansicht | Startseite `/` | Einstiegspunkt, trägt Kopf- und Fußzeile |
-| Besondere Seite | `/datenschutz` | längster Text, Tabellen, viele Links |
-| Besondere Seite | `/impressum` | kürzeste Rechtsseite, andere Struktur |
-| Besondere Seite | `/nutzungsbedingungen` | nummerierte Abschnitte, verschachtelte Listen |
-| Besondere Seite | `/barrierefreiheit` | neu, noch nie mit Nutzern erprobt |
-| Inhaltstyp-Vielfalt | `/stats` | Zahlen, Fortschrittsbalken, automatische Aktualisierung |
-| Funktionale Komponente | Sprachhinweis-Dialog | modaler Dialog mit Fokus-Käfig |
-| Funktionale Komponente | Ergebnis mit Karte | fremder eingebetteter Inhalt |
+| Kategorie              | Ansicht                | Begründung                                              |
+| ---------------------- | ---------------------- | ------------------------------------------------------- |
+| Gemeinsame Ansicht     | Startseite `/`         | Einstiegspunkt, trägt Kopf- und Fußzeile                |
+| Besondere Seite        | `/datenschutz`         | längster Text, Tabellen, viele Links                    |
+| Besondere Seite        | `/impressum`           | kürzeste Rechtsseite, andere Struktur                   |
+| Besondere Seite        | `/nutzungsbedingungen` | nummerierte Abschnitte, verschachtelte Listen           |
+| Besondere Seite        | `/barrierefreiheit`    | neu, noch nie mit Nutzern erprobt                       |
+| Inhaltstyp-Vielfalt    | `/stats`               | Zahlen, Fortschrittsbalken, automatische Aktualisierung |
+| Funktionale Komponente | Sprachhinweis-Dialog   | modaler Dialog mit Fokus-Käfig                          |
+| Funktionale Komponente | Ergebnis mit Karte     | fremder eingebetteter Inhalt                            |
 
 ### 3.2 Zufällige Auswahl
 
@@ -157,24 +156,31 @@ Ausschnitten. malziME hat einen wesentlichen Prozess:
 
 **Die Analyse eines Fotos**
 
-| Schritt | Zustand |
-|---|---|
-| 1 | Leere Startseite, Aufforderung zur Fotoauswahl |
-| 2 | Foto gewählt, Vorbereitung im Browser (Verkleinern, Metadaten lesen) |
-| 3 | Hochladen und Einreihen |
-| 4 | Warten in der Schlange, mit Position und Restzeit |
-| 5 | Verarbeitung, Live-Text während das Modell schreibt |
-| 6 | Ergebnis fertig, Enthüllung des Profils |
-| 7 | Umschalten in den Beast-Modus |
-| 8 | Realitäts-Check ausfüllen und absenden |
-| 9 | PDF-Export |
-| — | Abzweig: Fehlermeldung nach fehlgeschlagener Analyse |
-| — | Abzweig: Verbindungsabbruch mitten im Ablauf |
+| Schritt | Zustand                                                              |
+| ------- | -------------------------------------------------------------------- |
+| 1       | Leere Startseite, Aufforderung zur Fotoauswahl                       |
+| 2       | Foto gewählt, Vorbereitung im Browser (Verkleinern, Metadaten lesen) |
+| 3       | Hochladen und Einreihen                                              |
+| 4       | Warten in der Schlange, mit Position und Restzeit                    |
+| 5       | Verarbeitung, Live-Text während das Modell schreibt                  |
+| 6       | Ergebnis fertig, Enthüllung des Profils                              |
+| 7       | Umschalten in den Beast-Modus                                        |
+| 8       | Realitäts-Check ausfüllen und absenden                               |
+| 9       | PDF-Export                                                           |
+| —       | Abzweig: Fehlermeldung nach fehlgeschlagener Analyse                 |
+| —       | Abzweig: Verbindungsabbruch mitten im Ablauf                         |
 
-**Prüfstand: Die Schritte 1, 3, 4, 5, 6, 7 und beide Abzweige sind geprüft.
-Die Schritte 2, 8 und 9 sind es noch nicht** — Bildvorbereitung, Realitäts-Check und
-PDF-Export. Das ist eine offene Lücke gegenüber der Methodik und keine Kleinigkeit: Ein
-Prozess gilt erst als geprüft, wenn alle Schritte es sind.
+**Alle neun Schritte und beide Abzweige sind geprüft.**
+
+Beim Aufstellen dieser Liste fiel auf, dass die Schritte 2, 8 und 9 — Bildvorbereitung,
+Realitäts-Check und PDF-Export — nie gemessen worden waren. Sie sind seither ergänzt und
+laufen mit. Das ist der praktische Gewinn der Methodik: Die Forderung nach vollständigen
+Prozessen hat drei ungeprüfte Zustände sichtbar gemacht, die in einer selbst gewählten
+Struktur nie aufgefallen wären.
+
+Beim PDF-Export endet die Prüfung am Knopf. Die erzeugte Datei ist ein eigenes Format mit
+eigenem Regelwerk (PDF/UA) und gehört nicht in eine HTML-Prüfung; das ist eine bewusste
+Grenze, keine Lücke.
 
 ---
 
@@ -182,21 +188,34 @@ Prozess gilt erst als geprüft, wenn alle Schritte es sind.
 
 ### 4.1 Prüfmittel
 
-| Werkzeug | Herkunft | Regelwerk | Rolle |
-|---|---|---|---|
-| **axe-core 4.12.1** | Deque Systems | eigenes, auf WCAG abgebildet | Hauptwerkzeug, blockierendes Gate |
-| **pa11y 9.1.1 / HTML_CodeSniffer** | Squiz, quelloffen | **unabhängige** Umsetzung der W3C-Techniken | Zweitmeinung |
-| **Lighthouse** | Google | benutzt intern axe | Live-Prüfung, keine echte Zweitmeinung |
-| Eigene Messungen | — | direkt gegen die Kriterientexte | Zielgrößen, Umbruch, Textgröße, Textabstände, Fokus, Ansagen, Vorlese-Reihenfolge |
-| Bildpunkt-Messung | — | Kontrastformel der WCAG | entscheidet, wenn Werkzeuge sich widersprechen |
+| Werkzeug                           | Herkunft          | Regelwerk                                   | Rolle                                                                             |
+| ---------------------------------- | ----------------- | ------------------------------------------- | --------------------------------------------------------------------------------- |
+| **axe-core 4.12.1**                | Deque Systems     | eigenes, auf WCAG abgebildet                | Hauptwerkzeug, blockierendes Gate                                                 |
+| **pa11y 9.1.1 / HTML_CodeSniffer** | Squiz, quelloffen | **unabhängige** Umsetzung der W3C-Techniken | Zweitmeinung                                                                      |
+| **Lighthouse**                     | Google            | benutzt intern axe                          | Live-Prüfung, keine echte Zweitmeinung                                            |
+| Eigene Messungen                   | —                 | direkt gegen die Kriterientexte             | Zielgrößen, Umbruch, Textgröße, Textabstände, Fokus, Ansagen, Vorlese-Reihenfolge |
+| Bildpunkt-Messung                  | —                 | Kontrastformel der WCAG                     | entscheidet, wenn Werkzeuge sich widersprechen                                    |
 
 **Zwei Regeln aus der Erfahrung dieses Berichts:**
 
-**Eine Abstention ist kein Bestehen.** axe meldet auf jeder Seite 6 bis 13 Elemente als
-„unprüfbar". In der ersten Fassung dieses Berichts wurden nur die Verstöße gezählt und
-daraus „0 Verstöße" — die Abstentionen wurden abgelegt und nie aufgelöst. Der unabhängige
-Zweitprüfer meldete an genau dieser Stelle einen Fehler; die Bildpunkt-Messung entschied
-ihn. Jede Abstention wird einzeln aufgelöst.
+**Eine Abstention ist kein Bestehen.** axe meldet Elemente als „unprüfbar", wenn es den
+Hintergrund nicht bestimmen kann. In der ersten Fassung dieses Berichts wurden nur die
+Verstöße gezählt und daraus „0 Verstöße" — die Abstentionen lagen unbeantwortet daneben.
+
+Seither entscheidet eine **Bildpunkt-Messung**: Das Element wird fotografiert, das Foto
+Punkt für Punkt ausgelesen, hellster und dunkelster Punkt nach der Kontrastformel der WCAG
+verrechnet. Sie läuft bei jeder Messung automatisch mit und macht den Lauf rot, wenn sie
+einen Verstoß bestätigt.
+
+**Das hat sofort einen echten Mangel gefunden**, den axe nicht entscheiden konnte: das
+Info-Zeichen neben den beiden Profil-Modi, bei 2,18:1 statt der verlangten 4,5:1
+(Fund A-2026-08-17-09 in Anhang A). Behoben.
+
+**Stand: 55 Abstentionen je Browser, davon 0 ungeklärt.** Alle 55 sind dasselbe
+Trennzeichen in der Fußzeile — reine Zierde und damit von 1.4.3 ausdrücklich ausgenommen.
+Die Ausnahme steht als benannter Eintrag mit Begründung im Prüfcode, nicht als stille
+Regel: Wer eine hinzufügt, muss den Grund danebenschreiben, und der steht dann im
+Änderungsverlauf.
 
 **Jede Messung läuft doppelt und hat eine Positivkontrolle.** Übernommen wird nur, was beide
 Male auftritt; findet ein Werkzeug nichts zu prüfen, bricht der Lauf ab statt grün zu
@@ -209,31 +228,35 @@ Prüfweg und Ergebnis je Zeile steht in **[Anhang A](PRUEFPROTOKOLL.md#5-die-kri
 
 **Zusammenfassung:**
 
-| | Anzahl |
-|---|---|
-| erfüllt, nachgewiesen | 40 |
-| nicht anwendbar, mit Grund | 11 |
-| maschinell erfüllt, menschliche Prüfung offen | 4 |
-| **als verletzt festgestellt** | **0** |
+|                                               | Anzahl |
+| --------------------------------------------- | ------ |
+| erfüllt, nachgewiesen                         | 40     |
+| nicht anwendbar, mit Grund                    | 11     |
+| maschinell erfüllt, menschliche Prüfung offen | 4      |
+| **als verletzt festgestellt**                 | **0**  |
 
-Am Prüftag gefunden **und behoben**: acht Mängel, darunter zwei auf Stufe A. Sie stehen mit
+Am Prüftag gefunden **und behoben**: neun Mängel, darunter zwei auf Stufe A. Sie stehen mit
 Ursache, Behebung und Dauerprüfung in Anhang A. Zwei davon fand kein Werkzeug, sondern ein
-Mensch, der zum ersten Mal mit VoiceOver zuhörte.
+Mensch, der zum ersten Mal mit VoiceOver zuhörte; einen fand die Auflösung der
+Abstentionen.
+
+**Messumfang:** 46 Zustände je Browser-Maschine, drei Maschinen, also 138 Messungen — jede
+zweifach ausgeführt und nur übernommen, was beide Male auftrat.
 
 ### 4.3 Prüftiefe gegenüber der Baseline
 
 **Die wichtigste Einschränkung dieses Berichts.**
 
-| Aus der Baseline | Geprüft |
-|---|---|
-| Blink (Chrome, Edge) | ✅ automatisiert, alle Ansichten und Zustände |
-| WebKit (Safari macOS/iOS) | ✅ automatisiert, alle Ansichten und Zustände |
-| Gecko (Firefox) | ✅ automatisiert, Barrierefreiheits-Prüfungen |
-| VoiceOver (macOS) | ⚠️ **teilweise** — der Barrierefreiheits-Baum und alle Ansagen sind ausgelesen und beurteilt; **gehört** wurde einmalig von einer Person, was zwei Mängel zutage förderte |
-| VoiceOver (iOS) | ❌ **nicht geprüft** |
-| NVDA, JAWS (Windows) | ❌ **nicht geprüft** |
-| TalkBack (Android) | ❌ **nicht geprüft** |
-| Braillezeile, Schaltersteuerung | ❌ **nicht geprüft** |
+| Aus der Baseline                | Geprüft                                                                                                                                                                   |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Blink (Chrome, Edge)            | ✅ automatisiert, alle Ansichten und Zustände                                                                                                                             |
+| WebKit (Safari macOS/iOS)       | ✅ automatisiert, alle Ansichten und Zustände                                                                                                                             |
+| Gecko (Firefox)                 | ✅ automatisiert, Barrierefreiheits-Prüfungen                                                                                                                             |
+| VoiceOver (macOS)               | ⚠️ **teilweise** — der Barrierefreiheits-Baum und alle Ansagen sind ausgelesen und beurteilt; **gehört** wurde einmalig von einer Person, was zwei Mängel zutage förderte |
+| VoiceOver (iOS)                 | ❌ **nicht geprüft**                                                                                                                                                      |
+| NVDA, JAWS (Windows)            | ❌ **nicht geprüft**                                                                                                                                                      |
+| TalkBack (Android)              | ❌ **nicht geprüft**                                                                                                                                                      |
+| Braillezeile, Schaltersteuerung | ❌ **nicht geprüft**                                                                                                                                                      |
 
 Die Browser-Maschinen sind vollständig abgedeckt. **Die Hilfsmittel sind es nicht** — sie
 laufen auf Betriebssystemen, die dem Prüfer nicht zur Verfügung stehen. Deshalb ist unter
@@ -248,18 +271,21 @@ Menschen gebeten worden, die mit diesen Hilfsmitteln arbeiten.
 
 **Die Website ist weitgehend konform mit WCAG 2.2 Stufe AA.**
 
-Kein Erfolgskriterium ist als verletzt festgestellt. „Weitgehend" statt „vollständig" aus
-drei benannten Gründen:
+Kein Erfolgskriterium ist als verletzt festgestellt. Der wesentliche Prozess ist über alle
+neun Schritte geprüft, alle Abstentionen sind aufgelöst.
 
-1. **Drei Prozessschritte sind ungeprüft** (Bildvorbereitung, Realitäts-Check, PDF-Export).
-   Die Methodik verlangt vollständige Prozesse.
-2. **Die erklärte Baseline ist breiter als die Prüftiefe.** Vier Hilfsmittel-Kombinationen
-   sind nicht geprüft.
-3. **Das W3C schließt eine reine Werkzeugaussage aus:** „no tool alone can determine if a
-   site meets accessibility standards. Knowledgeable human evaluation is required."
+„Weitgehend" statt „vollständig" steht dort trotzdem, und zwar aus **zwei** benannten
+Gründen:
 
-Diese drei Punkte sind der Weg zu „vollständig konform" — nicht Ausreden, sondern eine
-Aufgabenliste.
+1. **Die erklärte Baseline ist breiter als die Prüftiefe.** Vier Hilfsmittel-Kombinationen
+   — VoiceOver auf iOS, NVDA, JAWS, TalkBack — sind nicht geprüft. Solange das so ist,
+   wäre „vollständig konform" eine Aussage über Geräte, an denen niemand gesessen hat.
+2. **Das W3C schließt eine reine Werkzeugaussage ohnehin aus:** „no tool alone can
+   determine if a site meets accessibility standards. Knowledgeable human evaluation is
+   required to determine if a site is accessible."
+
+Beide Punkte laufen auf dasselbe hinaus: Es fehlt nicht Arbeit am Code, sondern Menschen,
+die mit ihren Hilfsmitteln zuhören. Deshalb [Issue #155](https://github.com/malziland/malzime/issues/155).
 
 ### 5.2 Wiederkehrende Muster
 

--- a/docs/barrierefreiheit/PRUEFBERICHT-WCAG-EM.md
+++ b/docs/barrierefreiheit/PRUEFBERICHT-WCAG-EM.md
@@ -1,0 +1,291 @@
+# Prüfbericht Barrierefreiheit — malziME
+
+**Erstellt nach [WCAG-EM 2.0](https://www.w3.org/TR/WCAG-EM/)**, der Methodik des W3C zur
+Bewertung der Konformität mit den Web Content Accessibility Guidelines.
+
+> Dieser Bericht ersetzt die frühere Fassung `PRUEFPROTOKOLL.md`. Die Messungen darin
+> waren belastbar, die Struktur war selbst ausgedacht. Ein Bericht, auf den sich ein
+> Dritter berufen soll, muss einer anerkannten Methodik folgen — sonst steht dort nur
+> „wir haben gründlich geprüft".
+
+---
+
+## Angaben zur Prüfung (WCAG-EM Schritt 5.1)
+
+| | |
+|---|---|
+| **Prüfer** | malziland - learning \| training \| consulting e.U., Inhaber Christoph Krieger |
+| **Auftraggeber** | Eigenprüfung |
+| **Prüfdatum** | 17. August 2026 |
+| **Geprüfter Stand** | Commit `b83121d`, ausgelieferte Kennung `2026081703` |
+| **Art der Prüfung** | Selbstbewertung, werkzeuggestützt und teilweise manuell |
+
+---
+
+## Schritt 1 — Geltungsbereich
+
+### 1.1 Geprüftes Produkt
+
+Die Website **https://malzi.me** vollständig, einschließlich aller Unterseiten und der
+gesamten Anwendungslogik. Nicht enthalten: die eingebettete Landkarte von OpenStreetMap
+(fremder Inhalt, von uns nicht gestaltbar) und externe Ziele der Fußzeilen-Links.
+
+### 1.2 Angestrebte Konformitätsstufe
+
+**WCAG 2.2, Stufe AA.**
+
+Stufe AAA wird ausdrücklich nicht angestrebt. Das W3C empfiehlt sie nicht als Anforderung
+für ganze Websites, weil sie sich für manche Inhalte grundsätzlich nicht erfüllen lässt.
+Was davon nebenbei erfüllt ist, steht nachrichtlich in Anhang B.
+
+### 1.3 Accessibility-Support-Baseline
+
+**Diese Angabe ist die Grundlage jeder Konformitätsaussage** — ohne sie ist „konform" nicht
+bestimmbar. Sie legt fest, mit welchen Kombinationen aus Browser und Hilfsmittel die Seite
+funktionieren muss.
+
+**Die Baseline ist breit, und zwar nicht aus Ehrgeiz, sondern aus Sachlage:** malziME läuft
+in Schulworkshops auf den Geräten, die Schülerinnen, Schüler und Lehrkräfte mitbringen. Der
+Betreiber hat darauf keinen Einfluss und kann keine Kombination ausschließen.
+
+Damit gelten als unterstützt:
+
+| Browser | Hilfsmittel | Betriebssystem |
+|---|---|---|
+| Chrome, Edge (Blink) | NVDA, JAWS, Narrator | Windows |
+| Firefox (Gecko) | NVDA, JAWS | Windows |
+| Safari (WebKit) | VoiceOver | macOS |
+| Safari (WebKit) | VoiceOver | iOS, iPadOS |
+| Chrome (Blink) | TalkBack | Android |
+
+jeweils in den aktuellen und der jeweils vorangegangenen Hauptversion.
+
+**Was davon tatsächlich geprüft wurde, steht in Schritt 4.3.** Die Lücke zwischen erklärter
+Baseline und tatsächlicher Prüftiefe ist die wichtigste Einschränkung dieses Berichts und
+wird dort offen benannt.
+
+### 1.4 Zusätzliche Anforderungen
+
+Keine über WCAG 2.2 AA hinaus. Zwei projekteigene Festlegungen wirken mit:
+
+- **Keine Barrierefreiheits-Overlays.** Sie verschlechtern die Bedienung mit Screenreader
+  nachweislich.
+- **Die KI-Kennzeichnung der Beispielfotos bleibt in den Bildpunkten**, auch wenn das
+  „Text in Bildern" bedeutet. Grundlage: Artikel 50 der EU-KI-Verordnung, gültig seit
+  2. August 2026; eine Kennzeichnung neben dem Bild geht beim Weiterschicken verloren.
+
+---
+
+## Schritt 2 — Erkundung des Produkts
+
+### 2.1 Gemeinsame Ansichten
+
+Kopfzeile mit Sprachumschalter, Fußzeile mit den Rechtslinks, Sprungmarke „Zum Inhalt
+springen" — auf allen Seiten identisch aufgebaut.
+
+### 2.2 Wesentliche Funktionalität
+
+**Die Analyse eines Fotos.** Das ist der einzige eigentliche Zweck der Seite und ein
+mehrstufiger Ablauf, kein Einzelbild. Er wird in Schritt 3.3 als vollständiger Prozess
+dokumentiert.
+
+Nebenfunktionen: Umschalten zwischen den beiden Profil-Modi, der Realitäts-Check, der
+PDF-Export, der Sprachwechsel, die Nutzungsstatistik.
+
+### 2.3 Vielfalt der Inhaltstypen
+
+Fließtext, Listen, Tabellen (Rechtsseiten), Formularelemente (Dateiauswahl,
+Umschalter), modale Dialoge mit Fokus-Käfig, eine eingebettete Landkarte, dynamisch
+erzeugte Inhalte, Live-Bereiche für Statusmeldungen, animierte Zustandsanzeigen,
+erzeugte PDF-Dateien.
+
+### 2.4 Eingesetzte Technologien
+
+Auf diese Technologien verlässt sich die Seite; ohne sie funktioniert sie nicht
+vollständig:
+
+- **HTML** — statisch ausgeliefert, kein serverseitiges Rendern
+- **CSS** — einschließlich `prefers-reduced-motion`; **kein** `prefers-color-scheme`
+  (das dunkle Erscheinungsbild entsteht ausschließlich über den Beast-Schalter)
+- **JavaScript** (22 ES-Module) — ohne JavaScript ist keine Analyse möglich
+- **WAI-ARIA** — im Einsatz: `aria-label`, `aria-labelledby`, `aria-live`, `aria-hidden`,
+  `aria-modal`, `aria-atomic`, `aria-pressed`, `role`, `inert`
+- **Fremdbibliotheken**, selbst gehostet: Leaflet (Karte), exifr (Bild-Metadaten)
+
+### 2.5 Besondere Seiten
+
+Datenschutzerklärung, Impressum, Nutzungsbedingungen, Barrierefreiheitserklärung,
+Nutzungsstatistik.
+
+---
+
+## Schritt 3 — Repräsentative Stichprobe
+
+### 3.1 Strukturierte Auswahl
+
+Ausgewählt nach den fünf Kategorien der Methodik:
+
+| Kategorie | Ansicht | Begründung |
+|---|---|---|
+| Gemeinsame Ansicht | Startseite `/` | Einstiegspunkt, trägt Kopf- und Fußzeile |
+| Besondere Seite | `/datenschutz` | längster Text, Tabellen, viele Links |
+| Besondere Seite | `/impressum` | kürzeste Rechtsseite, andere Struktur |
+| Besondere Seite | `/nutzungsbedingungen` | nummerierte Abschnitte, verschachtelte Listen |
+| Besondere Seite | `/barrierefreiheit` | neu, noch nie mit Nutzern erprobt |
+| Inhaltstyp-Vielfalt | `/stats` | Zahlen, Fortschrittsbalken, automatische Aktualisierung |
+| Funktionale Komponente | Sprachhinweis-Dialog | modaler Dialog mit Fokus-Käfig |
+| Funktionale Komponente | Ergebnis mit Karte | fremder eingebetteter Inhalt |
+
+### 3.2 Zufällige Auswahl
+
+Die Methodik verlangt zusätzlich rund 10 % zufällig gewählter Ansichten als
+Qualitätskontrolle der strukturierten Auswahl.
+
+**Hier nicht anwendbar, mit Begründung:** Die Website hat sechs Seiten. Die strukturierte
+Auswahl umfasst sie **vollständig**; eine Zufallsauswahl könnte nichts finden, was nicht
+ohnehin geprüft ist. Die Zufallsauswahl dient bei großen Websites dazu, die Repräsentativität
+der Stichprobe zu prüfen — bei einer Vollerhebung entfällt ihr Zweck.
+
+Als Ersatz für den Zweck der Regel — unbeabsichtigte Varianten zu finden — wurden
+**Zustände** statt Seiten variiert: helles und dunkles Erscheinungsbild, beide Sprachen,
+zwei Fenstermaße, drei Browser-Maschinen.
+
+### 3.3 Vollständige Prozesse
+
+Die Methodik verlangt, dass ein Prozess **in allen Schritten** geprüft wird, nicht in
+Ausschnitten. malziME hat einen wesentlichen Prozess:
+
+**Die Analyse eines Fotos**
+
+| Schritt | Zustand |
+|---|---|
+| 1 | Leere Startseite, Aufforderung zur Fotoauswahl |
+| 2 | Foto gewählt, Vorbereitung im Browser (Verkleinern, Metadaten lesen) |
+| 3 | Hochladen und Einreihen |
+| 4 | Warten in der Schlange, mit Position und Restzeit |
+| 5 | Verarbeitung, Live-Text während das Modell schreibt |
+| 6 | Ergebnis fertig, Enthüllung des Profils |
+| 7 | Umschalten in den Beast-Modus |
+| 8 | Realitäts-Check ausfüllen und absenden |
+| 9 | PDF-Export |
+| — | Abzweig: Fehlermeldung nach fehlgeschlagener Analyse |
+| — | Abzweig: Verbindungsabbruch mitten im Ablauf |
+
+**Prüfstand: Die Schritte 1, 3, 4, 5, 6, 7 und beide Abzweige sind geprüft.
+Die Schritte 2, 8 und 9 sind es noch nicht** — Bildvorbereitung, Realitäts-Check und
+PDF-Export. Das ist eine offene Lücke gegenüber der Methodik und keine Kleinigkeit: Ein
+Prozess gilt erst als geprüft, wenn alle Schritte es sind.
+
+---
+
+## Schritt 4 — Auswertung der Stichprobe
+
+### 4.1 Prüfmittel
+
+| Werkzeug | Herkunft | Regelwerk | Rolle |
+|---|---|---|---|
+| **axe-core 4.12.1** | Deque Systems | eigenes, auf WCAG abgebildet | Hauptwerkzeug, blockierendes Gate |
+| **pa11y 9.1.1 / HTML_CodeSniffer** | Squiz, quelloffen | **unabhängige** Umsetzung der W3C-Techniken | Zweitmeinung |
+| **Lighthouse** | Google | benutzt intern axe | Live-Prüfung, keine echte Zweitmeinung |
+| Eigene Messungen | — | direkt gegen die Kriterientexte | Zielgrößen, Umbruch, Textgröße, Textabstände, Fokus, Ansagen, Vorlese-Reihenfolge |
+| Bildpunkt-Messung | — | Kontrastformel der WCAG | entscheidet, wenn Werkzeuge sich widersprechen |
+
+**Zwei Regeln aus der Erfahrung dieses Berichts:**
+
+**Eine Abstention ist kein Bestehen.** axe meldet auf jeder Seite 6 bis 13 Elemente als
+„unprüfbar". In der ersten Fassung dieses Berichts wurden nur die Verstöße gezählt und
+daraus „0 Verstöße" — die Abstentionen wurden abgelegt und nie aufgelöst. Der unabhängige
+Zweitprüfer meldete an genau dieser Stelle einen Fehler; die Bildpunkt-Messung entschied
+ihn. Jede Abstention wird einzeln aufgelöst.
+
+**Jede Messung läuft doppelt und hat eine Positivkontrolle.** Übernommen wird nur, was beide
+Male auftritt; findet ein Werkzeug nichts zu prüfen, bricht der Lauf ab statt grün zu
+melden.
+
+### 4.2 Ergebnis je Erfolgskriterium
+
+Die vollständige Tabelle aller 55 Kriterien der Stufe AA — 31 auf A, 24 auf AA — mit
+Prüfweg und Ergebnis je Zeile steht in **[Anhang A](PRUEFPROTOKOLL.md#5-die-kriterien-im-einzelnen)**.
+
+**Zusammenfassung:**
+
+| | Anzahl |
+|---|---|
+| erfüllt, nachgewiesen | 40 |
+| nicht anwendbar, mit Grund | 11 |
+| maschinell erfüllt, menschliche Prüfung offen | 4 |
+| **als verletzt festgestellt** | **0** |
+
+Am Prüftag gefunden **und behoben**: acht Mängel, darunter zwei auf Stufe A. Sie stehen mit
+Ursache, Behebung und Dauerprüfung in Anhang A. Zwei davon fand kein Werkzeug, sondern ein
+Mensch, der zum ersten Mal mit VoiceOver zuhörte.
+
+### 4.3 Prüftiefe gegenüber der Baseline
+
+**Die wichtigste Einschränkung dieses Berichts.**
+
+| Aus der Baseline | Geprüft |
+|---|---|
+| Blink (Chrome, Edge) | ✅ automatisiert, alle Ansichten und Zustände |
+| WebKit (Safari macOS/iOS) | ✅ automatisiert, alle Ansichten und Zustände |
+| Gecko (Firefox) | ✅ automatisiert, Barrierefreiheits-Prüfungen |
+| VoiceOver (macOS) | ⚠️ **teilweise** — der Barrierefreiheits-Baum und alle Ansagen sind ausgelesen und beurteilt; **gehört** wurde einmalig von einer Person, was zwei Mängel zutage förderte |
+| VoiceOver (iOS) | ❌ **nicht geprüft** |
+| NVDA, JAWS (Windows) | ❌ **nicht geprüft** |
+| TalkBack (Android) | ❌ **nicht geprüft** |
+| Braillezeile, Schaltersteuerung | ❌ **nicht geprüft** |
+
+Die Browser-Maschinen sind vollständig abgedeckt. **Die Hilfsmittel sind es nicht** — sie
+laufen auf Betriebssystemen, die dem Prüfer nicht zur Verfügung stehen. Deshalb ist unter
+[Issue #155](https://github.com/malziland/malzime/issues/155) öffentlich um Rückmeldung von
+Menschen gebeten worden, die mit diesen Hilfsmitteln arbeiten.
+
+---
+
+## Schritt 5 — Ergebnis der Bewertung
+
+### 5.1 Aussage zur Konformität
+
+**Die Website ist weitgehend konform mit WCAG 2.2 Stufe AA.**
+
+Kein Erfolgskriterium ist als verletzt festgestellt. „Weitgehend" statt „vollständig" aus
+drei benannten Gründen:
+
+1. **Drei Prozessschritte sind ungeprüft** (Bildvorbereitung, Realitäts-Check, PDF-Export).
+   Die Methodik verlangt vollständige Prozesse.
+2. **Die erklärte Baseline ist breiter als die Prüftiefe.** Vier Hilfsmittel-Kombinationen
+   sind nicht geprüft.
+3. **Das W3C schließt eine reine Werkzeugaussage aus:** „no tool alone can determine if a
+   site meets accessibility standards. Knowledgeable human evaluation is required."
+
+Diese drei Punkte sind der Weg zu „vollständig konform" — nicht Ausreden, sondern eine
+Aufgabenliste.
+
+### 5.2 Wiederkehrende Muster
+
+Zwei Fehlerklassen traten mehrfach auf und sind deshalb gesondert genannt:
+
+**Dynamisch erzeugte Elemente wurden von Prüfungen nicht erfasst.** Die Regel „jedes
+Bedienelement braucht `tabindex="0"`, sonst überspringt Safari es" war seit Langem als Test
+vorhanden — aber nur für statisches HTML. Alle im JavaScript erzeugten Knöpfe waren
+ungeprüft und tatsächlich nicht erreichbar. Abhilfe: Die Prüfung läuft jetzt gegen den
+DOM **nach** Ausführung des JavaScripts.
+
+**Messungen sagten „dass", nicht „wie oft".** Die Statusansagen waren korrekt und
+vollständig — und wiederholten sich alle zwei Sekunden. Eine formal richtige Seite war
+praktisch unbenutzbar. Abhilfe: Häufigkeit wird mitgemessen und begrenzt.
+
+### 5.3 Nächste Prüfung
+
+Bei jeder Änderung an Aussehen, Bedienung oder Seitenstruktur, mindestens halbjährlich.
+Die maschinellen Messungen laufen bei jeder Auslieferung automatisch mit.
+
+---
+
+## Anhänge
+
+- **[Anhang A](PRUEFPROTOKOLL.md)** — alle 55 Kriterien einzeln, mit Prüfweg und Ergebnis;
+  die behobenen Mängel mit Ursache und Dauerprüfung
+- **Anhang B** — Stufe AAA, nachrichtlich (in Anhang A, Abschnitt 8)
+- **Rohdaten** — `e2e/.protokoll/befunde-*.json` je Browser, bei jedem Lauf neu erzeugt
+- **Reproduzierbar** — `npx playwright test e2e/barrierefreiheit-protokoll.test.js`

--- a/docs/barrierefreiheit/PRUEFPROTOKOLL.md
+++ b/docs/barrierefreiheit/PRUEFPROTOKOLL.md
@@ -1,10 +1,18 @@
-# Prüfprotokoll Barrierefreiheit — malziME
+# Anhang A — Die 55 Kriterien im Einzelnen
+
+> **Dies ist der Anhang, nicht der Bericht.** Der Prüfbericht steht in
+> **[PRUEFBERICHT-WCAG-EM.md](PRUEFBERICHT-WCAG-EM.md)** und folgt der Methodik
+> [WCAG-EM 2.0](https://www.w3.org/TR/WCAG-EM/) des W3C. Dort stehen Geltungsbereich,
+> Accessibility-Support-Baseline, eingesetzte Technologien, die begründete Stichprobe und
+> die Konformitätsaussage. Hier steht nur die Detailtabelle, auf die er sich beruft.
 
 **Prüfgegenstand:** https://malzi.me
 **Angestrebte Stufe:** WCAG 2.2, Konformitätsstufe AA
 **Prüfdatum:** 17. August 2026
-**Prüfstand:** Commit `b3908c3`, ausgelieferte Kennung `2026081701`
 **Prüfer:** Eigenprüfung (malziland - learning | training | consulting e.U.)
+
+Der geprüfte Stand steht im Bericht — bewusst nur dort, damit die Commit-Nummer eine
+einzige Quelle hat und nicht in zwei Dateien auseinanderdriftet.
 
 ---
 
@@ -55,9 +63,10 @@ Zielgrößen, Reflow, Textvergrößerung, Textabstände und Fokus-Erscheinung.
 
 **Reproduzierbar:** `npx playwright test e2e/barrierefreiheit-protokoll.test.js`
 Rohdaten: `e2e/.protokoll/befunde-chromium.json`,
-`e2e/.protokoll/befunde-webkit-sprachumschalter.json`
+`e2e/.protokoll/befunde-webkit-sprachumschalter.json`,
+`e2e/.protokoll/befunde-firefox-barrierefreiheit.json` — 46 Zustände je Maschine.
 
-## 3 Zwei Vorsichtsmaßnahmen, die das Ergebnis erst belastbar machen
+## 3 Fünf Vorsichtsmaßnahmen, die das Ergebnis erst belastbar machen
 
 **Jede Messung läuft doppelt.** Übernommen wird nur, was beide Male auftritt. Grund:
 Ein erster Aufbau meldete 17 Kontrastverstöße, die in einem sauberen Einzellauf nicht
@@ -77,9 +86,23 @@ während der Wartezeit waren korrekt und vollständig; gemessen wurde erst nach
 einem Hinweis von außen, dass sie sich alle zwei Sekunden wiederholen. Häufigkeit
 gehört mitgemessen, sonst ist eine Seite formal richtig und praktisch unbenutzbar.
 
+**Eine Abstention ist kein Bestehen.** axe meldet Elemente als „unprüfbar", wenn es
+den Hintergrund nicht bestimmen kann — Verlauf, Halbtransparenz, überlappende
+Schichten. Die erste Fassung dieses Protokolls zählte nur die Verstöße und schrieb
+„0 Verstöße", während die Abstentionen unbeantwortet danebenlagen. Jetzt entscheidet
+eine **Bildpunkt-Messung**: Das Element wird fotografiert, das Foto Punkt für Punkt
+ausgelesen, hellster und dunkelster Punkt nach der Kontrastformel der WCAG verrechnet.
+Sie macht den Lauf rot, wenn sie einen Verstoß bestätigt — und hat sofort einen
+gefunden, den axe nicht entscheiden konnte (Abschnitt 6, Info-Zeichen). Ausnahmen wie
+das Trennzeichen in der Fußzeile stehen als benannter Eintrag mit Begründung im
+Prüfcode, nicht als stille Regel.
+
 **Jede Messung hat eine Positivkontrolle.** Liefert axe null geprüfte Regeln oder
 findet die Zielgrößen-Messung kein einziges Bedienelement, bricht der Lauf ab. Ohne
-das sähe ein kaputter Lauf aus wie ein perfektes Ergebnis.
+das sähe ein kaputter Lauf aus wie ein perfektes Ergebnis. Die Bildpunkt-Messung hat
+ihre eigene: Ein absichtlich zu blasser Text muss erkannt und ein ausreichender
+durchgelassen werden — ein Prüfmittel, das nie anschlägt, und eines, das immer
+anschlägt, sind gleich wertlos.
 
 ---
 
@@ -106,86 +129,87 @@ Legende: **erfüllt** = nachgewiesen · **n. a.** = nicht anwendbar, mit Grund �
 
 ### Stufe A
 
-| Kriterium | Prüfweg | Ergebnis |
-|---|---|---|
-| 1.1.1 Nicht-Text-Inhalt | axe (`image-alt`, `input-image-alt`, `role-img-alt`, `object-alt`); Unit-Test prüft `data-i18n-alt` für alle Bilder | **maschinell erfüllt**, Handprüfung offen |
-| 1.2.1 Nur-Audio, Nur-Video (aufgezeichnet) | Bestandsprüfung: keine Audio- oder Videobeiträge | **n. a.** |
-| 1.2.2 Untertitel (aufgezeichnet) | dito | **n. a.** |
-| 1.2.3 Audiodeskription / Medienalternative | dito | **n. a.** |
-| 1.3.1 Infos und Beziehungen | axe (`list`, `listitem`, `definition-list`, `th-has-data-cells`, `aria-required-parent`, `heading-order`) | **maschinell erfüllt**, Handprüfung offen |
-| 1.3.2 Bedeutungstragende Reihenfolge | Tab-Reihenfolge im Unit-Test festgeschrieben (Sprungmarke → Datei → Info → Umschalter → Demos → Links) | **erfüllt** |
-| 1.3.3 Sensorische Eigenschaften | Sichtprüfung: keine Anweisung verweist allein auf Form, Größe oder Position | **erfüllt** |
-| 1.4.1 Benutzung von Farbe | Sichtprüfung: Konfidenz-Punkte tragen zusätzlich Zahlwerte, Fehlermeldungen zusätzlich Text | **erfüllt** |
-| 1.4.2 Audio-Steuerelement | Die Tipp-Geräusche sind kürzer als 3 s, spielen nur auf Nutzeraktion und lassen sich abschalten | **n. a.** |
-| 2.1.1 Tastatur | **Struktur**-Prüfung: jedes Bedienelement trägt `tabindex="0"` — auch die von JavaScript erzeugten (`tastatur-erreichbarkeit.test.js`, 6 Seiten plus Umschalter und Dialog). Ein Tabulator-Durchlauf im Test taugt dafür NICHT: Playwrights WebKit tabbt auf Buttons unabhängig von Safaris Einstellung „Vollzugriff Tastatur" und ist grün, während die echte Bedienung scheitert | **erfüllt**, Handprüfung offen |
-| 2.1.2 Keine Tastaturfalle | E2E: 10 Tabulatorschritte im Dialog, Fokus verlässt ihn nie und kehrt bei Escape zurück | **erfüllt** |
-| 2.1.4 Zeichentasten-Kurzbefehle | Bestandsprüfung: keine Einzelzeichen-Kurzbefehle vorhanden | **n. a.** |
-| 2.2.1 Zeiteinteilung anpassbar | Die Analyse hat keine Frist für den Nutzer; das Abholfenster von 15 Minuten betrifft nur die Wiederholung eines fertigen Ergebnisses und verliert keine Eingabe | **erfüllt** |
-| 2.2.2 Pausieren, beenden, ausblenden | Alle Bewegungen (Scan-Auge, Live-Tippen, Karten-Einblendung) folgen `prefers-reduced-motion`; im E2E an den berechneten Animationswerten nachgewiesen | **erfüllt** |
-| 2.3.1 Dreimaliges Blitzen oder weniger | Bestandsprüfung: keine blitzenden Inhalte | **erfüllt** |
-| 2.4.1 Blöcke umgehen | Sprungmarke „Zum Inhalt springen" auf jeder Seite, Unit-Test prüft Ziel `#main` | **erfüllt** |
-| 2.4.2 Seite mit Titel | axe (`document-title`); jede der fünf Seiten hat einen eigenen, beschreibenden Titel | **erfüllt** |
-| 2.4.3 Fokus-Reihenfolge | Unit-Test schreibt die Reihenfolge fest; E2E prüft die Rückgabe des Fokus nach Dialogen | **erfüllt** |
-| 2.4.4 Linkzweck (im Kontext) | Eigene Messung: 0 Leerformeln („hier", „mehr", „klicken") auf allen fünf Seiten | **erfüllt** |
-| 2.5.1 Zeigergesten | Bestandsprüfung: keine Mehrfinger- oder Pfadgesten; die Karte ist zusätzlich über Knöpfe bedienbar | **erfüllt** |
-| 2.5.2 Zeiger-Abbruch | Alle Aktionen lösen beim Loslassen aus, nicht beim Drücken | **erfüllt** |
-| 2.5.3 Beschriftung im Namen | axe (`label-content-name-mismatch`); sichtbarer Text und `aria-label` stimmen überein | **erfüllt** |
-| 2.5.4 Betätigung durch Bewegung | Bestandsprüfung: keine Bewegungs- oder Neigungssteuerung | **n. a.** |
-| 3.1.1 Sprache der Seite | axe (`html-has-lang`, `html-lang-valid`); `lang` wird beim Sprachwechsel mitgesetzt | **erfüllt** |
-| 3.2.1 Bei Fokus | Bestandsprüfung: kein Fokus löst einen Kontextwechsel aus | **erfüllt** |
-| 3.2.2 Bei Eingabe | Der Sprachwechsel fragt vor dem Verwerfen eines Ergebnisses zurück | **erfüllt** |
-| 3.2.6 Konsistente Hilfe | Impressum und Kontakt stehen auf jeder Seite an derselben Stelle der Fußzeile | **erfüllt** |
-| 3.3.1 Fehlererkennung | Fehlermeldungen erscheinen als Text in einem `aria-live`-Bereich; im Protokoll als eigener Zustand gemessen | **erfüllt** |
-| 3.3.2 Beschriftungen oder Anweisungen | axe (`label`, `form-field-multiple-labels`); die Dateiauswahl trägt eine sichtbare Anweisung | **erfüllt** |
-| 3.3.7 Redundante Eingabe | Es gibt nur einen Eingabeschritt (Foto wählen); nichts wird zweimal verlangt | **n. a.** |
-| 4.1.2 Name, Rolle, Wert | axe (`button-name`, `link-name`, `aria-valid-attr-value`, `aria-required-attr`, `select-name`) | **erfüllt** |
+| Kriterium                                  | Prüfweg                                                                                                                                                                                                                                                                                                                                                                            | Ergebnis                                  |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| 1.1.1 Nicht-Text-Inhalt                    | axe (`image-alt`, `input-image-alt`, `role-img-alt`, `object-alt`); Unit-Test prüft `data-i18n-alt` für alle Bilder                                                                                                                                                                                                                                                                | **maschinell erfüllt**, Handprüfung offen |
+| 1.2.1 Nur-Audio, Nur-Video (aufgezeichnet) | Bestandsprüfung: keine Audio- oder Videobeiträge                                                                                                                                                                                                                                                                                                                                   | **n. a.**                                 |
+| 1.2.2 Untertitel (aufgezeichnet)           | dito                                                                                                                                                                                                                                                                                                                                                                               | **n. a.**                                 |
+| 1.2.3 Audiodeskription / Medienalternative | dito                                                                                                                                                                                                                                                                                                                                                                               | **n. a.**                                 |
+| 1.3.1 Infos und Beziehungen                | axe (`list`, `listitem`, `definition-list`, `th-has-data-cells`, `aria-required-parent`, `heading-order`)                                                                                                                                                                                                                                                                          | **maschinell erfüllt**, Handprüfung offen |
+| 1.3.2 Bedeutungstragende Reihenfolge       | Tab-Reihenfolge im Unit-Test festgeschrieben (Sprungmarke → Datei → Info → Umschalter → Demos → Links)                                                                                                                                                                                                                                                                             | **erfüllt**                               |
+| 1.3.3 Sensorische Eigenschaften            | Sichtprüfung: keine Anweisung verweist allein auf Form, Größe oder Position                                                                                                                                                                                                                                                                                                        | **erfüllt**                               |
+| 1.4.1 Benutzung von Farbe                  | Sichtprüfung: Konfidenz-Punkte tragen zusätzlich Zahlwerte, Fehlermeldungen zusätzlich Text                                                                                                                                                                                                                                                                                        | **erfüllt**                               |
+| 1.4.2 Audio-Steuerelement                  | Die Tipp-Geräusche sind kürzer als 3 s, spielen nur auf Nutzeraktion und lassen sich abschalten                                                                                                                                                                                                                                                                                    | **n. a.**                                 |
+| 2.1.1 Tastatur                             | **Struktur**-Prüfung: jedes Bedienelement trägt `tabindex="0"` — auch die von JavaScript erzeugten (`tastatur-erreichbarkeit.test.js`, 6 Seiten plus Umschalter und Dialog). Ein Tabulator-Durchlauf im Test taugt dafür NICHT: Playwrights WebKit tabbt auf Buttons unabhängig von Safaris Einstellung „Vollzugriff Tastatur" und ist grün, während die echte Bedienung scheitert | **erfüllt**, Handprüfung offen            |
+| 2.1.2 Keine Tastaturfalle                  | E2E: 10 Tabulatorschritte im Dialog, Fokus verlässt ihn nie und kehrt bei Escape zurück                                                                                                                                                                                                                                                                                            | **erfüllt**                               |
+| 2.1.4 Zeichentasten-Kurzbefehle            | Bestandsprüfung: keine Einzelzeichen-Kurzbefehle vorhanden                                                                                                                                                                                                                                                                                                                         | **n. a.**                                 |
+| 2.2.1 Zeiteinteilung anpassbar             | Die Analyse hat keine Frist für den Nutzer; das Abholfenster von 15 Minuten betrifft nur die Wiederholung eines fertigen Ergebnisses und verliert keine Eingabe                                                                                                                                                                                                                    | **erfüllt**                               |
+| 2.2.2 Pausieren, beenden, ausblenden       | Alle Bewegungen (Scan-Auge, Live-Tippen, Karten-Einblendung) folgen `prefers-reduced-motion`; im E2E an den berechneten Animationswerten nachgewiesen                                                                                                                                                                                                                              | **erfüllt**                               |
+| 2.3.1 Dreimaliges Blitzen oder weniger     | Bestandsprüfung: keine blitzenden Inhalte                                                                                                                                                                                                                                                                                                                                          | **erfüllt**                               |
+| 2.4.1 Blöcke umgehen                       | Sprungmarke „Zum Inhalt springen" auf jeder Seite, Unit-Test prüft Ziel `#main`                                                                                                                                                                                                                                                                                                    | **erfüllt**                               |
+| 2.4.2 Seite mit Titel                      | axe (`document-title`); jede der fünf Seiten hat einen eigenen, beschreibenden Titel                                                                                                                                                                                                                                                                                               | **erfüllt**                               |
+| 2.4.3 Fokus-Reihenfolge                    | Unit-Test schreibt die Reihenfolge fest; E2E prüft die Rückgabe des Fokus nach Dialogen                                                                                                                                                                                                                                                                                            | **erfüllt**                               |
+| 2.4.4 Linkzweck (im Kontext)               | Eigene Messung: 0 Leerformeln („hier", „mehr", „klicken") auf allen fünf Seiten                                                                                                                                                                                                                                                                                                    | **erfüllt**                               |
+| 2.5.1 Zeigergesten                         | Bestandsprüfung: keine Mehrfinger- oder Pfadgesten; die Karte ist zusätzlich über Knöpfe bedienbar                                                                                                                                                                                                                                                                                 | **erfüllt**                               |
+| 2.5.2 Zeiger-Abbruch                       | Alle Aktionen lösen beim Loslassen aus, nicht beim Drücken                                                                                                                                                                                                                                                                                                                         | **erfüllt**                               |
+| 2.5.3 Beschriftung im Namen                | axe (`label-content-name-mismatch`); sichtbarer Text und `aria-label` stimmen überein                                                                                                                                                                                                                                                                                              | **erfüllt**                               |
+| 2.5.4 Betätigung durch Bewegung            | Bestandsprüfung: keine Bewegungs- oder Neigungssteuerung                                                                                                                                                                                                                                                                                                                           | **n. a.**                                 |
+| 3.1.1 Sprache der Seite                    | axe (`html-has-lang`, `html-lang-valid`); `lang` wird beim Sprachwechsel mitgesetzt                                                                                                                                                                                                                                                                                                | **erfüllt**                               |
+| 3.2.1 Bei Fokus                            | Bestandsprüfung: kein Fokus löst einen Kontextwechsel aus                                                                                                                                                                                                                                                                                                                          | **erfüllt**                               |
+| 3.2.2 Bei Eingabe                          | Der Sprachwechsel fragt vor dem Verwerfen eines Ergebnisses zurück                                                                                                                                                                                                                                                                                                                 | **erfüllt**                               |
+| 3.2.6 Konsistente Hilfe                    | Impressum und Kontakt stehen auf jeder Seite an derselben Stelle der Fußzeile                                                                                                                                                                                                                                                                                                      | **erfüllt**                               |
+| 3.3.1 Fehlererkennung                      | Fehlermeldungen erscheinen als Text in einem `aria-live`-Bereich; im Protokoll als eigener Zustand gemessen                                                                                                                                                                                                                                                                        | **erfüllt**                               |
+| 3.3.2 Beschriftungen oder Anweisungen      | axe (`label`, `form-field-multiple-labels`); die Dateiauswahl trägt eine sichtbare Anweisung                                                                                                                                                                                                                                                                                       | **erfüllt**                               |
+| 3.3.7 Redundante Eingabe                   | Es gibt nur einen Eingabeschritt (Foto wählen); nichts wird zweimal verlangt                                                                                                                                                                                                                                                                                                       | **n. a.**                                 |
+| 4.1.2 Name, Rolle, Wert                    | axe (`button-name`, `link-name`, `aria-valid-attr-value`, `aria-required-attr`, `select-name`)                                                                                                                                                                                                                                                                                     | **erfüllt**                               |
 
 ### Stufe AA
 
-| Kriterium | Prüfweg | Ergebnis |
-|---|---|---|
-| 1.2.4 Untertitel (live) | keine Live-Inhalte | **n. a.** |
-| 1.2.5 Audiodeskription (aufgezeichnet) | keine Videobeiträge | **n. a.** |
-| 1.3.4 Ausrichtung | Sichtprüfung: keine Einschränkung auf Hoch- oder Querformat | **erfüllt** |
-| 1.3.5 Eingabezweck bestimmen | Es gibt kein Formularfeld, das personenbezogene Daten erhebt | **n. a.** |
-| 1.4.3 Kontrast (Minimum) | axe (`color-contrast`), 15 Zustände, doppelt gemessen, beide Browser: **0 Verstöße**. Nachgerechnet: 4,73 : 1 bis 15 : 1 | **erfüllt** |
-| 1.4.4 Textgröße ändern | Eigene Messung: Wurzelschrift auf 200 % (16 → 32 px), alle fünf Seiten ohne waagrechtes Scrollen und ohne abgeschnittenen Inhalt | **erfüllt** |
-| 1.4.5 Bilder von Text | Kein Text als Bild, mit einer benannten Ausnahme: die KI-Kennzeichnung in den Demo-Fotos (siehe Abschnitt 6) | **erfüllt** |
-| 1.4.10 Reflow | Eigene Messung bei 320 px: alle fünf Seiten genau 320 px, kein waagrechtes Scrollen. Zwei Mängel am Prüftag gefunden und behoben (siehe Abschnitt 6) | **erfüllt** |
-| 1.4.11 Nicht-Text-Kontrast | axe; zusätzlich eigene Messung der Umschalter-Flächen in hellem und dunklem Thema | **erfüllt** |
-| 1.4.12 Textabstände | Eigene Messung mit Zeilenhöhe 1,5, Absatzabstand 2 em, Buchstabenabstand 0,12 em, Wortabstand 0,16 em: nichts überlappt, nichts verschwindet | **erfüllt** |
-| 1.4.13 Inhalt bei Hover oder Fokus | Die Info-Einblendungen sind schließbar (Escape), bleiben bei Zeigerwechsel stehen und verdecken den Auslöser nicht | **erfüllt** |
-| 2.4.5 Verschiedene Wege | Fußzeile auf jeder Seite plus Rubrik-Verweis zurück zur Startseite | **erfüllt** |
-| 2.4.6 Überschriften und Beschriftungen | Eigene Messung: 1 bis 16 Überschriften je Seite, **0 übersprungene Ebenen** | **erfüllt** |
-| 2.4.7 Fokus sichtbar | Eigene Messung nach echtem Fokussieren: jedes Element trägt einen Ring von mindestens 2 px. Am Prüftag verbessert (siehe Abschnitt 6) | **erfüllt** |
-| 2.4.11 Fokus nicht verdeckt (Minimum) | Eigene Messung: kein fokussiertes Element liegt hinter der geklebten Umschalt-Leiste | **erfüllt** |
-| 2.5.7 Ziehbewegungen | Die Karte ist zusätzlich über Knöpfe bedienbar; sonst gibt es keine Ziehbewegung | **erfüllt** |
-| 2.5.8 Zielgröße (Minimum) | Eigene Messung der **tastbaren Fläche** (nicht der gemalten Box) über 12 bis 45 Bedienelemente je Seite: **0 Mängel**. Die Ausnahmen „inline im Fließtext" und „Abstand mindestens 24 px" sind umgesetzt | **erfüllt** |
-| 3.1.2 Sprache von Teilen | Der Sprachumschalter setzt `lang` je Knopf; der zweisprachige Hinweis trägt `lang="de"` und `lang="en"` je Zeile | **erfüllt** |
-| 3.2.3 Konsistente Navigation | Fußzeile und Kopfzeile in gleicher Reihenfolge auf allen Seiten | **erfüllt** |
-| 3.2.4 Konsistente Erkennung | Gleiche Funktionen tragen durchgehend gleiche Beschriftung | **erfüllt** |
-| 3.3.3 Fehlerempfehlung | Jede Fehlermeldung nennt den nächsten Schritt („Versuch es nochmal", „nimm ein anderes Foto") | **erfüllt** |
-| 3.3.4 Fehlervermeidung (rechtlich, finanziell, Daten) | Keine Rechtsgeschäfte, keine Zahlungen, keine löschbaren Nutzerdaten. Der einzige verlustbehaftete Schritt — Sprachwechsel bei vorliegendem Ergebnis — fragt zurück | **erfüllt** |
-| 3.3.8 Barrierefreie Authentifizierung | Keine Anmeldung, kein Konto, kein Passwort | **n. a.** |
-| 4.1.3 Statusmeldungen | Warteschlangen-Status, Fehlermeldungen und Ergebnis-Ansage laufen über `aria-live`-Bereiche (`#status`, `#srAnnounce`) | **maschinell erfüllt**, Handprüfung offen |
+| Kriterium                                             | Prüfweg                                                                                                                                                                                                  | Ergebnis                                  |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| 1.2.4 Untertitel (live)                               | keine Live-Inhalte                                                                                                                                                                                       | **n. a.**                                 |
+| 1.2.5 Audiodeskription (aufgezeichnet)                | keine Videobeiträge                                                                                                                                                                                      | **n. a.**                                 |
+| 1.3.4 Ausrichtung                                     | Sichtprüfung: keine Einschränkung auf Hoch- oder Querformat                                                                                                                                              | **erfüllt**                               |
+| 1.3.5 Eingabezweck bestimmen                          | Es gibt kein Formularfeld, das personenbezogene Daten erhebt                                                                                                                                             | **n. a.**                                 |
+| 1.4.3 Kontrast (Minimum)                              | axe (`color-contrast`), 15 Zustände, doppelt gemessen, beide Browser: **0 Verstöße**. Nachgerechnet: 4,73 : 1 bis 15 : 1                                                                                 | **erfüllt**                               |
+| 1.4.4 Textgröße ändern                                | Eigene Messung: Wurzelschrift auf 200 % (16 → 32 px), alle fünf Seiten ohne waagrechtes Scrollen und ohne abgeschnittenen Inhalt                                                                         | **erfüllt**                               |
+| 1.4.5 Bilder von Text                                 | Kein Text als Bild, mit einer benannten Ausnahme: die KI-Kennzeichnung in den Demo-Fotos (siehe Abschnitt 6)                                                                                             | **erfüllt**                               |
+| 1.4.10 Reflow                                         | Eigene Messung bei 320 px: alle fünf Seiten genau 320 px, kein waagrechtes Scrollen. Zwei Mängel am Prüftag gefunden und behoben (siehe Abschnitt 6)                                                     | **erfüllt**                               |
+| 1.4.11 Nicht-Text-Kontrast                            | axe; zusätzlich eigene Messung der Umschalter-Flächen in hellem und dunklem Thema                                                                                                                        | **erfüllt**                               |
+| 1.4.12 Textabstände                                   | Eigene Messung mit Zeilenhöhe 1,5, Absatzabstand 2 em, Buchstabenabstand 0,12 em, Wortabstand 0,16 em: nichts überlappt, nichts verschwindet                                                             | **erfüllt**                               |
+| 1.4.13 Inhalt bei Hover oder Fokus                    | Die Info-Einblendungen sind schließbar (Escape), bleiben bei Zeigerwechsel stehen und verdecken den Auslöser nicht                                                                                       | **erfüllt**                               |
+| 2.4.5 Verschiedene Wege                               | Fußzeile auf jeder Seite plus Rubrik-Verweis zurück zur Startseite                                                                                                                                       | **erfüllt**                               |
+| 2.4.6 Überschriften und Beschriftungen                | Eigene Messung: 1 bis 16 Überschriften je Seite, **0 übersprungene Ebenen**                                                                                                                              | **erfüllt**                               |
+| 2.4.7 Fokus sichtbar                                  | Eigene Messung nach echtem Fokussieren: jedes Element trägt einen Ring von mindestens 2 px. Am Prüftag verbessert (siehe Abschnitt 6)                                                                    | **erfüllt**                               |
+| 2.4.11 Fokus nicht verdeckt (Minimum)                 | Eigene Messung: kein fokussiertes Element liegt hinter der geklebten Umschalt-Leiste                                                                                                                     | **erfüllt**                               |
+| 2.5.7 Ziehbewegungen                                  | Die Karte ist zusätzlich über Knöpfe bedienbar; sonst gibt es keine Ziehbewegung                                                                                                                         | **erfüllt**                               |
+| 2.5.8 Zielgröße (Minimum)                             | Eigene Messung der **tastbaren Fläche** (nicht der gemalten Box) über 12 bis 45 Bedienelemente je Seite: **0 Mängel**. Die Ausnahmen „inline im Fließtext" und „Abstand mindestens 24 px" sind umgesetzt | **erfüllt**                               |
+| 3.1.2 Sprache von Teilen                              | Der Sprachumschalter setzt `lang` je Knopf; der zweisprachige Hinweis trägt `lang="de"` und `lang="en"` je Zeile                                                                                         | **erfüllt**                               |
+| 3.2.3 Konsistente Navigation                          | Fußzeile und Kopfzeile in gleicher Reihenfolge auf allen Seiten                                                                                                                                          | **erfüllt**                               |
+| 3.2.4 Konsistente Erkennung                           | Gleiche Funktionen tragen durchgehend gleiche Beschriftung                                                                                                                                               | **erfüllt**                               |
+| 3.3.3 Fehlerempfehlung                                | Jede Fehlermeldung nennt den nächsten Schritt („Versuch es nochmal", „nimm ein anderes Foto")                                                                                                            | **erfüllt**                               |
+| 3.3.4 Fehlervermeidung (rechtlich, finanziell, Daten) | Keine Rechtsgeschäfte, keine Zahlungen, keine löschbaren Nutzerdaten. Der einzige verlustbehaftete Schritt — Sprachwechsel bei vorliegendem Ergebnis — fragt zurück                                      | **erfüllt**                               |
+| 3.3.8 Barrierefreie Authentifizierung                 | Keine Anmeldung, kein Konto, kein Passwort                                                                                                                                                               | **n. a.**                                 |
+| 4.1.3 Statusmeldungen                                 | Warteschlangen-Status, Fehlermeldungen und Ergebnis-Ansage laufen über `aria-live`-Bereiche (`#status`, `#srAnnounce`)                                                                                   | **maschinell erfüllt**, Handprüfung offen |
 
 ---
 
 ## 6 Am Prüftag gefundene und behobene Mängel
 
-Diese vier Punkte waren am 17. August verletzt und sind noch am selben Tag behoben.
+Diese Punkte waren am 17. August verletzt und sind noch am selben Tag behoben.
 Sie stehen hier, weil ein Protokoll, das nur Erfolge nennt, unglaubwürdig ist.
 
-| Kriterium | Befund | Behebung | Dauerprüfung |
-|---|---|---|---|
-| 1.4.10 Reflow | Nutzungsbedingungen 333 statt 320 px — die ODR-Adresse der EU ist 34 Zeichen ohne Leerstelle und konnte nicht umbrechen | Umbruch für Links in Rechtstexten | ja |
-| 1.4.10 Reflow | Profil-Seite 324 statt 320 px — die Wert-Plakette der Datenwert-Skala schob die Zeile auf | Zeile bricht um statt die Seite zu verbreitern | ja |
-| 1.4.10 Reflow (Ursache) | Die geklebte Umschalt-Leiste zog mit fest verdrahteten 20 px über den Rand, während die Seitenpolsterung bei schmalen Bildschirmen auf 16 px zurückgeht | Beide Werte kommen jetzt aus einer Quelle und können nicht auseinanderdriften | ja |
-| 2.4.7 Fokus sichtbar | 7 von 12 bis 20 Elementen je Rechtsseite trugen nur den Browser-Standardring. Sichtbar war er, aber sein Aussehen entscheidet jeder Browser selbst | Eigener Ring, 2 px, 5,9 : 1 gegen Papier und 11 : 1 im dunklen Thema | ja |
-| 2.1.1 Tastatur (Stufe A) | **Der Sprachumschalter war auf Safari mit der Tastatur nicht erreichbar.** Seine Knöpfe entstehen im JavaScript und trugen kein `tabindex="0"`; Safari tabbt ohne „Vollzugriff Tastatur" nicht auf Buttons. Betroffen waren 7 Knöpfe in zwei Dateien | `tabindex="0"` ergänzt | ja |
-| 2.1.1 Tastatur (Stufe A) | **Der Rücksprung zur Startseite war auf allen Unterseiten nicht erreichbar** — derselbe Grund, `.eyebrow-home` ohne `tabindex`. Vom neuen Wächter gefunden, nicht von Hand | `tabindex="0"` auf fünf Seiten ergänzt | ja |
-| 4.1.3 Statusmeldungen | **Der Wartezustand wurde alle zwei Sekunden erneut angesagt.** Gemessen: 19 Ansagen in 30 Sekunden, bei voller Analyse rund 40 — fast immer derselbe Satz. Ursache: Der Text wurde bei jeder Statusabfrage neu geschrieben, auch unverändert; jede Zuweisung löst in einem `aria-live`-Bereich eine Ansage aus. Dazu die rotierenden Zier-Meldungen, die sich tatsächlich ändern | Nur noch bei echter Änderung schreiben; Rotation stumm geschaltet. Gemessen: **19 → 3** | ja |
-| 4.1.3 Statusmeldungen | **Nach „Analyse abgeschlossen" folgte nichts.** Der Fokus sprang auf einen Abschnitt ohne Rolle und ohne Namen — dort hat ein Screenreader nichts zu sagen | `role="region"` mit übersetztem Namen („Dein Profil") | ja |
+| Kriterium                                   | Befund                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Behebung                                                                                                                 | Dauerprüfung |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------ |
+| 1.4.10 Reflow                               | Nutzungsbedingungen 333 statt 320 px — die ODR-Adresse der EU ist 34 Zeichen ohne Leerstelle und konnte nicht umbrechen                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Umbruch für Links in Rechtstexten                                                                                        | ja           |
+| 1.4.10 Reflow                               | Profil-Seite 324 statt 320 px — die Wert-Plakette der Datenwert-Skala schob die Zeile auf                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Zeile bricht um statt die Seite zu verbreitern                                                                           | ja           |
+| 1.4.10 Reflow (Ursache)                     | Die geklebte Umschalt-Leiste zog mit fest verdrahteten 20 px über den Rand, während die Seitenpolsterung bei schmalen Bildschirmen auf 16 px zurückgeht                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Beide Werte kommen jetzt aus einer Quelle und können nicht auseinanderdriften                                            | ja           |
+| 2.4.7 Fokus sichtbar                        | 7 von 12 bis 20 Elementen je Rechtsseite trugen nur den Browser-Standardring. Sichtbar war er, aber sein Aussehen entscheidet jeder Browser selbst                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Eigener Ring, 2 px, 5,9 : 1 gegen Papier und 11 : 1 im dunklen Thema                                                     | ja           |
+| 2.1.1 Tastatur (Stufe A)                    | **Der Sprachumschalter war auf Safari mit der Tastatur nicht erreichbar.** Seine Knöpfe entstehen im JavaScript und trugen kein `tabindex="0"`; Safari tabbt ohne „Vollzugriff Tastatur" nicht auf Buttons. Betroffen waren 7 Knöpfe in zwei Dateien                                                                                                                                                                                                                                                                                                                                                              | `tabindex="0"` ergänzt                                                                                                   | ja           |
+| 2.1.1 Tastatur (Stufe A)                    | **Der Rücksprung zur Startseite war auf allen Unterseiten nicht erreichbar** — derselbe Grund, `.eyebrow-home` ohne `tabindex`. Vom neuen Wächter gefunden, nicht von Hand                                                                                                                                                                                                                                                                                                                                                                                                                                        | `tabindex="0"` auf fünf Seiten ergänzt                                                                                   | ja           |
+| 4.1.3 Statusmeldungen                       | **Der Wartezustand wurde alle zwei Sekunden erneut angesagt.** Gemessen: 19 Ansagen in 30 Sekunden, bei voller Analyse rund 40 — fast immer derselbe Satz. Ursache: Der Text wurde bei jeder Statusabfrage neu geschrieben, auch unverändert; jede Zuweisung löst in einem `aria-live`-Bereich eine Ansage aus. Dazu die rotierenden Zier-Meldungen, die sich tatsächlich ändern                                                                                                                                                                                                                                  | Nur noch bei echter Änderung schreiben; Rotation stumm geschaltet. Gemessen: **19 → 3**                                  | ja           |
+| 1.4.3 Kontrast / 1.4.11 Nicht-Text-Kontrast | **Das Info-Zeichen neben den beiden Profil-Modi war auf 55 % Deckkraft gesetzt: 2,18:1 statt 4,5:1 für den Buchstaben und 3:1 für den Kreisrand.** Es ist ein Bedienelement (`role="button"`, mit der Tastatur erreichbar), keine Zierde. Beim Überfahren mit der Maus wurde es voll deckend — das zählt nicht: Das Kriterium gilt für den Zustand, in dem man das Element vorfindet, und wer mit Tastatur oder Finger arbeitet, fährt gar nicht darüber. **axe konnte den Fall nicht entscheiden und meldete ihn als „unprüfbar"** — gefunden hat ihn erst die Bildpunkt-Messung, die diese Abstentionen auflöst | Deckkraft im Ruhezustand entfernt, der Aufhell-Effekt läuft jetzt über die Farbe. Gemessen 5,22:1 hell und 7,85:1 dunkel | ja           |
+| 4.1.3 Statusmeldungen                       | **Nach „Analyse abgeschlossen" folgte nichts.** Der Fokus sprang auf einen Abschnitt ohne Rolle und ohne Namen — dort hat ein Screenreader nichts zu sagen                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `role="region"` mit übersetztem Namen („Dein Profil")                                                                    | ja           |
 
 **Bewusste, benannte Abweichung zu 1.4.5 (Bilder von Text):** Die drei Demo-Fotos
 tragen die KI-Kennzeichnung in die Pixel gebrannt. Das ist seit August 2026 Pflicht
@@ -199,12 +223,12 @@ strukturierten Daten hinterlegt, ist also für Screenreader erreichbar. Die Ausn
 Vier Kriterien galten als maschinell nicht entscheidbar. Diese Grenze war zu weit
 gezogen — der größere Teil ließ sich messen, sobald das passende Werkzeug gebaut war.
 
-| Kriterium | Wie es jetzt belegt ist | Rest |
-|---|---|---|
-| 1.1.1 Nicht-Text-Inhalt | Die Vorlese-Reihenfolge aller neun Seiten und Zustände ist mitgeschrieben. Jedes Demo-Bild sagt „AI-generated sample image … Does not depict a real person." **Kein Bild ohne Alternativtext, kein Bedienelement ohne Namen** | ob die Formulierung für einen Menschen taugt |
-| 1.3.1 Infos und Beziehungen | Überschriftenstruktur je Seite ausgezählt, keine übersprungene Ebene, Reihenfolge geprüft | — |
-| 4.1.3 Statusmeldungen | Die Ansagen sind wörtlich mitgeschrieben: „Dein Foto ist unterwegs" → „Analyse gestartet" → „Warteschlange · Position" → „Analyse abgeschlossen" → „Dein Profil". Häufigkeit gemessen und begrenzt | ob Safari und VoiceOver sie aussprechen |
-| 2.1.1 Tastatur | Strukturprüfung über sechs Seiten: jedes Bedienelement trägt `tabindex="0"`. Ein Tabulator-Durchlauf im Test taugt dafür nicht — Playwrights WebKit springt auf Knöpfe unabhängig von Safaris Einstellung | — |
+| Kriterium                   | Wie es jetzt belegt ist                                                                                                                                                                                                       | Rest                                         |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| 1.1.1 Nicht-Text-Inhalt     | Die Vorlese-Reihenfolge aller neun Seiten und Zustände ist mitgeschrieben. Jedes Demo-Bild sagt „AI-generated sample image … Does not depict a real person." **Kein Bild ohne Alternativtext, kein Bedienelement ohne Namen** | ob die Formulierung für einen Menschen taugt |
+| 1.3.1 Infos und Beziehungen | Überschriftenstruktur je Seite ausgezählt, keine übersprungene Ebene, Reihenfolge geprüft                                                                                                                                     | —                                            |
+| 4.1.3 Statusmeldungen       | Die Ansagen sind wörtlich mitgeschrieben: „Dein Foto ist unterwegs" → „Analyse gestartet" → „Warteschlange · Position" → „Analyse abgeschlossen" → „Dein Profil". Häufigkeit gemessen und begrenzt                            | ob Safari und VoiceOver sie aussprechen      |
+| 2.1.1 Tastatur              | Strukturprüfung über sechs Seiten: jedes Bedienelement trägt `tabindex="0"`. Ein Tabulator-Durchlauf im Test taugt dafür nicht — Playwrights WebKit springt auf Knöpfe unabhängig von Safaris Einstellung                     | —                                            |
 
 **Was zwingend am Gerät bleibt**, und das ist keine Formalie: ob Safari und
 VoiceOver das Ausgelesene auch tatsächlich aussprechen, und ob es sich für einen
@@ -226,14 +250,14 @@ gleichwertig.
 
 **Sechs sind nachweislich nicht erfüllt, mit Grund:**
 
-| Kriterium | Befund | Warum es so bleibt |
-|---|---|---|
-| 1.4.6 Kontrast 7 : 1 | 17 bis 37 Elemente je Seite (die Profil-Ansicht erfüllt es) | Die Markenpalette ist auf 4,5 : 1 ausgelegt; 7 : 1 wäre ein Umbau der Marke |
-| 1.4.8 Visuelle Präsentation | Zeilenlänge bis 103 statt 80 Zeichen | Verhältnismäßigkeit |
-| 1.4.9 Bilder von Text (ohne Ausnahme) | die KI-Kennzeichnung | **unerfüllbar** — die Kennzeichnung ist Pflicht |
-| 2.5.5 Zielgröße 44 × 44 | 6 bis 30 Bedienelemente je Seite | AAA kennt die Abstands-Ausnahme nicht; ein Umbau der Bedienflächen |
-| 3.1.4 Abkürzungen | auf den Rechtsseiten behoben, auf der Startseite offen | Der Text kommt dort aus den Sprachdateien; 17 Fundstellen für ein AAA-Kriterium |
-| 3.1.5 Lesbarkeit | Rechtstexte über Sekundarstufe I | Erforderte eine zweite, vereinfachte Fassung jedes Rechtstexts |
+| Kriterium                             | Befund                                                      | Warum es so bleibt                                                              |
+| ------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| 1.4.6 Kontrast 7 : 1                  | 17 bis 37 Elemente je Seite (die Profil-Ansicht erfüllt es) | Die Markenpalette ist auf 4,5 : 1 ausgelegt; 7 : 1 wäre ein Umbau der Marke     |
+| 1.4.8 Visuelle Präsentation           | Zeilenlänge bis 103 statt 80 Zeichen                        | Verhältnismäßigkeit                                                             |
+| 1.4.9 Bilder von Text (ohne Ausnahme) | die KI-Kennzeichnung                                        | **unerfüllbar** — die Kennzeichnung ist Pflicht                                 |
+| 2.5.5 Zielgröße 44 × 44               | 6 bis 30 Bedienelemente je Seite                            | AAA kennt die Abstands-Ausnahme nicht; ein Umbau der Bedienflächen              |
+| 3.1.4 Abkürzungen                     | auf den Rechtsseiten behoben, auf der Startseite offen      | Der Text kommt dort aus den Sprachdateien; 17 Fundstellen für ein AAA-Kriterium |
+| 3.1.5 Lesbarkeit                      | Rechtstexte über Sekundarstufe I                            | Erforderte eine zweite, vereinfachte Fassung jedes Rechtstexts                  |
 
 Sechs weitere AAA-Kriterien sind nur von Hand entscheidbar und hier nicht bewertet.
 

--- a/docs/barrierefreiheit/VOICEOVER-CHECKLISTE.md
+++ b/docs/barrierefreiheit/VOICEOVER-CHECKLISTE.md
@@ -23,12 +23,12 @@ hinterlegen — dann schaltet dreimaliges Drücken der Seitentaste um.
 
 **Die vier Tasten, die du am Mac brauchst:**
 
-| Taste | Was passiert |
-|---|---|
-| **Ctrl + ⌥ + →** | zum nächsten Element |
-| **Ctrl + ⌥ + Leertaste** | Element auslösen (wie klicken) |
-| **Tabulator** | zum nächsten Bedienelement springen |
-| **Ctrl** | VoiceOver zum Schweigen bringen |
+| Taste                    | Was passiert                        |
+| ------------------------ | ----------------------------------- |
+| **Ctrl + ⌥ + →**         | zum nächsten Element                |
+| **Ctrl + ⌥ + Leertaste** | Element auslösen (wie klicken)      |
+| **Tabulator**            | zum nächsten Bedienelement springen |
+| **Ctrl**                 | VoiceOver zum Schweigen bringen     |
 
 **Am iPhone:** einmal tippen = vorlesen, zweimal tippen = auslösen, mit einem Finger
 nach rechts streichen = nächstes Element.
@@ -52,7 +52,8 @@ zehnmal).
 - [ ] Wird die Überschrift „malziME" oder der Seitentitel vorgelesen?
 
 **Was du gehört hast, wenn es abweicht:**
-_____________________________________________
+
+---
 
 ### Schritt 2 — Die Demo-Fotos (Kriterium 1.1.1)
 
@@ -66,7 +67,8 @@ Das zweite ist der eigentliche Punkt: Die Kennzeichnung steht in den Pixeln des
 Bildes. Wer nicht sieht, muss sie gesagt bekommen.
 
 **Was du gehört hast:**
-_____________________________________________
+
+---
 
 ### Schritt 3 — Der Aufbau (Kriterium 1.3.1)
 
@@ -78,7 +80,8 @@ Rufe die Überschriftenliste auf: **Ctrl + ⌥ + U**, dann mit **←/→** zur K
 - [ ] Steht eine Überschrift an einer Stelle, wo keine hingehört?
 
 **Was dir aufgefallen ist:**
-_____________________________________________
+
+---
 
 ### Schritt 4 — Die Analyse ansagen (Kriterium 4.1.3)
 
@@ -95,7 +98,8 @@ Das ist der wichtigste Schritt des ganzen Durchgangs. Wer nicht sieht, erfährt 
 nicht, ob die Seite arbeitet oder hängt.
 
 **Wortlaut der Ansagen, so gut du ihn behältst:**
-_____________________________________________
+
+---
 
 ### Schritt 5 — Das Ergebnis durchgehen
 
@@ -109,7 +113,8 @@ Der letzte Punkt ist kein Formalismus: Ein Profil, das vorgelesen wird, ohne das
 Einordnung mitkommt, ist genau das, was malziME kritisiert.
 
 **Was du gehört hast:**
-_____________________________________________
+
+---
 
 ### Schritt 6 — Der Beast-Modus
 
@@ -120,7 +125,8 @@ Tabuliere zum Umschalter „Beast" und löse ihn aus.
 - [ ] Werden die neuen Inhalte vorgelesen, oder bleibt es still?
 
 **Was du gehört hast:**
-_____________________________________________
+
+---
 
 ### Schritt 7 — Nur mit der Tastatur, ohne VoiceOver (Kriterium 2.1.1)
 
@@ -139,7 +145,8 @@ Der letzte Punkt hat am 17. August einen echten Fehler zutage gebracht, der nur 
 iPhone und iPad auftrat. Deshalb steht er hier.
 
 **Wo du hängen geblieben bist:**
-_____________________________________________
+
+---
 
 ---
 
@@ -157,7 +164,8 @@ Streiche mit einem Finger von links nach rechts, bis du unten bist.
 - [ ] Wird etwas vorgelesen, das gar nicht da ist?
 
 **Was dir aufgefallen ist:**
-_____________________________________________
+
+---
 
 ### Schritt 9 — Analyse am Handy
 
@@ -172,7 +180,8 @@ greift auf iPhones nicht, dafür fängt die Warteschlange das ab. Ob das mit Voi
 auch trägt, hat noch niemand geprüft.
 
 **Was passiert ist:**
-_____________________________________________
+
+---
 
 ### Schritt 10 — Der Sprachumschalter
 
@@ -184,7 +193,8 @@ Doppeltippe auf **EN**.
       Wird der zweisprachige Hinweis vorgelesen — beide Zeilen?
 
 **Was du gehört hast:**
-_____________________________________________
+
+---
 
 ---
 
@@ -196,9 +206,9 @@ _____________________________________________
 **Gesamteindruck in einem Satz — würdest du damit arbeiten können, wenn du nichts
 sehen würdest?**
 
-_____________________________________________
+---
 
-_____________________________________________
+---
 
 ---
 

--- a/e2e/barrierefreiheit-protokoll.test.js
+++ b/e2e/barrierefreiheit-protokoll.test.js
@@ -122,6 +122,140 @@ async function endpunkteStellen(page, { jobStatus = { status: "done", result: PR
   await page.route("**/tile.openstreetmap.org/**", (r) => r.fulfill({ status: 200, body: "" }));
 }
 
+/* ── Abstentionen aufloesen ────────────────────────────────────────────────
+   axe meldet Kontrast als "unpruefbar", wenn es den Hintergrund nicht
+   bestimmen kann — Verlauf, Bild, ueberlappende Schichten, Halbtransparenz.
+   Das ist KEIN Bestehen. In der ersten Fassung des Protokolls wurden nur die
+   Verstoesse gezaehlt und daraus "0 Verstoesse" gemacht, waehrend 6 bis 13
+   Abstentionen je Seite unbeantwortet liegen blieben. Der unabhaengige
+   Zweitpruefer meldete genau dort einen Fehler.
+
+   Hier entscheidet die Messung statt der Vermutung: Das Element wird
+   fotografiert, das Foto in eine Leinwand gelegt und Bildpunkt fuer Bildpunkt
+   ausgelesen. Hellster und dunkelster Punkt sind Hintergrund und Schrift; ihr
+   Verhaeltnis ist der Kontrast nach der Formel der WCAG. Antialiasing erzeugt
+   Zwischentoene, die zwischen beiden liegen und das Ergebnis nicht verfaelschen
+   koennen. */
+function leuchtdichte(r, g, b) {
+  const k = [r, g, b].map((v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * k[0] + 0.7152 * k[1] + 0.0722 * k[2];
+}
+
+async function kontrastAusBildpunkten(page, waehler) {
+  const el = page.locator(waehler).first();
+  if (!(await el.count())) return null;
+  if (!(await el.isVisible().catch(() => false))) return null;
+
+  let png;
+  try {
+    png = await el.screenshot({ timeout: 5000 });
+  } catch {
+    return null; /* Element nicht fotografierbar (0 Pixel, ausserhalb) */
+  }
+
+  /* Das Foto zurueck in die Seite geben und dort auslesen — so braucht die
+     Messung keine zusaetzliche Bibliothek zum Entpacken von PNG. */
+  const punkte = await page.evaluate(async (b64) => {
+    const bild = new Image();
+    bild.src = "data:image/png;base64," + b64;
+    await bild.decode();
+    const c = document.createElement("canvas");
+    c.width = bild.naturalWidth;
+    c.height = bild.naturalHeight;
+    const ctx = c.getContext("2d", { willReadFrequently: true });
+    ctx.drawImage(bild, 0, 0);
+    const d = ctx.getImageData(0, 0, c.width, c.height).data;
+    const raus = [];
+    for (let i = 0; i < d.length; i += 4) {
+      if (d[i + 3] < 250) continue; /* halbtransparente Punkte taugen nicht */
+      raus.push([d[i], d[i + 1], d[i + 2]]);
+    }
+    return raus;
+  }, png.toString("base64"));
+
+  if (punkte.length < 4) return null;
+
+  let hell = -1;
+  let dunkel = 2;
+  for (const [r, g, b] of punkte) {
+    const l = leuchtdichte(r, g, b);
+    if (l > hell) hell = l;
+    if (l < dunkel) dunkel = l;
+  }
+  return Number(((hell + 0.05) / (dunkel + 0.05)).toFixed(2));
+}
+
+/* Schriftgroesse und -staerke entscheiden, welche Schwelle gilt: 3:1 fuer
+   grossen Text (ab 24 px, oder ab 18.66 px fett), sonst 4.5:1. */
+async function schwelleFuer(page, waehler) {
+  return page
+    .locator(waehler)
+    .first()
+    .evaluate((n) => {
+      const s = getComputedStyle(n);
+      const px = parseFloat(s.fontSize);
+      const fett = parseInt(s.fontWeight, 10) >= 700;
+      return (fett && px >= 18.66) || px >= 24 ? 3 : 4.5;
+    })
+    .catch(() => 4.5);
+}
+
+/* Benannte Ausnahmen — jede mit Grund, jede einzeln. Bewusst eine Liste im
+   Quelltext und keine stille Regel wie "alles mit aria-hidden ueberspringen":
+   Wer hier etwas eintraegt, muss eine Begruendung danebenschreiben, und die
+   steht dann im Diff. Eine unsichtbare Sammelausnahme waere genau der
+   Mechanismus, mit dem ein Protokoll unbemerkt wertlos wird. */
+const KONTRAST_AUSNAHMEN = [
+  {
+    passt: (waehler) => waehler.includes(".footer-sep"),
+    grund:
+      "Der Mittelpunkt zwischen den Fusszeilen-Links ist reine Zierde: Er traegt keine " +
+      "Information — die Links sind eigene Elemente und ohne ihn genauso getrennt — und " +
+      "hat keine Funktion. WCAG 1.4.3 nimmt reine Zierde ausdruecklich aus. Im Markup " +
+      'als aria-hidden="true" ausgewiesen, damit die Ausnahme dort steht, wo sie gilt, ' +
+      "und damit Screenreader nicht zwischen jedem Link einen Punkt vorlesen.",
+  },
+];
+
+async function abstentionenAufloesen(page, incomplete) {
+  const offen = [];
+  for (const regel of incomplete) {
+    if (regel.id !== "color-contrast") {
+      /* Andere Abstentionen sind selten und brauchen ein Augenpaar — sie
+         werden benannt, nicht weggerechnet. */
+      offen.push({ regel: regel.id, elemente: regel.nodes.length, aufloesung: "Handpruefung noetig" });
+      continue;
+    }
+    for (const knoten of regel.nodes) {
+      const waehler = knoten.target.join(" ");
+      const ausnahme = KONTRAST_AUSNAHMEN.find((a) => a.passt(waehler));
+      if (ausnahme) {
+        offen.push({ regel: regel.id, element: waehler, aufloesung: "Ausnahme: " + ausnahme.grund });
+        continue;
+      }
+      const gemessen = await kontrastAusBildpunkten(page, waehler);
+      if (gemessen == null) {
+        offen.push({ regel: regel.id, element: waehler, aufloesung: "nicht messbar" });
+        continue;
+      }
+      const schwelle = await schwelleFuer(page, waehler);
+      if (gemessen + 0.01 < schwelle) {
+        offen.push({
+          regel: regel.id,
+          element: waehler,
+          gemessen,
+          verlangt: schwelle,
+          aufloesung: "VERSTOSS, durch Bildpunkt-Messung bestaetigt",
+        });
+      }
+    }
+  }
+  return offen;
+}
+
 /**
  * Misst EINEN Zustand und legt das Ergebnis ab.
  *
@@ -160,6 +294,8 @@ async function messen(page, bildschirm, zustand) {
     zustand,
     geprueft: lauf1.passes.length,
     unpruefbar: lauf1.incomplete.map((v) => ({ regel: v.id, elemente: v.nodes.length })),
+    /* Jede Abstention einzeln aufgeloest — leer heisst: alle geklaert. */
+    abstentionOffen: await abstentionenAufloesen(page, lauf1.incomplete),
     wackelig: wackelig.map((v) => ({ regel: v.id, anzahl: v.nodes.length })),
     verstoesse: stabil.map((v) => ({
       regel: v.id,
@@ -175,6 +311,10 @@ async function messen(page, bildschirm, zustand) {
      "keine Verstoesse". Ohne diese Zeile waere ein kaputter Lauf ein
      Musterprotokoll. */
   expect(eintrag.geprueft, `axe hat auf ${bildschirm}/${zustand} nichts geprueft`).toBeGreaterThan(0);
+  /* Eine Abstention, die sich als Verstoss herausstellt, ist ein Verstoss —
+     und muss den Lauf rot machen, sonst haette der Auflöser keine Wirkung. */
+  const bestaetigt = eintrag.abstentionOffen.filter((a) => a.aufloesung.startsWith("VERSTOSS"));
+  expect(bestaetigt, `Kontrast zu schwach auf ${bildschirm}/${zustand}: ${JSON.stringify(bestaetigt)}`).toEqual([]);
   befunde.push(eintrag);
   return eintrag;
 }
@@ -608,6 +748,90 @@ test.describe("Prüfprotokoll WCAG 2.2 AA", () => {
     await messen(page, "Profil", "Beast, Umschalter geklebt");
 
     await umbruchMessen(page, "Profil");
+  });
+
+  /* WCAG-EM Schritt 3.3 verlangt VOLLSTAENDIGE Prozesse, nicht Einzelzustaende.
+     Diese drei Schritte der Analyse fehlten: Bildvorbereitung, Realitaets-Check
+     und PDF-Export. Ein Prozess gilt erst als geprueft, wenn alle Schritte es
+     sind. */
+  /* RUECKBAUPROBE fuer den Auflöser selbst. Ein Pruefmittel, das nicht rot
+     werden kann, belegt nichts. Hier wird absichtlich zu schwacher Kontrast
+     erzeugt und gemessen — findet die Bildpunkt-Messung ihn nicht, ist sie
+     kaputt, nicht die Seite. */
+  test("Rueckbauprobe: die Bildpunkt-Messung erkennt zu schwachen Kontrast", async ({ page }) => {
+    await endpunkteStellen(page);
+    await page.goto("/");
+    await page.evaluate(() => {
+      const d = document.createElement("p");
+      d.id = "kontrast-probe";
+      d.textContent = "Absichtlich zu blass";
+      /* 4.06:1 auf Weiss — deutlich unter den verlangten 4.5:1, aber nah genug,
+         dass nur eine echte Messung den Unterschied sieht. */
+      d.style.cssText = "color:#8a8a8a;background:#ffffff;font-size:16px;padding:8px;position:relative;z-index:9999";
+      document.body.prepend(d);
+    });
+    const gemessen = await kontrastAusBildpunkten(page, "#kontrast-probe");
+    expect(gemessen).not.toBeNull();
+    expect(gemessen).toBeLessThan(4.5);
+
+    /* Gegenprobe in dieselbe Richtung: Reicht der Kontrast, darf die Messung
+       NICHT anschlagen. Sonst wuerde sie alles rot faerben und waere ebenso
+       wertlos wie eine, die nie anschlaegt. */
+    await page.evaluate(() => {
+      document.getElementById("kontrast-probe").style.color = "#1a1a1a";
+    });
+    const gut = await kontrastAusBildpunkten(page, "#kontrast-probe");
+    expect(gut).toBeGreaterThan(4.5);
+  });
+
+  test("Prozess-Schritt: Foto gewaehlt, Vorbereitung laeuft", async ({ page }) => {
+    await endpunkteStellen(page, { jobStatus: { status: "queued", position: 1, etaSeconds: 20 } });
+    await page.goto("/");
+    /* Der Zustand zwischen Klick und Einreihung: Der Browser verkleinert das
+       Bild und liest die Metadaten. Kurz, aber sichtbar — und fuer jemanden mit
+       Screenreader der Moment, in dem etwas passieren muss. */
+    await page.click('[data-demo="selfie"]');
+    await page.waitForTimeout(1200);
+    await messen(page, "Analyse-Prozess", "Schritt 2: Bildvorbereitung");
+
+    /* Die eigentliche Zusicherung dieses Schritts, und der Grund, warum er in
+       der Prozessliste steht: Zwischen Klick und Warteschlange vergeht Zeit, in
+       der auf dem Bildschirm etwas passiert. Wer nicht sieht, erfaehrt davon
+       nur ueber einen Live-Bereich. Bleibt der leer, sitzt jemand vor einer
+       Seite, die scheinbar nichts tut — formal fehlerfrei, praktisch kaputt.
+       (WCAG 4.1.3 Statusmeldungen, Stufe AA) */
+    const lebend = page.locator('[aria-live="polite"], [aria-live="assertive"], [role="status"]');
+    await expect(lebend.first()).toHaveCount(1);
+    const gesagt = (await lebend.allTextContents()).join(" ").trim();
+    expect(gesagt.length, "Bildvorbereitung laeuft, aber kein Live-Bereich sagt etwas").toBeGreaterThan(0);
+  });
+
+  test("Prozess-Schritt: Realitaets-Check ausfuellen", async ({ page }) => {
+    await endpunkteStellen(page);
+    await page.goto("/");
+    await page.click('[data-demo="selfie"]');
+    await expect(page.locator(".cat-card").first()).toBeVisible({ timeout: 20000 });
+    const rc = page.locator(".rc-knopf").first();
+    if (await rc.count()) {
+      await rc.click();
+      await page.waitForTimeout(400);
+    }
+    await messen(page, "Analyse-Prozess", "Schritt 8: Realitaets-Check");
+    await zielgroessenMessen(page, "Realitaets-Check");
+  });
+
+  test("Prozess-Schritt: PDF-Export", async ({ page }) => {
+    await endpunkteStellen(page);
+    await page.goto("/");
+    await page.click('[data-demo="selfie"]');
+    await expect(page.locator(".cat-card").first()).toBeVisible({ timeout: 20000 });
+    /* Nur den Knopf pruefen, nicht die erzeugte Datei: Ein PDF ist ein eigenes
+       Format mit eigenen Barrierefreiheits-Regeln (PDF/UA) und gehoert nicht in
+       eine HTML-Pruefung. Was hier zaehlt: Ist der Weg dorthin bedienbar und
+       benannt? */
+    const knopf = page.locator("#exportPdf, [id*=export]").first();
+    await expect(knopf).toHaveCount(1);
+    await messen(page, "Analyse-Prozess", "Schritt 9: PDF-Export erreichbar");
   });
 
   test("Fehlermeldungen", async ({ page }) => {

--- a/public/barrierefreiheit.html
+++ b/public/barrierefreiheit.html
@@ -22,7 +22,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081702" />
+    <link rel="stylesheet" href="./styles.css?v=2026081703" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -235,6 +235,6 @@
     <!-- Diese Seite liegt nur auf Deutsch vor. Der Sprachumschalter zeigt das
          mit einem zweisprachigen Hinweis an. Verschwindet samt
          js/sprachhinweis.js, sobald die Rechtstexte auch auf Englisch da sind. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081702"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081703"></script>
   </body>
 </html>

--- a/public/barrierefreiheit.html
+++ b/public/barrierefreiheit.html
@@ -68,10 +68,18 @@
             <strong>11 nicht anwendbar</strong>, weil malziME keine Video- oder Tonbeitr&auml;ge, keine Anmeldung, keine
             Zeitbegrenzung und kein Formular mit personenbezogenen Daten enth&auml;lt.
             <strong>Vier weitere Kriterien sind messtechnisch erf&uuml;llt</strong> und werden zus&auml;tzlich von Hand
-            mit einem Screenreader gepr&uuml;ft; bis zum Abschluss dieser Pr&uuml;fung lautet die Aussage bewusst
-            &bdquo;weitgehend&ldquo; statt &bdquo;vollst&auml;ndig&ldquo;.
+            mit einem Screenreader gepr&uuml;ft.
           </p>
           <p><strong>Kein Kriterium ist als verletzt festgestellt.</strong></p>
+          <p>
+            <strong>Warum trotzdem &bdquo;weitgehend&ldquo; und nicht &bdquo;vollst&auml;ndig&ldquo;:</strong> Unsere
+            Workshops laufen auf allen Ger&auml;ten, die die Schulen und die Jugendlichen mitbringen &ndash; darauf
+            haben wir keinen Einfluss. Entsprechend breit ist unser Anspruch. Gepr&uuml;ft haben wir alle drei
+            Browser-Maschinen, aber l&auml;ngst nicht alle Hilfsmittel:
+            <strong>VoiceOver auf dem iPhone, NVDA, JAWS und TalkBack sind ungepr&uuml;ft</strong>, weil uns diese
+            Ger&auml;te nicht zur Verf&uuml;gung stehen. Solange das so ist, w&auml;re &bdquo;vollst&auml;ndig
+            konform&ldquo; eine Aussage &uuml;ber Ger&auml;te, an denen niemand gesessen hat.
+          </p>
         </div>
       </section>
 
@@ -79,14 +87,22 @@
       <section class="legal-section">
         <h2><span class="sec-num">03</span> Was gepr&uuml;ft wurde &ndash; und wie</h2>
         <p>
-          Gepr&uuml;ft wurden alle Seiten in allen wesentlichen Zust&auml;nden: leere Startseite, Warteschlange,
-          laufende KI-Ausgabe, fertiges Profil im seri&ouml;sen und im Beast-Modus, Fehlermeldungen, ge&ouml;ffnete
-          Hinweise.
+          Gepr&uuml;ft wurde nach
+          <a href="https://www.w3.org/TR/WCAG-EM/" rel="noopener noreferrer" target="_blank" tabindex="0">WCAG-EM 2.0</a
+          >, der offiziellen Pr&uuml;fmethodik des W3C. Sie schreibt vor, was ein Pr&uuml;fbericht enthalten muss
+          &ndash; unter anderem, mit welchen Ger&auml;ten eine Seite funktionieren soll und dass ein mehrstufiger Ablauf
+          in <em>allen</em> Schritten gepr&uuml;ft wird, nicht nur an einzelnen Stellen.
+        </p>
+        <p>
+          Gepr&uuml;ft wurden alle Seiten in allen wesentlichen Zust&auml;nden &ndash;
+          <strong>46 Zust&auml;nde je Browser</strong>: leere Startseite, Bildvorbereitung, Warteschlange, laufende
+          KI-Ausgabe, fertiges Profil im seri&ouml;sen und im Beast-Modus, Realit&auml;ts-Check, PDF-Ausgabe,
+          Fehlermeldungen, Verbindungsabbruch, ge&ouml;ffnete Hinweise.
         </p>
         <ul class="legal-list">
           <li>
-            <strong>Zwei Browser:</strong> Chromium und WebKit &ndash; die Maschine hinter Safari, weil unsere Workshops
-            auf iPhones stattfinden.
+            <strong>Drei Browser-Maschinen:</strong> Chromium (Chrome, Edge), WebKit (Safari) und Gecko (Firefox)
+            &ndash; damit sind alle Maschinen abgedeckt, die auf den Ger&auml;ten der Teilnehmenden laufen k&ouml;nnen.
           </li>
           <li>
             <strong>Zwei Bildschirmgr&ouml;&szlig;en:</strong> 1280&nbsp;Pixel am Rechner und 320&nbsp;Pixel am kleinen
@@ -104,6 +120,12 @@
           <li>
             <strong>Jede Messung l&auml;uft doppelt.</strong> &Uuml;bernommen wird nur, was beide Male auftritt &ndash;
             sonst landen Messfehler als Befunde im Protokoll.
+          </li>
+          <li>
+            <strong>Wo das Werkzeug sich enth&auml;lt, wird nachgemessen.</strong> axe kann manche Farbkontraste nicht
+            beurteilen und meldet sie als &bdquo;unpr&uuml;fbar&ldquo;. Das ist kein Bestehen. In solchen F&auml;llen
+            fotografieren wir das Element und rechnen den Kontrast Bildpunkt f&uuml;r Bildpunkt nach. Genau so haben wir
+            am 17.&nbsp;August ein zu blasses Info-Zeichen gefunden und behoben.
           </li>
           <li>
             <strong>Jede Messung hat eine Gegenprobe.</strong> Findet das Pr&uuml;fwerkzeug nichts zu pr&uuml;fen,
@@ -136,6 +158,11 @@
             nachweislich nicht &ndash; darunter das erh&ouml;hte Kontrastverh&auml;ltnis von 7&nbsp;:&nbsp;1, das einen
             Umbau unserer Markenfarben erfordern w&uuml;rde, und die Lesbarkeitsstufe, die eine zweite, vereinfachte
             Fassung aller Rechtstexte verlangt.
+          </li>
+          <li>
+            <strong>Nicht alle Hilfsmittel sind gepr&uuml;ft.</strong> Welche das sind und warum daraus die Aussage
+            &bdquo;weitgehend konform&ldquo; folgt, steht in Abschnitt&nbsp;02. Wenn Sie mit einem dieser Hilfsmittel
+            arbeiten: Ihre R&uuml;ckmeldung ist f&uuml;r uns wertvoller als jede weitere Messung.
           </li>
           <li>
             <strong>Die eingebettete Landkarte</strong> stammt von OpenStreetMap und wird von uns nicht gestaltet. Ihre
@@ -217,17 +244,17 @@
     <footer class="site-footer">
       <div class="footer-inner">
         <span class="footer-copy">&copy; 2026 malziME &bull; powered by malziland</span>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/" tabindex="0">Startseite</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/impressum" tabindex="0">Impressum</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/datenschutz" tabindex="0">Datenschutz</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/nutzungsbedingungen" tabindex="0">Nutzungsbedingungen</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/barrierefreiheit" tabindex="0">Barrierefreiheit</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/stats" tabindex="0">Stats</a>
       </div>
     </footer>

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -373,17 +373,17 @@
     <footer class="site-footer">
       <div class="footer-inner">
         <span class="footer-copy">&copy; 2026 malziME &bull; powered by malziland</span>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/" tabindex="0">Startseite</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/impressum" tabindex="0">Impressum</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/datenschutz" tabindex="0">Datenschutz</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/nutzungsbedingungen" tabindex="0">Nutzungsbedingungen</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/barrierefreiheit" tabindex="0">Barrierefreiheit</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/stats" tabindex="0">Stats</a>
       </div>
     </footer>

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -22,7 +22,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081702" />
+    <link rel="stylesheet" href="./styles.css?v=2026081703" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -390,6 +390,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081702"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081703"></script>
   </body>
 </html>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -128,17 +128,17 @@
     <footer class="site-footer">
       <div class="footer-inner">
         <span class="footer-copy">&copy; 2026 malziME &bull; powered by malziland</span>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/" tabindex="0">Startseite</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/impressum" tabindex="0">Impressum</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/datenschutz" tabindex="0">Datenschutz</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/nutzungsbedingungen" tabindex="0">Nutzungsbedingungen</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/barrierefreiheit" tabindex="0">Barrierefreiheit</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/stats" tabindex="0">Stats</a>
       </div>
     </footer>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -47,7 +47,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081702" />
+    <link rel="stylesheet" href="./styles.css?v=2026081703" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -145,6 +145,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081702"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081703"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -100,7 +100,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081702" />
+    <link rel="stylesheet" href="./styles.css?v=2026081703" />
     <script type="application/ld+json">
       [
         {
@@ -424,7 +424,7 @@
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
             <img
-              src="./img/demo/demo-selfie-thumb.jpg?v=2026081702"
+              src="./img/demo/demo-selfie-thumb.jpg?v=2026081703"
               data-i18n-src="demo.src.selfie"
               data-i18n-alt="demo.alt.selfie"
               alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person."
@@ -434,7 +434,7 @@
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
             <img
-              src="./img/demo/demo-cafe-thumb.jpg?v=2026081702"
+              src="./img/demo/demo-cafe-thumb.jpg?v=2026081703"
               data-i18n-src="demo.src.cafe"
               data-i18n-alt="demo.alt.cafe"
               alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person."
@@ -444,7 +444,7 @@
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
             <img
-              src="./img/demo/demo-hiker-thumb.jpg?v=2026081702"
+              src="./img/demo/demo-hiker-thumb.jpg?v=2026081703"
               data-i18n-src="demo.src.hiker"
               data-i18n-alt="demo.alt.hiker"
               alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person."
@@ -549,6 +549,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081702"></script>
+    <script type="module" src="./app.js?v=2026081703"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -494,13 +494,13 @@
     <footer class="site-footer">
       <div class="footer-inner">
         <span class="footer-copy" data-i18n="footer.copy">&copy; 2026 malziME &bull; powered by malziland</span>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/impressum" target="_blank" rel="noopener" tabindex="0" data-i18n="footer.impressum">Impressum</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/datenschutz" target="_blank" rel="noopener" tabindex="0" data-i18n="footer.datenschutz"
           >Datenschutz</a
         >
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a
           href="/nutzungsbedingungen"
           target="_blank"
@@ -509,11 +509,11 @@
           data-i18n="footer.nutzungsbedingungen"
           >Nutzungsbedingungen</a
         >
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/barrierefreiheit" target="_blank" rel="noopener" tabindex="0" data-i18n="footer.barrierefreiheit"
           >Barrierefreiheit</a
         >
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/stats" target="_blank" rel="noopener" tabindex="0" data-i18n="footer.stats">Stats</a>
       </div>
     </footer>

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -14,7 +14,7 @@ import { logClientError } from "./error-logger.js";
    ausgeschrieben — und wurde vom Deploy prompt selbst überschrieben, weil das
    Muster null Ziffern erlaubte. Beides ist behoben; der Satz nennt das Muster
    trotzdem nicht mehr wörtlich. */
-const DEMO_BUSTER = "?v=2026081702";
+const DEMO_BUSTER = "?v=2026081703";
 
 /* 2026-08-13: Die KI-Kennzeichnung ist in die Pixel gebrannt (Pflicht seit
    08/2026 — ein CSS-Etikett verschwindet, sobald jemand das Bild speichert).

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -22,7 +22,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081702" />
+    <link rel="stylesheet" href="./styles.css?v=2026081703" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -328,6 +328,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081702"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081703"></script>
   </body>
 </html>

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -311,17 +311,17 @@
     <footer class="site-footer">
       <div class="footer-inner">
         <span class="footer-copy">&copy; 2026 malziME &bull; powered by malziland</span>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/" tabindex="0">Startseite</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/impressum" tabindex="0">Impressum</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/datenschutz" tabindex="0">Datenschutz</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/nutzungsbedingungen" tabindex="0">Nutzungsbedingungen</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/barrierefreiheit" tabindex="0">Barrierefreiheit</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/stats" tabindex="0">Stats</a>
       </div>
     </footer>

--- a/public/stats.html
+++ b/public/stats.html
@@ -217,17 +217,17 @@
     <footer class="site-footer">
       <div class="footer-inner">
         <span class="footer-copy" data-i18n="footer.copy">&copy; 2026 malziME &bull; powered by malziland</span>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/" tabindex="0" data-i18n="footer.startseite">Startseite</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/impressum" tabindex="0" data-i18n="footer.impressum">Impressum</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/datenschutz" tabindex="0" data-i18n="footer.datenschutz">Datenschutz</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/nutzungsbedingungen" tabindex="0" data-i18n="footer.nutzungsbedingungen">Nutzungsbedingungen</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/barrierefreiheit" tabindex="0" data-i18n="footer.barrierefreiheit">Barrierefreiheit</a>
-        <span class="footer-sep">&middot;</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
         <a href="/stats" tabindex="0" data-i18n="footer.stats">Stats</a>
       </div>
     </footer>

--- a/public/stats.html
+++ b/public/stats.html
@@ -25,7 +25,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081702" />
+    <link rel="stylesheet" href="./styles.css?v=2026081703" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -232,6 +232,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081702"></script>
+    <script type="module" src="./js/stats.js?v=2026081703"></script>
   </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -554,15 +554,25 @@ html[data-has-result] {
   font-size: 0.58rem;
   font-weight: 700;
   font-style: normal;
-  color: inherit;
+  color: var(--muted);
   line-height: 1;
-  opacity: 0.55;
-  transition: opacity 0.2s var(--ease);
+  /* KEIN opacity im Ruhezustand. Vorher stand hier 0.55 — das verblasste den
+     Buchstaben UND den Kreisrand (border: currentColor) auf 2.18:1. Verlangt
+     sind 4.5:1 fuer den Buchstaben (WCAG 1.4.3) und 3:1 fuer den Rand des
+     Bedienelements (1.4.11); beides verfehlt. Dass es beim Ueberfahren mit der
+     Maus hell wird, hilft nicht: Das Kriterium gilt fuer den Zustand, in dem
+     man das Element vorfindet — und wer mit der Tastatur oder am Finger
+     arbeitet, faehrt gar nicht darueber.
+     Gefunden nicht von axe, sondern von der Bildpunkt-Messung, die axes
+     Abstention aufloest. --muted auf --bg ergibt 5.22:1 hell und 7.85:1
+     dunkel. Der Aufhell-Effekt bleibt, er laeuft jetzt ueber die Farbe. */
+  transition: color 0.2s var(--ease);
 }
 
 .info-icon:hover .info-i,
+.info-icon:focus-visible .info-i,
 .info-icon.tooltip-open .info-i {
-  opacity: 1;
+  color: var(--text);
 }
 
 .tooltip {


### PR DESCRIPTION
## Warum

Nutzer-Ansage: methodisch richtig arbeiten, nicht das Erstbeste umsetzen. Die Messungen waren belastbar, die **Struktur war selbst ausgedacht**. Für einen Förderantrag ist „gründlich geprüft" wertlos, „geprüft nach WCAG-EM" belastbar.

## Was sich ändert

**`PRUEFBERICHT-WCAG-EM.md`** ist neu und kanonisch — fünf Schritte nach der [W3C-Methodik](https://www.w3.org/TR/WCAG-EM/). `PRUEFPROTOKOLL.md` wird zu **Anhang A**.

Vier Pflichtangaben fehlten vorher komplett:
- Accessibility-Support-Baseline (ohne sie ist „konform" nicht bestimmbar)
- eingesetzte Technologien
- begründete Stichprobe samt Zufallsanteil
- vollständige Prozesse statt Einzelzustände

Die Baseline ist nach Nutzer-Korrektur **breit**: alle Geräte, die Schulen und Jugendliche mitbringen. Der Bericht stellt ihr die tatsächliche Prüftiefe gegenüber — drei Browser-Maschinen vollständig, vier Hilfsmittel-Kombinationen gar nicht.

## Zwei Funde, beide von der Methodik ausgelöst

**Drei Prozessschritte waren nie gemessen** — Bildvorbereitung, Realitäts-Check, PDF-Export. Ergänzt.

**Ein zu blasses Bedienelement.** Der Bericht behauptete „Jede Abstention wird einzeln aufgelöst" — den Mechanismus gab es nicht. Jetzt schon: Element fotografieren, Kontrast Bildpunkt für Bildpunkt nachrechnen. Fand sofort `.info-i` bei `opacity: 0.55` → **2,18:1 statt 4,5:1**. Ein Bedienelement (`role="button"`, tabindex 0), keine Zierde; dass es bei Mausberührung hell wurde, hilft an Tastatur und Finger nicht.

Behoben über Farbe statt Deckkraft: 5,22:1 hell, 7,85:1 dunkel. Messung gegen Handrechnung gegengeprüft (2,21 gerechnet / 2,18 gemessen).

Rückbauprobe in **beide** Richtungen: zu blasser Text MUSS erkannt, ausreichender MUSS durchgelassen werden.

## Prüfstand

| Suite | Ergebnis |
|---|---|
| Backend | 844/845 grün (1 übersprungen) |
| Frontend | 407/407 grün |
| E2E | 157/157 grün |

`scripts/pruefstand.sh`, Commit `ebbbb5b`, 2026-08-17 — in `docs/VERIFICATION.md` gestempelt.

**Messstand:** 46 Zustände × 3 Browser = 138 Messungen, **0 Verstöße**, 55 Abstentionen, davon **0 ungeklärt**. Alle 55 sind der Fußzeilen-Trennpunkt — reine Zierde nach 1.4.3, als benannte Ausnahme *mit Begründung* im Prüfcode statt als stille Sammelregel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)