### PR TITLE
feat: aus der Lücke wird eine Einladung — Mitmach-Aufruf auf /barrierefreiheit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+### Geändert
+
+- **Die Barrierefreiheitserklärung lädt jetzt ein, statt sich zu entschuldigen.**
+  Bisher stand dort, die fehlenden Hilfsmittel-Durchgänge lägen daran, dass uns
+  „diese Geräte nicht zur Verfügung stehen" — was für das iPhone schlicht nicht
+  stimmte. Jetzt steht dieselbe Tatsache mit einem Weg daneben: Was offen ist,
+  liegt öffentlich auf GitHub, und wer mit einem Screenreader arbeitet, kann es
+  in fünf Minuten beantworten. Ohne GitHub-Konto genügt eine E-Mail.
+
+- **`/barrierefreiheit` trägt jetzt dieselben Kästen wie alle anderen Seiten**
+  (Open Source, Projektunterstützung). Sie war die einzige Seite ohne.
+
 ## [3.4.0] — 2026-08-18
 
 Barrierefreiheit: geprüft nach der Methodik des W3C, sechs Mängel behoben.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 844/845 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 3847562, 2026-08-18 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 407/407 grün — `scripts/pruefstand.sh`, Commit 3847562, 2026-08-18 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 161/161 grün — `scripts/pruefstand.sh`, Commit 3847562, 2026-08-18 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 844/845 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 05e2a71, 2026-08-18 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 407/407 grün — `scripts/pruefstand.sh`, Commit 05e2a71, 2026-08-18 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 161/161 grün — `scripts/pruefstand.sh`, Commit 05e2a71, 2026-08-18 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/docs/barrierefreiheit/PRUEFBERICHT-WCAG-EM.md
+++ b/docs/barrierefreiheit/PRUEFBERICHT-WCAG-EM.md
@@ -16,8 +16,8 @@ Bewertung der Konformität mit den Web Content Accessibility Guidelines.
 | ------------------- | ------------------------------------------------------------------------------ |
 | **Prüfer**          | malziland - learning \| training \| consulting e.U., Inhaber Christoph Krieger |
 | **Auftraggeber**    | Eigenprüfung                                                                   |
-| **Prüfdatum**       | 17. August 2026                                                                |
-| **Geprüfter Stand** | Commit `b83121d`, ausgelieferte Kennung `2026081703`                           |
+| **Prüfdatum**       | 17.–18. August 2026                                                            |
+| **Geprüfter Stand** | Commit `05e2a71` (v3.4.0), ausgelieferte Kennung `2026081802`                  |
 | **Art der Prüfung** | Selbstbewertung, werkzeuggestützt und teilweise manuell                        |
 
 ---

--- a/public/barrierefreiheit.html
+++ b/public/barrierefreiheit.html
@@ -34,7 +34,7 @@
     <main id="main" class="container legal-page">
       <span class="page-eyebrow"><a href="/" class="eyebrow-home" tabindex="0">malziME</a> &middot; Rechtliches</span>
       <h1>Barrierefreiheit</h1>
-      <p class="legal-subtitle">Gepr&uuml;ft, nicht behauptet &middot; Stand: 17. August 2026</p>
+      <p class="legal-subtitle">Gepr&uuml;ft, nicht behauptet &middot; Stand: 18. August 2026</p>
       <div class="page-rule"></div>
 
       <!-- 1. Anspruch -->
@@ -72,13 +72,18 @@
           </p>
           <p><strong>Kein Kriterium ist als verletzt festgestellt.</strong></p>
           <p>
-            <strong>Warum trotzdem &bdquo;weitgehend&ldquo; und nicht &bdquo;vollst&auml;ndig&ldquo;:</strong> Unsere
-            Workshops laufen auf allen Ger&auml;ten, die die Schulen und die Jugendlichen mitbringen &ndash; darauf
-            haben wir keinen Einfluss. Entsprechend breit ist unser Anspruch. Gepr&uuml;ft haben wir alle drei
-            Browser-Maschinen, aber l&auml;ngst nicht alle Hilfsmittel:
-            <strong>VoiceOver auf dem iPhone, NVDA, JAWS und TalkBack sind ungepr&uuml;ft</strong>, weil uns diese
-            Ger&auml;te nicht zur Verf&uuml;gung stehen. Solange das so ist, w&auml;re &bdquo;vollst&auml;ndig
-            konform&ldquo; eine Aussage &uuml;ber Ger&auml;te, an denen niemand gesessen hat.
+            <strong>Warum &bdquo;weitgehend&ldquo; und nicht &bdquo;vollst&auml;ndig&ldquo;:</strong> Unsere Workshops
+            laufen auf allen Ger&auml;ten, die Schulen und Jugendliche mitbringen. Entsprechend breit setzen wir den
+            Ma&szlig;stab &ndash; und entsprechend genau sagen wir, wo wir stehen. Alle drei Browser-Maschinen sind
+            gepr&uuml;ft. Bei den Hilfsmitteln ist noch ein St&uuml;ck Weg offen:
+            <strong>VoiceOver am iPhone</strong> steht als n&auml;chster Durchgang an,
+            <strong>NVDA, JAWS und TalkBack</strong> laufen auf Systemen, die wir nicht im Haus haben.
+          </p>
+          <p>
+            Diesen Rest schlie&szlig;t man nicht am Schreibtisch. Wer t&auml;glich mit einem Screenreader arbeitet,
+            merkt in f&uuml;nf Minuten, wof&uuml;r wir Stunden messen.
+            <strong>Deshalb liegt die Frage offen auf GitHub</strong> &ndash; nachzulesen und zu beantworten von allen,
+            die mitreden k&ouml;nnen (Abschnitt 06).
           </p>
         </div>
       </section>
