### PR TITLE
release: 3.4.0 — Barrierefreiheit nach WCAG-EM geprüft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ ein neu gebautes Messmittel, zwei fielen beim Umbau auf die W3C-Prüfmethodik an
   ein Prüfmittel, das nie anschlägt, und eines, das immer anschlägt, sind gleich
   wertlos.
 
+- **Zwei wackelige Prüfungen entwackelt.** Eine Zusicherung wählte über einen
+  Komma-Wähler „das erste Element im Dokument" statt „das mit Inhalt" und wurde
+  auf Firefox rot, obwohl die Seite in Ordnung war; eine zweite konnte praktisch
+  nicht fehlschlagen. Ein wackeliger Riegel ist schlimmer als keiner — er wird
+  irgendwann übergangen, und dann fängt er auch die echten Fälle nicht mehr.
+  Gewartet wird jetzt auf die Bedingung statt auf die Uhr.
+
 - **Ein Protokoll der Vorlese-Reihenfolge** über alle Seiten und Zustände: jedes
   Element mit Rolle, Name und Zustand, in der Reihenfolge, in der es gesprochen
   würde. Ergebnis: kein Bedienelement ohne Namen, kein Bild ohne Alternativtext.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [3.4.0] — 2026-08-18
+
+Barrierefreiheit: geprüft nach der Methodik des W3C, sechs Mängel behoben.
+
+Der Prüfbericht folgt jetzt **WCAG-EM 2.0** statt einer selbst gewählten Form.
+Das ist kein Formalismus — die Methodik verlangt Angaben, die vorher fehlten,
+und genau diese Fragen brachten drei ungeprüfte Schritte und einen echten
+Kontrastmangel ans Licht.
+
+Die Konformitätsaussage lautet bewusst „weitgehend konform" und nicht
+„konform": Alle drei Browser-Maschinen sind geprüft, vier
+Hilfsmittel-Kombinationen nicht.
 
 ### Behoben — Barrierefreiheit
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 844/845 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 53cd5e8, 2026-08-18 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 407/407 grün — `scripts/pruefstand.sh`, Commit 53cd5e8, 2026-08-18 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 161/161 grün — `scripts/pruefstand.sh`, Commit 53cd5e8, 2026-08-18 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 844/845 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 3847562, 2026-08-18 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 407/407 grün — `scripts/pruefstand.sh`, Commit 3847562, 2026-08-18 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 161/161 grün — `scripts/pruefstand.sh`, Commit 3847562, 2026-08-18 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/e2e/barrierefreiheit-protokoll.test.js
+++ b/e2e/barrierefreiheit-protokoll.test.js
@@ -708,11 +708,13 @@ test.describe("Prüfprotokoll WCAG 2.2 AA", () => {
     });
     await page.goto("/");
     await page.click('[data-demo="selfie"]');
-    await page.waitForTimeout(4000);
     /* POSITIVKONTROLLE: Ohne sie koennte dieser Test eine leere Seite messen
        und "keine Verstoesse" melden — der Wartezustand muss nachweislich da
-       sein, sonst ist das Protokoll an dieser Stelle wertlos. */
-    await expect(page.locator("#scanText")).not.toBeEmpty();
+       sein, sonst ist das Protokoll an dieser Stelle wertlos.
+       Gewartet wird auf die Bedingung, nicht auf die Uhr: Eine feste Frist ist
+       auf einem langsamen Laufer zu kurz und auf einem schnellen verschenkte
+       Zeit. */
+    await expect(page.locator("#scanText")).not.toBeEmpty({ timeout: 20000 });
     await messen(page, "Warteschlange", "wartend mit Position und Restzeit");
 
     await page.unroute("**/api/job-status**");
@@ -723,8 +725,22 @@ test.describe("Prüfprotokoll WCAG 2.2 AA", () => {
         body: JSON.stringify({ status: "processing", liveText: "Du bist vermutlich Mitte zwanzig und " }),
       })
     );
