### PR TITLE
chore: Cache-Buster auf 2026081801

### DIFF
--- a/public/barrierefreiheit.html
+++ b/public/barrierefreiheit.html
@@ -22,7 +22,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081703" />
+    <link rel="stylesheet" href="./styles.css?v=2026081801" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -262,6 +262,6 @@
     <!-- Diese Seite liegt nur auf Deutsch vor. Der Sprachumschalter zeigt das
          mit einem zweisprachigen Hinweis an. Verschwindet samt
          js/sprachhinweis.js, sobald die Rechtstexte auch auf Englisch da sind. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081703"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081801"></script>
   </body>
 </html>

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -22,7 +22,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081703" />
+    <link rel="stylesheet" href="./styles.css?v=2026081801" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -390,6 +390,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081703"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081801"></script>
   </body>
 </html>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -47,7 +47,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081703" />
+    <link rel="stylesheet" href="./styles.css?v=2026081801" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -145,6 +145,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081703"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081801"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -100,7 +100,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
-    <link rel="stylesheet" href="./styles.css?v=2026081703" />
+    <link rel="stylesheet" href="./styles.css?v=2026081801" />
     <script type="application/ld+json">
       [
         {
@@ -424,7 +424,7 @@
         <div class="demo-grid">
           <button class="demo-thumb" data-demo="selfie" type="button" tabindex="0">
             <img
-              src="./img/demo/demo-selfie-thumb.jpg?v=2026081703"
+              src="./img/demo/demo-selfie-thumb.jpg?v=2026081801"
               data-i18n-src="demo.src.selfie"
               data-i18n-alt="demo.alt.selfie"
               alt="Mit KI erstelltes Beispielbild: Selfie am Stephansplatz. Zeigt keine reale Person."
@@ -434,7 +434,7 @@
           </button>
           <button class="demo-thumb" data-demo="cafe" type="button" tabindex="0">
             <img
-              src="./img/demo/demo-cafe-thumb.jpg?v=2026081703"
+              src="./img/demo/demo-cafe-thumb.jpg?v=2026081801"
               data-i18n-src="demo.src.cafe"
               data-i18n-alt="demo.alt.cafe"
               alt="Mit KI erstelltes Beispielbild: Im Café in Salzburg. Zeigt keine reale Person."
@@ -444,7 +444,7 @@
           </button>
           <button class="demo-thumb" data-demo="hiker" type="button" tabindex="0">
             <img
-              src="./img/demo/demo-hiker-thumb.jpg?v=2026081703"
+              src="./img/demo/demo-hiker-thumb.jpg?v=2026081801"
               data-i18n-src="demo.src.hiker"
               data-i18n-alt="demo.alt.hiker"
               alt="Mit KI erstelltes Beispielbild: Wanderung bei Hallstatt. Zeigt keine reale Person."
@@ -549,6 +549,6 @@
     <div id="srAnnounce" class="sr-only" aria-live="assertive"></div>
 
     <script src="./lib/leaflet/leaflet.js"></script>
-    <script type="module" src="./app.js?v=2026081703"></script>
+    <script type="module" src="./app.js?v=2026081801"></script>
   </body>
 </html>

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -14,7 +14,7 @@ import { logClientError } from "./error-logger.js";
    ausgeschrieben — und wurde vom Deploy prompt selbst überschrieben, weil das
    Muster null Ziffern erlaubte. Beides ist behoben; der Satz nennt das Muster
    trotzdem nicht mehr wörtlich. */
-const DEMO_BUSTER = "?v=2026081703";
+const DEMO_BUSTER = "?v=2026081801";
 
 /* 2026-08-13: Die KI-Kennzeichnung ist in die Pixel gebrannt (Pflicht seit
    08/2026 — ein CSS-Etikett verschwindet, sobald jemand das Bild speichert).

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -22,7 +22,7 @@
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
-    <link rel="stylesheet" href="./styles.css?v=2026081703" />
+    <link rel="stylesheet" href="./styles.css?v=2026081801" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -328,6 +328,6 @@
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
-    <script type="module" src="./js/sprachhinweis.js?v=2026081703"></script>
+    <script type="module" src="./js/sprachhinweis.js?v=2026081801"></script>
   </body>
 </html>

--- a/public/stats.html
+++ b/public/stats.html
@@ -25,7 +25,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./site.webmanifest" />
 
-    <link rel="stylesheet" href="./styles.css?v=2026081703" />
+    <link rel="stylesheet" href="./styles.css?v=2026081801" />
   </head>
   <body>
     <a href="#main" class="skip-link" tabindex="0">Zum Inhalt springen</a>
@@ -232,6 +232,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./js/stats.js?v=2026081703"></script>
+    <script type="module" src="./js/stats.js?v=2026081801"></script>
   </body>
 </html>


### PR DESCRIPTION
Nachlauf zum Hosting-Deploy von `a8c0832` (Prüfbericht nach WCAG-EM, Kontrast-Fix am Info-Zeichen). Live-Smoke 6/6 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)