### PR TITLE
release: 3.4.1 + Riegel gegen den vergessenen Versionsschnitt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
+## [3.4.1] — 2026-08-18
 
 ### Geändert
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -234,3 +234,38 @@ if [ -n "$UEBERSPRUNGEN" ]; then
 else
   echo "Deploy abgeschlossen. Version: ?v=$VERSION — alle Riegel gelaufen."
 fi
+
+# ── OPS-2026-08-18-01: Der Versionsschnitt darf nicht vergessen werden ──
+# Dreimal an einem Tag ausgeliefert, dreimal die Nummer nicht gesetzt: GitHub
+# meldete v3.3.2 beziehungsweise v3.4.0, waehrend live schon mehr stand. Das
+# Repository behauptet dann WENIGER, als ausgeliefert ist — wer den Stand
+# nachlesen will, wird in die Irre gefuehrt.
+#
+# Warum als Schlusshinweis und nicht als Riegel VOR dem Deploy: Steht die Nummer
+# schon vor dem Merge im CHANGELOG, legt release.yml den Release an, sobald der
+# Merge auf main landet — also rund acht Minuten VOR der Auslieferung. Die
+# Reihenfolge muss bleiben: erst ausliefern, dann die Nummer setzen. Der
+# richtige Ort dafuer ist der Cache-Buster-PR, der ohnehin nach jedem Deploy
+# faellig ist.
+OBERSTE="$(sh scripts/changelog-oberste-version.sh CHANGELOG.md 2>/dev/null || true)"
+case "$OBERSTE" in
+  ""|*nver*)
+    echo ""
+    echo "════════════════════════════════════════════════════════════════"
+    echo " OFFEN: Der CHANGELOG steht auf [Unveröffentlicht]."
+    echo ""
+    echo " Ausgeliefert ist ?v=$VERSION — im Repository steht diese"
+    echo " Auslieferung aber unter keiner Versionsnummer. Damit meldet"
+    echo " GitHub einen aelteren Stand, als tatsaechlich live ist."
+    echo ""
+    echo " ZU TUN, zusammen mit dem Cache-Buster-PR:"
+    echo "   1. In CHANGELOG.md '## [Unveröffentlicht]' durch die neue"
+    echo "      Nummer und das heutige Datum ersetzen."
+    echo "   2. Pruefen:  sh scripts/changelog-oberste-version.sh CHANGELOG.md"
+    echo "   3. Mitcommitten — release.yml legt Tag und Release dann selbst an."
+    echo "════════════════════════════════════════════════════════════════"
+    ;;
+  *)
+    echo "CHANGELOG: oberste Version ist $OBERSTE — Versionsschnitt gesetzt."
+    ;;
+esac


### PR DESCRIPTION
## Der Fehler

**Zum dritten Mal an einem Tag:** ausgeliefert (`2026081803`, `2026081804`), Versionsschnitt nicht gesetzt. GitHub meldete `v3.4.0`, während live vier Commits weiter war. Das Repository behauptet dann **weniger**, als ausgeliefert ist. Aufgefallen ist es dem Nutzer — zum zweiten Mal.

## Warum 3.4.1 und nicht in 3.4.0 eingefaltet

Der Tag `v3.4.0` zeigt auf `05e2a71`; die Änderungen liegen darüber. Einfalten hieße den Tag verschieben — dann behauptete der CHANGELOG, `v3.4.0` enthalte Dinge, die in diesem Stand nachweislich nicht drin sind.

Das Ziel ist mit 3.4.1 genauso erreicht: **Der Abschnitt `[Unveröffentlicht]` verschwindet vollständig.**

## Der Riegel

`deploy.sh` prüft am Ende die oberste CHANGELOG-Überschrift und schreibt einen unübersehbaren Kasten, wenn dort `[Unveröffentlicht]` steht — mit der Handlungsanweisung, den Schnitt im Cache-Buster-PR mitzunehmen.

Bewusst ein **Schlusshinweis und kein Riegel vor dem Deploy**: Steht die Nummer schon vor dem Merge im CHANGELOG, legt `release.yml` den Release an, sobald der Merge auf `main` landet — also rund acht Minuten *vor* der Auslieferung. Die Reihenfolge muss bleiben: erst ausliefern, dann die Nummer setzen.

Rückbauprobe gefahren: mit `[Unveröffentlicht]` erscheint der Hinweis, mit einer Nummer bleibt er aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)