@@ -200,6 +205,25 @@
           Seite betroffen ist und mit welchem Ger&auml;t oder Hilfsmittel Sie unterwegs waren. Auch ein knapper Hinweis
           hilft &ndash; wir suchen selbst weiter.
         </p>
+        <div class="support-box support-box--inline">
+          <p class="support-headline">Sie arbeiten mit einem Screenreader?</p>
+          <p class="support-text">
+            Dann sehen Sie in f&uuml;nf Minuten, wof&uuml;r wir Stunden messen. Was uns fehlt, steht offen auf GitHub
+            &ndash; jede R&uuml;ckmeldung z&auml;hlt, auch eine einzelne Zeile.
+          </p>
+          <a
+            href="https://github.com/malziland/malzime/issues/155"
+            target="_blank"
+            rel="noopener"
+            class="support-btn"
+            tabindex="0"
+            >Zur offenen Frage auf GitHub</a
+          >
+          <p class="support-fein">
+            Ohne GitHub-Konto geht es genauso &ndash; schreiben Sie einfach an die Adresse oben.
+          </p>
+        </div>
+
         <p>
           Sollten Sie sich durch eine Barriere benachteiligt f&uuml;hlen, steht Ihnen unabh&auml;ngig von uns das
           <strong>Schlichtungsverfahren beim Sozialministeriumservice</strong> offen. Es ist kostenfrei und formlos,
@@ -234,12 +258,37 @@
           <p>Weitere Kontaktdaten im <a href="/impressum" tabindex="0">Impressum</a>.</p>
         </div>
         <p>
-          Erstellt am 17.&nbsp;August&nbsp;2026 auf Grundlage einer Selbstbewertung mit den unter 03 genannten
-          Werkzeugen. Wir pr&uuml;fen erneut bei jeder &Auml;nderung an Aussehen, Bedienung oder Seitenaufbau,
-          mindestens aber halbj&auml;hrlich. Die maschinellen Messungen laufen bei jeder Auslieferung automatisch mit.
+          Erstellt am 17.&nbsp;August&nbsp;2026, zuletzt gepr&uuml;ft am 18.&nbsp;August&nbsp;2026, auf Grundlage einer
+          Selbstbewertung mit den unter 03 genannten Werkzeugen. Wir pr&uuml;fen erneut bei jeder &Auml;nderung an
+          Aussehen, Bedienung oder Seitenaufbau, mindestens aber halbj&auml;hrlich. Die maschinellen Messungen laufen
+          bei jeder Auslieferung automatisch mit.
         </p>
       </section>
     </main>
+
+    <div class="opensource-box">
+      <a
+        href="https://github.com/malziland/malzime"
+        target="_blank"
+        rel="noopener"
+        class="opensource-link"
+        tabindex="0"
+      >
+        <svg viewBox="0 0 16 16">
+          <path
+            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"
+          />
+        </svg>
+        Open Source auf GitHub
+      </a>
+    </div>
+    <div class="support-box">
+      <p class="support-headline">Keine Paywall. Kein Bullshit.</p>
+      <p class="support-text">Und du h&auml;ltst es am Laufen.</p>
+      <a href="https://buymeacoffee.com/malzime" target="_blank" rel="noopener" class="support-btn" tabindex="0"
+        >Jetzt Projekt unterst&uuml;tzen</a
+      >
+    </div>
 
     <footer class="site-footer">
       <div class="footer-inner">

