### PR TITLE
fix: Formulierung des Mitmach-Aufrufs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 ### Geändert
 
 - **Die Barrierefreiheitserklärung lädt jetzt ein, statt sich zu entschuldigen.**
-  Bisher stand dort, die fehlenden Hilfsmittel-Durchgänge lägen daran, dass uns
-  „diese Geräte nicht zur Verfügung stehen" — was für das iPhone schlicht nicht
-  stimmte. Jetzt steht dieselbe Tatsache mit einem Weg daneben: Was offen ist,
-  liegt öffentlich auf GitHub, und wer mit einem Screenreader arbeitet, kann es
-  in fünf Minuten beantworten. Ohne GitHub-Konto genügt eine E-Mail.
+  Bisher rechtfertigte sie die fehlenden Hilfsmittel-Durchgänge damit, dass uns
+  „diese Geräte nicht zur Verfügung stehen". Jetzt steht dort schlicht, dass
+  diese Durchgänge noch nicht abgeschlossen sind — und daneben ein Weg, das zu
+  ändern: Rückmeldungen sammeln wir auf GitHub, ohne Konto genügt eine E-Mail.
+
+  Der Aufruf richtet sich an alle, die mit einem Hilfsmittel arbeiten, nicht nur
+  an Screenreader-Nutzer — und er stellt keine Bedingungen. Ein erster Entwurf
+  hatte von Menschen gesprochen, „die mitreden können"; auf einer Seite über
+  Barrierefreiheit ist das genau die falsche Hürde.
 
 - **`/barrierefreiheit` trägt jetzt dieselben Kästen wie alle anderen Seiten**
   (Open Source, Projektunterstützung). Sie war die einzige Seite ohne.

--- a/public/barrierefreiheit.html
+++ b/public/barrierefreiheit.html
@@ -74,16 +74,13 @@
           <p>
             <strong>Warum &bdquo;weitgehend&ldquo; und nicht &bdquo;vollst&auml;ndig&ldquo;:</strong> Unsere Workshops
             laufen auf allen Ger&auml;ten, die Schulen und Jugendliche mitbringen. Entsprechend breit setzen wir den
-            Ma&szlig;stab &ndash; und entsprechend genau sagen wir, wo wir stehen. Alle drei Browser-Maschinen sind
-            gepr&uuml;ft. Bei den Hilfsmitteln ist noch ein St&uuml;ck Weg offen:
-            <strong>VoiceOver am iPhone</strong> steht als n&auml;chster Durchgang an,
-            <strong>NVDA, JAWS und TalkBack</strong> laufen auf Systemen, die wir nicht im Haus haben.
+            Ma&szlig;stab. Alle Browser sind gepr&uuml;ft; die Durchg&auml;nge mit Hilfsmitteln sind noch nicht
+            abgeschlossen.
           </p>
           <p>
-            Diesen Rest schlie&szlig;t man nicht am Schreibtisch. Wer t&auml;glich mit einem Screenreader arbeitet,
-            merkt in f&uuml;nf Minuten, wof&uuml;r wir Stunden messen.
-            <strong>Deshalb liegt die Frage offen auf GitHub</strong> &ndash; nachzulesen und zu beantworten von allen,
-            die mitreden k&ouml;nnen (Abschnitt 06).
+            Diesen Teil schlie&szlig;t man nicht allein am Schreibtisch. Wer t&auml;glich mit einem Hilfsmittel
+            arbeitet, merkt in f&uuml;nf Minuten, wof&uuml;r wir Stunden messen. &Uuml;ber R&uuml;ckmeldungen freuen wir
+            uns deshalb besonders &ndash; wie das geht, steht in Abschnitt&nbsp;06.
           </p>
         </div>
       </section>
@@ -165,9 +162,9 @@
             Fassung aller Rechtstexte verlangt.
           </li>
           <li>
-            <strong>Nicht alle Hilfsmittel sind gepr&uuml;ft.</strong> Welche das sind und warum daraus die Aussage
-            &bdquo;weitgehend konform&ldquo; folgt, steht in Abschnitt&nbsp;02. Wenn Sie mit einem dieser Hilfsmittel
-            arbeiten: Ihre R&uuml;ckmeldung ist f&uuml;r uns wertvoller als jede weitere Messung.
+            <strong>Nicht alle Hilfsmittel sind gepr&uuml;ft.</strong> Warum daraus die Aussage &bdquo;weitgehend
+            konform&ldquo; folgt, steht in Abschnitt&nbsp;02. Wenn Sie mit einem Hilfsmittel arbeiten: Ihre
+            R&uuml;ckmeldung ist f&uuml;r uns wertvoller als jede weitere Messung.
           </li>
           <li>
             <strong>Die eingebettete Landkarte</strong> stammt von OpenStreetMap und wird von uns nicht gestaltet. Ihre
@@ -206,10 +203,10 @@
           hilft &ndash; wir suchen selbst weiter.
         </p>
         <div class="support-box support-box--inline">
-          <p class="support-headline">Sie arbeiten mit einem Screenreader?</p>
+          <p class="support-headline">Sie arbeiten mit einem Hilfsmittel?</p>
           <p class="support-text">
-            Dann sehen Sie in f&uuml;nf Minuten, wof&uuml;r wir Stunden messen. Was uns fehlt, steht offen auf GitHub
-            &ndash; jede R&uuml;ckmeldung z&auml;hlt, auch eine einzelne Zeile.
+            Dann sehen Sie in f&uuml;nf Minuten, wof&uuml;r wir Stunden messen. Wir sammeln R&uuml;ckmeldungen auf
+            GitHub &ndash; jede z&auml;hlt, auch eine einzelne Zeile.
           </p>
           <a
             href="https://github.com/malziland/malzime/issues/155"
@@ -217,7 +214,7 @@
             rel="noopener"
             class="support-btn"
             tabindex="0"
-            >Zur offenen Frage auf GitHub</a
+            >R&uuml;ckmeldung geben auf GitHub</a
           >
           <p class="support-fein">
             Ohne GitHub-Konto geht es genauso &ndash; schreiben Sie einfach an die Adresse oben.


### PR DESCRIPTION
Drei Einwände des Nutzers, alle berechtigt.

**1. Zu konkret.** Der Abschnitt zählte auf, was geprüft ist und was fehlt. Jetzt steht dort nur noch, dass die Durchgänge mit Hilfsmitteln nicht abgeschlossen sind. Die namentliche Liste bleibt im Prüfbericht (Schritt 4.3) — dort gehört die Genauigkeit hin, nicht in den Außentext.

**2. Schiefes Deutsch.** „Deshalb liegt die Frage offen auf GitHub, nachzulesen und zu beantworten" — so sagt man das nicht.

**3. Ausschließende Formulierung**, und das auf einer Seite über Barrierefreiheit: „…von allen, die mitreden können". Das klingt nach Eignungsprüfung und schreckt genau die ab, die helfen wollen. Ersatzlos weg. Auch „Screenreader" ist zu „Hilfsmittel" geweitet — Braillezeile, Schaltersteuerung und Vergrößerung gehören dazu.

Der Verweis in Abschnitt 04 versprach eine Aufzählung, die es in 02 nicht mehr gibt — nachgezogen.

Gezielt geprüft: 17 Tests der betroffenen Dateien, 40 s. Den vollen Durchlauf macht die CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)