-    await page.waitForTimeout(4000);
-    await expect(page.locator("#liveTextFest, #scanText").first()).not.toBeEmpty();
+    /* NICHT `locator("#a, #b").first()` — das waehlt nach Reihenfolge im
+       Dokument, nicht nach "das mit Inhalt". Sobald die Verarbeitung beginnt,
+       wird #scanText geleert und der Text steht in #liveTextFest; .first()
+       prueft dann das leere Element. Auf Firefox trat genau diese Reihenfolge
+       ein — der Riegel war dort rot, obwohl die Seite in Ordnung war.
+       Ein wackeliger Riegel ist schlimmer als keiner: Er wird irgendwann
+       uebergangen, und dann faengt er auch die echten Faelle nicht mehr.
+       Geprueft wird deshalb, ob IRGENDWO Live-Text steht, und mit Warten auf
+       die Bedingung statt auf die Uhr. */
+    await expect
+      .poll(
+        async () =>
+          (await page.locator("#liveTextFest, #scanText").allTextContents()).join("").replace(/\s+/g, "").length,
+        { timeout: 20000, message: "Weder #liveTextFest noch #scanText tragen Live-Text" }
+      )
+      .toBeGreaterThan(0);
     await messen(page, "Live-Text", "Modell schreibt mit");
   });
 
@@ -829,8 +845,16 @@ test.describe("Prüfprotokoll WCAG 2.2 AA", () => {
        Format mit eigenen Barrierefreiheits-Regeln (PDF/UA) und gehoert nicht in
        eine HTML-Pruefung. Was hier zaehlt: Ist der Weg dorthin bedienbar und
        benannt? */
-    const knopf = page.locator("#exportPdf, [id*=export]").first();
-    await expect(knopf).toHaveCount(1);
+    /* `toHaveCount(1)` auf einem .first()-Waehler ist fast immer wahr und
+       belegt nichts — es genuegt IRGENDEIN Treffer, auch der falsche.
+       Geprueft wird deshalb, was der Schritt wirklich braucht: Der Knopf ist
+       sichtbar, mit der Tastatur erreichbar und traegt einen Namen. Ein
+       Bedienelement ohne Namen ist fuer einen Screenreader nicht vorhanden. */
+    const knopf = page.getByRole("button", { name: /pdf|export|herunterladen|speichern/i }).first();
+    await expect(knopf).toBeVisible({ timeout: 20000 });
+    const name = (await knopf.evaluate((n) => n.getAttribute("aria-label") || n.textContent || "")).trim();
+    expect(name.length, "Der PDF-Knopf traegt keinen Namen").toBeGreaterThan(2);
+    await expect(knopf).toHaveAttribute("tabindex", "0");
     await messen(page, "Analyse-Prozess", "Schritt 9: PDF-Export erreichbar");
   });
 


### PR DESCRIPTION
## Warum jetzt

Der Versionsschnitt fehlte. Zwei Deploys sind in der Nacht rausgegangen (`2026081801`, `2026081802`), während GitHub weiterhin `v3.3.2` als neuesten Stand meldete — **das Repository behauptete weniger, als live stand.** Projektregel ist „Deploy = Release".

## Inhalt

- Prüfbericht nach **WCAG-EM 2.0** statt selbst gewählter Form
- **Sechs behobene Mängel**, darunter ein Kontrastmangel an einem Bedienelement (2,18 : 1) und doppelte Screenreader-Ansagen
- **Vier neue Wächter**, jeder mit Positivkontrolle und Rückbauprobe
- Testdateien von sechs auf vier, mit klaren Zuständigkeiten

## Bewusst offen

Die Aussage bleibt **„weitgehend konform"**. Alle drei Browser-Maschinen sind geprüft, vier Hilfsmittel-Kombinationen nicht. Der iPhone-Durchgang hebt sie später auf „konform" — eigener kleiner Schnitt, weil sich dann nur noch ein Satz auf drei Flächen ändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)