--- a/public/styles.css
+++ b/public/styles.css
@@ -3822,3 +3822,51 @@ html[lang="en"] .rc-zitat::after {
 .seiten-kopfzeile .page-eyebrow {
   margin-bottom: 0;
 }
+
+/* ── Aufruf zum Mitmachen, eingebettet in einen Textabschnitt ──────────────
+   Anlass 2026-08-18: Die Barrierefreiheitserklaerung benannte die ungepruefen
+   Hilfsmittel als Entschuldigung ("stehen uns nicht zur Verfuegung"). Aus der
+   Luecke wird eine Einladung — dieselbe Tatsache, aber mit einem Weg daneben.
+
+   Baut auf .support-box auf, das ausserhalb von <main> am Seitenende steht.
+   Diese Abwandlung sitzt MITTEN im Text und braucht deshalb einen eigenen
+   Rahmen, damit sie sich vom Fliesstext absetzt, ohne wie eine Werbeflaeche zu
+   wirken. */
+.support-box--inline {
+  max-width: none;
+  padding: 20px 18px;
+  margin: 18px 0;
+  background: var(--tint-teal);
+  border-left: 2px solid var(--ml-teal);
+  border-radius: var(--radius-md);
+}
+
+.support-box--inline .support-headline {
+  margin: 0 0 6px;
+}
+
+.support-box--inline .support-text {
+  margin: 0 0 14px;
+}
+
+/* KASKADEN-KOLLISION, beim Ansehen gefunden und fast ausgeliefert:
+   `.legal-section a` (Spezifitaet 0,1,1) schlaegt `.support-btn` (0,1,0) und
+   faerbte den Knopftext tuerkis MIT Unterstreichung — tuerkis auf tuerkisem
+   Verlauf, praktisch unlesbar. Kein Messwerkzeug haette das gemeldet: Der
+   Knopf war vorhanden, benannt und anklickbar. Nur Hinsehen zeigt es.
+   Deshalb hier gezielt zurueckgeholt, nicht mit !important erschlagen. */
+.legal-section .support-box--inline .support-btn,
+.legal-section .support-box--inline .support-btn:hover {
+  color: #ffffff;
+  text-decoration: none;
+}
+
+/* Der Nachsatz nimmt die Huerde weg: Ein GitHub-Konto ist keine Bedingung.
+   Bewusst kleiner, aber NICHT blasser — 0.82rem auf --muted haelt die
+   verlangten 4.5:1 (WCAG 1.4.3). Eine graue Fussnote waere genau der Fehler,
+   den diese Seite anprangert. */
+.support-box--inline .support-fein {
+  margin: 12px 0 0;
+  font-size: 0.82rem;
+  color: var(--muted);
+}


### PR DESCRIPTION
## Warum

Der Satz über die ungeprüften Hilfsmittel klang wie eine Entschuldigung. Und er enthielt eine sachliche Ungenauigkeit: „weil uns diese Geräte nicht zur Verfügung stehen" stimmte für das iPhone nicht — das ist vorhanden, der Durchgang steht nur aus.

**Die Tatsache bleibt unverändert stehen** (NVDA, JAWS, TalkBack ungeprüft) — nur mit einem Weg daneben statt einer Rechtfertigung dahinter.

## Was neu ist

Ein Aufruf in Abschnitt 06 mit dem türkisen Knopf der anderen Seiten, verlinkt auf Issue #155. Ohne GitHub-Konto genügt eine E-Mail; das steht ausdrücklich dabei, damit die Hürde nicht höher wird als das Anliegen.

**Nebenbefund:** `/barrierefreiheit` war die einzige Seite ohne `opensource-box` und `support-box`. Beim Anlegen übersehen, jetzt angeglichen.

## Ein Fehler, den nur Hinsehen gezeigt hat

`.legal-section a` (Spezifität 0,1,1) schlägt `.support-btn` (0,1,0) und färbte den Knopftext **türkis mit Unterstreichung — auf türkisem Verlauf, praktisch unlesbar.**

Kein Messwerkzeug hätte das gemeldet: Der Knopf war vorhanden, benannt, anklickbar und mit `tabindex="0"` erreichbar. Gezielt zurückgeholt statt mit `!important` erschlagen.

Nachgemessen an den Bildpunkten:

| Element | Kontrast | verlangt |
|---|---|---|
| Knopf | 9,67 : 1 | 4,5 : 1 |
| Nachsatz | 5,02 : 1 | 4,5 : 1 |
| Fließtext | 8,53 : 1 | 4,5 : 1 |

Angesehen in drei Zuständen (900 px, 380 px, dunkel). Rechtsseiten sind immer hell — das dunkle Bild entsteht nur über den Beast-Schalter auf der Startseite.

## Prüfstand

Backend 844/845 grün (1 übersprungen) · Frontend 407/407 · E2E 161/161 — `scripts/pruefstand.sh`, 2026-08-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)