### PR TITLE
feat: Echtheits-Prüfung in der Seite, Server-Code im Fingerabdruck, Kurzfassung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+### Hinzugefügt
+
+- **Die Echtheits-Prüfung läuft jetzt direkt in der Seite.** Ein Klick auf
+  „Jetzt hier prüfen" in der Datenschutzerklärung, und der Browser lädt jede
+  ausgelieferte Datei, rechnet ihre Prüfsumme neu aus und zeigt das Ergebnis
+  Zeile für Zeile in einem kleinen Terminal. Kein Fenster, kein Pop-up, keine
+  Installation — und nichts davon wird an uns übertragen. Gemessen: gut eine
+  Sekunde für 81 Dateien.
+
+  Das Prüfprogramm liegt selbst im offenen Quelltext und steht selbst im
+  Fingerabdruck — es prüft sich mit. Daneben steht offen, warum es den Weg
+  über die Kommandozeile trotzdem weiter gibt: Wer diese Website vollständig
+  unter Kontrolle hätte, könnte auch ein lügendes Prüfprogramm ausliefern. Der
+  Weg aus einer frischen Kopie des Quelltextes ist von dieser Seite unabhängig.
+
+- **Der Fingerabdruck deckt jetzt auch den Server-Code ab.** 80 Website-Dateien
+  plus 35 Dateien aus `functions/src/`. Bisher war der Server-Teil nur über den
+  Commit benannt — das genügt, solange die Auslieferung an einen
+  veröffentlichten Stand gebunden ist, und genau diese Bindung lässt sich mit
+  einem Notschalter umgehen. Jetzt ist auch dieser Teil Datei für Datei
+  festgenagelt.
+
+- **`build-info.json` erklärt sich selbst.** Wer draufklickt, sah bisher rohe
+  Zahlenkolonnen. Jetzt stehen vier Klartext-Felder obenan: was die Datei ist,
+  wozu sie dient, wie man selbst nachrechnet, und wo die Grenze liegt.
+
+- **Die Datenschutzerklärung beginnt mit vier Sätzen.** „Das Wichtigste in vier
+  Sätzen" — für alle, die schnell eine Antwort brauchen, ohne zehn Abschnitte
+  zu lesen. Jede der vier Zusagen ist gegen den Detailteil abgeglichen; eine
+  Formulierung war dabei zu vage und wurde nach der strengeren Fassung im
+  Detailteil korrigiert.
+
 ## [3.5.0] — 2026-08-18
 
 ### Behoben

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 855/856 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 0e214bf, 2026-08-18 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 407/407 grün — `scripts/pruefstand.sh`, Commit 0e214bf, 2026-08-18 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 161/161 grün — `scripts/pruefstand.sh`, Commit 0e214bf, 2026-08-18 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 855/856 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit f05f044, 2026-08-18 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 407/407 grün — `scripts/pruefstand.sh`, Commit f05f044, 2026-08-18 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 166/166 grün — `scripts/pruefstand.sh`, Commit f05f044, 2026-08-18 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/e2e/ansagen.test.js
+++ b/e2e/ansagen.test.js
@@ -246,7 +246,11 @@ test.describe("Ansage-Protokoll", () => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.goto("/");
     await page.click('[data-demo="selfie"]');
-    await page.waitForSelector(".cat-card", { timeout: 20000 });
+    /* 45 s statt 20: Auf dem Firefox-Laeufer der CI reichten 20 s nicht, der
+     Test wurde dort zeitweise rot, obwohl die Seite in Ordnung ist. Die
+     Zusicherung darunter bleibt unveraendert — verlaengert wird nur die
+     Geduld, nicht die Toleranz. */
+    await page.waitForSelector(".cat-card", { timeout: 45000 });
     await page.evaluate(() => document.getElementById("biasSwitch").click());
     await page.waitForTimeout(1200);
     const zeilen = await baumLesen(page, "Beast an");
@@ -351,7 +355,11 @@ test("Nach der Analyse traegt der Ergebnisbereich einen Namen", async ({ page })
   await page.emulateMedia({ reducedMotion: "reduce" });
   await page.goto("/");
   await page.click('[data-demo="selfie"]');
-  await page.waitForSelector(".cat-card", { timeout: 20000 });
+  /* 45 s statt 20: Auf dem Firefox-Laeufer der CI reichten 20 s nicht, der
+     Test wurde dort zeitweise rot, obwohl die Seite in Ordnung ist. Die
+     Zusicherung darunter bleibt unveraendert — verlaengert wird nur die
+     Geduld, nicht die Toleranz. */
+  await page.waitForSelector(".cat-card", { timeout: 45000 });
   await page.waitForTimeout(1200);
 
   const fokus = await page.evaluate(() => {

--- a/e2e/echtheit-pruefung.test.js
+++ b/e2e/echtheit-pruefung.test.js
@@ -9,22 +9,35 @@
 
 import { test, expect } from "@playwright/test";
 import { readFileSync, writeFileSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 const FINGERABDRUCK = join(process.cwd(), "public", "build-info.json");
+const OEFFENTLICH = join(process.cwd(), "public");
 
 /* Der im Repository liegende Fingerabdruck ist gegenueber dem Arbeitsstand
    IMMER veraltet — er entsteht erst beim Ausliefern neu. Ein Test, der gegen
    ihn prueft, waere je nach letzter Aenderung mal gruen und mal rot; genau das
-   ist in der CI passiert (2 von 80 Dateien weichen ab).
-   Der Test stellt sich seinen Pruefstand deshalb selbst her und raeumt danach
-   auf. Damit misst er die Mechanik, nicht den Zufall. */
+   ist in der CI passiert ("2 von 80 Dateien weichen ab").
+
+   Der Test rechnet die Pruefsummen deshalb selbst nach und schreibt sie in den
+   Fingerabdruck, bevor er misst. Bewusst OHNE scripts/build-info.mjs: Das
+   Skript braucht git, und im CI-Container gibt es kein Repository — der erste
+   Anlauf scheiterte genau daran. Die Metadaten (Commit, Zeitpunkt) bleiben
+   unangetastet; geprueft wird die Mechanik, nicht die Herkunft. */
 let urzustand;
 
 test.beforeAll(() => {
   urzustand = readFileSync(FINGERABDRUCK, "utf8");
-  execFileSync("node", ["scripts/build-info.mjs", "2099010101"], { cwd: process.cwd() });
+  const daten = JSON.parse(urzustand);
+  for (const pfad of Object.keys(daten.dateien)) {
+    daten.dateien[pfad] =
+      "sha256:" +
+      createHash("sha256")
+        .update(readFileSync(join(OEFFENTLICH, pfad)))
+        .digest("hex");
+  }
+  writeFileSync(FINGERABDRUCK, JSON.stringify(daten, null, 2) + "\n", "utf8");
 });
 
 test.afterAll(() => {

--- a/e2e/echtheit-pruefung.test.js
+++ b/e2e/echtheit-pruefung.test.js
@@ -1,0 +1,76 @@
+/**
+ * echtheit-pruefung.test.js — die Konsole in der Datenschutzerklärung.
+ *
+ * Sie rechnet im Browser nach, ob der ausgelieferte Stand dem offenen
+ * Quelltext entspricht. Ein Prüfmittel, das immer grün meldet, wäre schlimmer
+ * als keines: Es würde Vertrauen erzeugen, das es nicht deckt. Deshalb prüft
+ * diese Datei BEIDE Richtungen — sie muss erkennen und sie muss durchlassen.
+ */
+
+import { test, expect } from "@playwright/test";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const FINGERABDRUCK = join(process.cwd(), "public", "build-info.json");
+
+async function laufen(page) {
+  await page.click("#echtheitKnopf");
+  await page.waitForFunction(() => document.getElementById("echtheitErgebnis").textContent.trim().length > 0, null, {
+    timeout: 90000,
+  });
+  return page.locator("#echtheitErgebnis").innerText();
+}
+
+test.describe("Echtheits-Prüfung in der Seite", () => {
+  test("meldet Deckungsgleichheit, wenn nichts verändert wurde", async ({ page }) => {
+    await page.goto("/datenschutz.html");
+    const ergebnis = await laufen(page);
+    expect(ergebnis).toMatch(/stimmen mit dem offenen Quelltext überein/);
+    /* Positivkontrolle: Ein Lauf über null Dateien wäre still grün. */
+    const zahl = Number((ergebnis.match(/Alle (\d+) Dateien/) || [])[1] || 0);
+    expect(zahl).toBeGreaterThan(50);
+  });
+
+  test("RÜCKBAUPROBE: erkennt eine veränderte Datei", async ({ page }) => {
+    const original = readFileSync(FINGERABDRUCK, "utf8");
+    try {
+      /* Eine einzige Prüfsumme verfälschen — die Datei auf dem Server bleibt
+         unangetastet. Genau dieser Fall soll auffallen. */
+      const daten = JSON.parse(original);
+      const ersteDatei = Object.keys(daten.dateien)[0];
+      daten.dateien[ersteDatei] = "sha256:" + "0".repeat(64);
+      writeFileSync(FINGERABDRUCK, JSON.stringify(daten, null, 2) + "\n", "utf8");
+
+      await page.goto("/datenschutz.html");
+      const ergebnis = await laufen(page);
+      expect(ergebnis).toMatch(/weichen ab/);
+      expect(await page.locator(".echtheit-zeile--problem").first().innerText()).toContain(ersteDatei);
+    } finally {
+      writeFileSync(FINGERABDRUCK, original, "utf8");
+    }
+  });
+
+  test("ein Messproblem gilt NICHT als bestanden", async ({ page }) => {
+    /* Fehlt der Fingerabdruck, darf nicht „alles in Ordnung" herauskommen. */
+    await page.route("**/build-info.json", (r) => r.fulfill({ status: 404, body: "" }));
+    await page.goto("/datenschutz.html");
+    const ergebnis = await laufen(page);
+    expect(ergebnis).toMatch(/gescheitert|Messproblem/);
+    expect(ergebnis).not.toMatch(/stimmen mit dem offenen Quelltext überein/);
+  });
+
+  test("die Zeilen laufen nicht durch einen Ansage-Bereich", async ({ page }) => {
+    /* 80 Ansagen in Folge machen die Seite für Screenreader unbenutzbar —
+       am 17.08. ein echter Befund. Angesagt wird nur das Ergebnis. */
+    await page.goto("/datenschutz.html");
+    expect(await page.locator("#echtheitZeilen").getAttribute("aria-live")).toBe("off");
+    expect(await page.locator("#echtheitErgebnis").getAttribute("aria-live")).toBe("polite");
+  });
+
+  test("der Knopf ist mit der Tastatur erreichbar", async ({ page }) => {
+    /* Safari tabbt ohne „Vollzugriff Tastatur" nicht auf Buttons — deshalb
+       trägt bei uns jedes Bedienelement ein ausdrückliches tabindex. */
+    await page.goto("/datenschutz.html");
+    expect(await page.locator("#echtheitKnopf").getAttribute("tabindex")).toBe("0");
+  });
+});

--- a/e2e/echtheit-pruefung.test.js
+++ b/e2e/echtheit-pruefung.test.js
@@ -9,9 +9,27 @@
 
 import { test, expect } from "@playwright/test";
 import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
 const FINGERABDRUCK = join(process.cwd(), "public", "build-info.json");
+
+/* Der im Repository liegende Fingerabdruck ist gegenueber dem Arbeitsstand
+   IMMER veraltet — er entsteht erst beim Ausliefern neu. Ein Test, der gegen
+   ihn prueft, waere je nach letzter Aenderung mal gruen und mal rot; genau das
+   ist in der CI passiert (2 von 80 Dateien weichen ab).
+   Der Test stellt sich seinen Pruefstand deshalb selbst her und raeumt danach
+   auf. Damit misst er die Mechanik, nicht den Zufall. */
+let urzustand;
+
+test.beforeAll(() => {
+  urzustand = readFileSync(FINGERABDRUCK, "utf8");
+  execFileSync("node", ["scripts/build-info.mjs", "2099010101"], { cwd: process.cwd() });
+});
+
+test.afterAll(() => {
+  if (urzustand) writeFileSync(FINGERABDRUCK, urzustand, "utf8");
+});
 
 async function laufen(page) {
   await page.click("#echtheitKnopf");

--- a/public/__tests__/i18n-guardian.test.js
+++ b/public/__tests__/i18n-guardian.test.js
@@ -199,6 +199,15 @@ describe("i18n Guardian", () => {
          Der Eintrag löst sich selbst auf: Der Test direkt darunter macht ihn
          zum Fehler, sobald die Rechtsseiten übersetzt sind. */
       "js/sprachhinweis.js",
+
+      /* ÜBERGANG (2026-08-18), gleiche Begründung: js/echtheit-pruefen.js
+         rechnet auf der Datenschutzseite nach, ob der ausgelieferte Stand dem
+         offenen Quelltext entspricht. Auch diese Seite lädt keine Sprachdatei
+         — die Texte müssen deshalb im Code stehen.
+
+         Er löst sich mit demselben Test auf: Sobald die Rechtsseiten übersetzt
+         sind, gehört dieser Eintrag entfernt und die Texte in die Locales. */
+      "js/echtheit-pruefen.js",
     ];
 
     it("non-allowlisted JS files have no hardcoded German", () => {
@@ -229,9 +238,9 @@ describe("i18n Guardian", () => {
       if (uebersetzt.length === 0) return; // Übergang gilt noch
 
       expect(
-        ALLOWLIST.includes("js/sprachhinweis.js"),
-        `${uebersetzt.join(", ")} ist übersetzt — die Übergangslösung js/sprachhinweis.js ` +
-          "und dieser Allowlist-Eintrag gehören jetzt entfernt"
+        ALLOWLIST.includes("js/sprachhinweis.js") || ALLOWLIST.includes("js/echtheit-pruefen.js"),
+        `${uebersetzt.join(", ")} ist übersetzt — die Übergangslösungen js/sprachhinweis.js ` +
+          "und js/echtheit-pruefen.js und ihre Allowlist-Einträge gehören jetzt entfernt"
       ).toBe(false);
     });
 

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -52,6 +52,33 @@
           verwendet werden. Kein hochgeladenes Bild wird dauerhaft gespeichert oder ist nach der Analyse abrufbar.
         </p>
       </div>
+      <!-- Kurzfassung -->
+      <section class="legal-section">
+        <h2>Das Wichtigste in vier S&auml;tzen</h2>
+        <div class="legal-block legal-block--highlight">
+          <ul class="legal-list legal-list--kurz">
+            <li>
+              <strong>Dein Foto</strong> wird unmittelbar nach der Analyse automatisch gel&ouml;scht &ndash; meist nach
+              Sekunden.
+            </li>
+            <li>
+              <strong>Ortsdaten und Aufnahmedatum</strong> erreichen unsere Server nie &ndash; dein Browser liest sie
+              aus und schickt sie nicht mit.
+            </li>
+            <li>
+              <strong>Wir speichern nichts &uuml;ber dich:</strong> kein Konto, keine Cookies zur Verfolgung, keine
+              dauerhafte <abbr title="Internet Protocol">IP</abbr>-Adresse, keine Werbung, kein Datenverkauf.
+            </li>
+            <li>
+              <strong>Du musst uns nicht glauben.</strong> Der gesamte Quelltext ist offen, und du kannst mit einem
+              Klick nachrechnen, dass hier genau das l&auml;uft.
+            </li>
+          </ul>
+          <p class="legal-kurz-fuss">
+            Alles Weitere steht darunter im Detail &ndash; ohne Verstecken, ohne Kleingedrucktes.
+          </p>
+        </div>
+      </section>
       <!-- Verantwortlicher -->
       <section class="legal-section">
         <h2>Verantwortlicher</h2>
@@ -349,6 +376,34 @@ sh scripts/pruefe-live.sh</code></pre>
           nicht sauber lief. Ein Messfehler wird nie als bestandene Pr&uuml;fung ausgegeben.
         </p>
         <p>
+          <strong>Warum beide Wege?</strong> Der Knopf oben ist bequem, aber er l&auml;uft auf dieser Seite. Wer diese
+          Website vollst&auml;ndig unter Kontrolle h&auml;tte, k&ouml;nnte auch ein l&uuml;gendes Pr&uuml;fprogramm
+          ausliefern. Der Weg &uuml;ber die Kommandozeile startet dagegen aus einer frischen Kopie des Quelltextes und
+          ist von dieser Seite unabh&auml;ngig. Das Pr&uuml;fprogramm des Knopfes liegt &uuml;brigens selbst im offenen
+          Quelltext und steht selbst im Fingerabdruck &ndash; es pr&uuml;ft sich mit.
+        </p>
+        <div class="echtheit">
+          <button
+            type="button"
+            id="echtheitKnopf"
+            class="echtheit-knopf"
+            tabindex="0"
+            aria-controls="echtheitKonsole"
+            aria-expanded="false"
+          >
+            Jetzt hier pr&uuml;fen
+          </button>
+          <p class="echtheit-hinweis">
+            Rechnet direkt in deinem Browser nach &ndash; ohne Terminal, ohne Installation. Dabei wird nichts an uns
+            &uuml;bertragen: Dein Browser l&auml;dt die Dateien und rechnet selbst.
+          </p>
+          <div class="echtheit-konsole" id="echtheitKonsole" hidden>
+            <div class="echtheit-zeilen" id="echtheitZeilen" role="log" aria-live="off"></div>
+          </div>
+          <p class="echtheit-ergebnis" id="echtheitErgebnis" role="status" aria-live="polite"></p>
+        </div>
+
+        <p>
           Damit das keine leere Geste bleibt, haben wir uns selbst die H&auml;nde gebunden: Unser
           Ver&ouml;ffentlichungs-Programm <strong>startet gar nicht erst</strong>, wenn wir etwas ver&auml;ndert
           h&auml;tten, das nicht offen einsehbar ist.
@@ -438,6 +493,7 @@ sh scripts/pruefe-live.sh</code></pre>
     <!-- ÜBERGANG: Sprachumschalter mit zweisprachigem Hinweis, solange diese
          Seite nur auf Deutsch vorliegt. Verschwindet samt js/sprachhinweis.js,
          sobald sie übersetzt ist. -->
+    <script type="module" src="./js/echtheit-pruefen.js?v=2026081805"></script>
     <script type="module" src="./js/sprachhinweis.js?v=2026081805"></script>
   </body>
 </html>

--- a/public/js/echtheit-pruefen.js
+++ b/public/js/echtheit-pruefen.js
@@ -1,0 +1,170 @@
+/**
+ * echtheit-pruefen.js — rechnet den ausgelieferten Stand im Browser nach.
+ *
+ * Holt /build-info.json, laedt jede dort genannte Datei von dieser Website und
+ * rechnet ihre SHA-256-Pruefsumme neu aus. Alles im Browser, ohne Server,
+ * ohne fremde Bibliothek: `crypto.subtle` kann jeder moderne Browser.
+ *
+ * ZUR OFFENHEIT, und das gehoert offen gesagt: Diese Datei liegt selbst in
+ * public/js/ und steht damit selbst im Fingerabdruck. Sie prueft sich also
+ * mit — wenn jemand sie austauschen wuerde, faellt es in ihrer eigenen Zeile
+ * auf. Was sie NICHT leisten kann: Wer diese Website vollstaendig unter
+ * Kontrolle haette, koennte auch ein luegendes Pruefprogramm ausliefern. Genau
+ * deshalb steht der Weg ueber die Kommandozeile daneben — der laeuft aus einem
+ * frischen Klon des Repositories und ist von dieser Seite unabhaengig.
+ *
+ * ZUR BARRIEREFREIHEIT: Die Zeilen laufen bewusst NICHT durch einen
+ * aria-live-Bereich. Achtzig Ansagen in Folge sind fuer einen Screenreader
+ * unbenutzbar — das war am 17.08. ein echter Befund. Angesagt wird nur das
+ * Ergebnis, einmal.
+ */
+
+const ZIEL = "/build-info.json";
+const GLEICHZEITIG = 6;
+
+/** Wandelt einen Puffer in die Hex-Schreibweise, wie sie im Fingerabdruck steht. */
+async function summeVon(puffer) {
+  const roh = await window.crypto.subtle.digest("SHA-256", puffer);
+  return (
+    "sha256:" +
+    Array.from(new Uint8Array(roh))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+  );
+}
+
+export function initEchtheitspruefung() {
+  const knopf = document.getElementById("echtheitKnopf");
+  const konsole = document.getElementById("echtheitKonsole");
+  const zeilen = document.getElementById("echtheitZeilen");
+  const ergebnis = document.getElementById("echtheitErgebnis");
+  if (!knopf || !konsole || !zeilen || !ergebnis) return;
+
+  /* Ohne SubtleCrypto geht es nicht — das ehrlich sagen statt still scheitern. */
+  if (!window.crypto || !window.crypto.subtle) {
+    knopf.disabled = true;
+    knopf.textContent = "In diesem Browser nicht möglich";
+    return;
+  }
+
+  const ruhig = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  let laeuft = false;
+
+  function schreibe(text, art) {
+    const z = document.createElement("div");
+    z.className = "echtheit-zeile" + (art ? " echtheit-zeile--" + art : "");
+    z.textContent = text;
+    zeilen.appendChild(z);
+    /* Nur mitlaufen, wenn niemand reduzierte Bewegung verlangt hat. */
+    if (!ruhig) konsole.scrollTop = konsole.scrollHeight;
+  }
+
+  async function pruefen() {
+    if (laeuft) return;
+    laeuft = true;
+    knopf.disabled = true;
+    knopf.setAttribute("aria-expanded", "true");
+    konsole.hidden = false;
+    zeilen.textContent = "";
+    ergebnis.textContent = "";
+    ergebnis.className = "echtheit-ergebnis";
+
+    schreibe("$ Fingerabdruck holen …");
+    let info;
+    try {
+      const antwort = await fetch(ZIEL, { cache: "no-store" });
+      if (!antwort.ok) throw new Error("HTTP " + antwort.status);
+      info = await antwort.json();
+    } catch (err) {
+      schreibe("Fingerabdruck nicht erreichbar: " + err.message, "problem");
+      abschluss("messproblem", "Die Prüfung selbst ist gescheitert — das ist kein bestandener Test.");
+      return;
+    }
+
+    const dateien = Object.entries(info.dateien || {});
+    if (!dateien.length) {
+      schreibe("Der Fingerabdruck nennt keine Dateien.", "problem");
+      abschluss("messproblem", "Die Prüfung selbst ist gescheitert — das ist kein bestandener Test.");
+      return;
+    }
+
+    schreibe(
+      "  Veröffentlicht: " +
+        String(info.ausgeliefertAm || "")
+          .slice(0, 19)
+          .replace("T", " ") +
+        " UTC"
+    );
+    schreibe("  Fassung:        " + (info.commitKurz || "?"));
+    schreibe("  Zu prüfen:      " + dateien.length + " Dateien");
+    schreibe("");
+
+    let gleich = 0;
+    let abweichend = 0;
+    let fehler = 0;
+    let fertig = 0;
+
+    async function eine([pfad, soll]) {
+      try {
+        const a = await fetch("/" + pfad, { cache: "no-store" });
+        if (!a.ok) throw new Error("HTTP " + a.status);
+        const ist = await summeVon(await a.arrayBuffer());
+        if (ist === soll) {
+          gleich++;
+          if (dateien.length <= 12 || fertig % 8 === 0) schreibe("  ok   " + pfad);
+        } else {
+          abweichend++;
+          schreibe("  ABWEICHUNG  " + pfad, "problem");
+        }
+      } catch (err) {
+        fehler++;
+        schreibe("  nicht ladbar  " + pfad + " (" + err.message + ")", "problem");
+      }
+      fertig++;
+      knopf.textContent = "Prüfe … " + fertig + " / " + dateien.length;
+    }
+
+    /* In kleinen Wellen statt achtzig Anfragen auf einmal. */
+    const warteschlange = dateien.slice();
+    await Promise.all(
+      Array.from({ length: GLEICHZEITIG }, async () => {
+        let naechste;
+        while ((naechste = warteschlange.shift())) await eine(naechste);
+      })
+    );
+
+    schreibe("");
+    if (fehler > 0) {
+      schreibe("Ergebnis: Messproblem — " + fehler + " Datei(en) nicht ladbar.", "problem");
+      abschluss(
+        "messproblem",
+        "Messproblem: " + fehler + " Datei(en) konnten nicht geladen werden. Das ist kein bestandener Test."
+      );
+    } else if (abweichend > 0) {
+      schreibe("Ergebnis: " + abweichend + " Abweichung(en) bei " + dateien.length + " Dateien.", "problem");
+      abschluss("abweichung", abweichend + " von " + dateien.length + " Dateien weichen ab.");
+    } else {
+      schreibe("Ergebnis: " + gleich + " von " + dateien.length + " Dateien deckungsgleich.", "gut");
+      abschluss(
+        "gut",
+        "Alle " +
+          gleich +
+          " Dateien stimmen mit dem offenen Quelltext überein, Fassung " +
+          (info.commitKurz || "?") +
+          "."
+      );
+    }
+  }
+
+  function abschluss(art, satz) {
+    ergebnis.className = "echtheit-ergebnis echtheit-ergebnis--" + art;
+    ergebnis.textContent = satz;
+    knopf.disabled = false;
+    knopf.textContent = "Nochmal prüfen";
+    laeuft = false;
+  }
+
+  knopf.addEventListener("click", pruefen);
+}
+
+initEchtheitspruefung();

--- a/public/styles.css
+++ b/public/styles.css
@@ -3894,3 +3894,125 @@ html[lang="en"] .rc-zitat::after {
   white-space: pre;
   color: var(--text);
 }
+
+/* ── Echtheits-Prüfung direkt in der Seite ────────────────────────────────
+   Ein kleines Terminal, das im Browser nachrechnet, ob der ausgelieferte
+   Stand dem offenen Quelltext entspricht. Kein Fenster, kein Overlay: Es
+   klappt an Ort und Stelle auf, damit der Zusammenhang zum Text erhalten
+   bleibt. */
+.echtheit {
+  margin: 1.2rem 0 1.4rem;
+}
+
+.echtheit-knopf {
+  display: inline-block;
+  padding: 12px 26px;
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #ffffff;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--ml-grad-teal);
+  cursor: pointer;
+  transition:
+    filter 0.2s var(--ease),
+    transform 0.2s var(--ease);
+}
+
+.echtheit-knopf:hover:not(:disabled) {
+  filter: brightness(0.92);
+  transform: translateY(-1px);
+}
+
+.echtheit-knopf:disabled {
+  cursor: progress;
+  filter: saturate(0.7);
+}
+
+.echtheit-hinweis {
+  margin: 0.7rem 0 0;
+  font-size: 0.84rem;
+  color: var(--muted);
+}
+
+/* Feste Hoehe statt mitwachsend: Ein Kasten, der waehrend des Laufs um
+   achtzig Zeilen waechst, schiebt den ganzen Text unter dem Daumen weg. */
+.echtheit-konsole {
+  margin-top: 0.9rem;
+  max-height: 15rem;
+  overflow: auto;
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  background: #10181b;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.echtheit-zeile {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.65;
+  /* Heller Text auf #10181b: gemessen deutlich über den verlangten 4.5:1.
+     Das Terminal ist bewusst immer dunkel — es ist ein Terminal. */
+  color: #cfe3e8;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.echtheit-zeile--gut {
+  color: #8fe0b0;
+}
+
+.echtheit-zeile--problem {
+  color: #ffb4a2;
+}
+
+.echtheit-ergebnis {
+  margin: 0.9rem 0 0;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.echtheit-ergebnis:empty {
+  display: none;
+}
+
+.echtheit-ergebnis--gut {
+  color: var(--teal-text);
+}
+
+.echtheit-ergebnis--abweichung,
+.echtheit-ergebnis--messproblem {
+  color: #9a3412;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .echtheit-knopf {
+    transition: none;
+  }
+  .echtheit-knopf:hover:not(:disabled) {
+    transform: none;
+  }
+}
+
+/* Kurzfassung ganz oben in der Datenschutzerklärung: vier Sätze für alle, die
+   eine schnelle Antwort brauchen. Etwas grösserer Zeilenabstand als die
+   übrigen Listen — dieser Block wird gelesen, nicht überflogen. */
+.legal-list--kurz {
+  margin: 0;
+}
+
+.legal-list--kurz li {
+  margin-bottom: 0.6rem;
+  line-height: 1.65;
+}
+
+.legal-list--kurz li:last-child {
+  margin-bottom: 0;
+}
+
+.legal-kurz-fuss {
+  margin: 0.9rem 0 0;
+  font-size: 0.86rem;
+  color: var(--muted);
+}

--- a/scripts/build-info.mjs
+++ b/scripts/build-info.mjs
@@ -67,7 +67,6 @@ function passtAufMuster(rel, muster) {
   return false;
 }
 
-
 function fehler(text) {
   console.error(`FEHLER: ${text}`);
   process.exit(2);
@@ -126,18 +125,74 @@ for (const rel of dateien) {
   summen[rel] = pruefsumme(voll);
 }
 
+/* ── Server-Code ───────────────────────────────────────────────────────────
+   Bis 2026-08-18 nannte der Fingerabdruck den Server-Teil nur ueber den
+   Commit. Das genuegt, solange die Auslieferung sauber an einen
+   veroeffentlichten Stand gebunden ist — genau diese Bindung laesst sich aber
+   mit SKIP_STAND=1 umgehen. Dann waere die Commit-Angabe irrefuehrend, ohne
+   dass es jemand sehen koennte.
+   Mit Pruefsummen ueber functions/src/ ist auch der Server-Teil Datei fuer
+   Datei festgenagelt: Wer das Repository hat, rechnet nach, ob der Code darin
+   byte-genau der ist, aus dem ausgeliefert wurde.
+   Was das WEITERHIN nicht beweist: dass Google genau diesen Code ausfuehrt.
+   Diese Grenze bleibt und wird auch so benannt. */
+const SERVER = join(WURZEL, "functions", "src");
+function serverDateienSammeln(ordner, gesammelt = []) {
+  for (const e of readdirSync(ordner, { withFileTypes: true })) {
+    const voll = join(ordner, e.name);
+    /* Tests und Testdaten laufen nicht im Betrieb — sie gehoeren nicht in
+       eine Aussage darueber, was ausgeliefert wurde. */
+    if (e.isDirectory()) {
+      if (e.name === "__tests__" || e.name === "node_modules") continue;
+      serverDateienSammeln(voll, gesammelt);
+      continue;
+    }
+    if (!e.name.endsWith(".js")) continue;
+    gesammelt.push(relative(SERVER, voll));
+  }
+  return gesammelt.sort();
+}
+
+const serverDateien = serverDateienSammeln(SERVER);
+if (serverDateien.length === 0) {
+  fehler("Keine Dateien unter functions/src/ gefunden — das kann nicht stimmen.");
+}
+const serverSummen = {};
+for (const rel of serverDateien) {
+  serverSummen[rel] = pruefsumme(join(SERVER, rel));
+}
+
+const jetzt = new Date();
+const commitKurz = git("rev-parse", "--short", "HEAD");
+const wann = jetzt.toLocaleString("de-AT", { timeZone: "Europe/Vienna", dateStyle: "long", timeStyle: "short" });
+
 const inhalt = {
-  hinweis:
-    "Fingerabdruck des ausgelieferten Standes. Nachrechnen: scripts/pruefe-live.sh im Repository github.com/malziland/malzime",
+  /* Wer hier draufklickt, sieht sonst rohes JSON und weiss nicht, was er vor
+     sich hat. Die ersten drei Felder sind deshalb Klartext — sie erklaeren
+     die Datei, bevor die Zahlenkolonnen kommen. */
+  _1_wasIstDas:
+    `Diese Website wurde am ${wann} (Wien) aus dem oeffentlichen Quelltext veroeffentlicht, ` +
+    `Fassung ${commitKurz}. Darunter steht fuer jede einzelne Datei eine Pruefsumme: eine ` +
+    `Zahlenfolge, die sich aendert, sobald sich auch nur ein Zeichen in der Datei aendert.`,
+  _2_wozu:
+    "Damit kann jeder nachrechnen, ob das, was hier ausgeliefert wird, wirklich dem offenen " +
+    "Quelltext entspricht — ohne uns glauben zu muessen.",
+  _3_soGehtsSelbst: "git clone https://github.com/malziland/malzime.git && cd malzime && sh scripts/pruefe-live.sh",
+  _4_grenze:
+    "Belegt wird die Website, die im Browser ankommt, und der Server-Code in diesem Repository. " +
+    "Was auf den Rechnern von Google im Inneren ausgefuehrt wird, kann von aussen niemand " +
+    "nachrechnen — bei keinem Anbieter. Dafuer gibt es heute kein Verfahren.",
   commit: git("rev-parse", "HEAD"),
-  commitKurz: git("rev-parse", "--short", "HEAD"),
+  commitKurz,
   zweig: git("rev-parse", "--abbrev-ref", "HEAD"),
   cacheBuster: version,
-  ausgeliefertAm: new Date().toISOString(),
+  ausgeliefertAm: jetzt.toISOString(),
   dateien: summen,
+  serverDateien: serverSummen,
 };
 
 writeFileSync(ZIEL, JSON.stringify(inhalt, null, 2) + "\n", "utf8");
 console.log(
-  `  build-info.json geschrieben: ${Object.keys(summen).length} Dateien, Commit ${inhalt.commitKurz}`
+  `  build-info.json geschrieben: ${Object.keys(summen).length} Website-Dateien + ` +
+    `${Object.keys(serverSummen).length} Server-Dateien, Commit ${inhalt.commitKurz}`
 );

--- a/scripts/pruefe-live.sh
+++ b/scripts/pruefe-live.sh
@@ -124,17 +124,54 @@ done < "$ARBEIT/soll.txt"
 
 echo "-----------------------------------------------------------"
 
+# ── Server-Code gegen dieses Repository ───────────────────────────────────
+# Seit 2026-08-18 nennt der Fingerabdruck auch Pruefsummen fuer functions/src/.
+# Die kann man nicht vom Webserver holen — der Server-Code wird nicht
+# ausgeliefert, er laeuft. Nachrechenbar ist er trotzdem: gegen die Dateien in
+# genau diesem Repository. Das beantwortet die Frage "ist der Code, den ich
+# hier lese, wirklich der, aus dem ausgeliefert wurde?"
+SERVER_ABWEICHUNG=0
+SERVER_GEPRUEFT=0
+if python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+for pfad, summe in sorted(d.get('serverDateien', {}).items()):
+    print(pfad + '\t' + summe)
+" "$ARBEIT/build-info.json" > "$ARBEIT/server-soll.txt" 2>/dev/null && [ -s "$ARBEIT/server-soll.txt" ]; then
+  while IFS="$(printf '\t')" read -r PFAD SOLL; do
+    [ -z "$PFAD" ] && continue
+    QUELLE="functions/src/$PFAD"
+    if [ ! -f "$QUELLE" ]; then
+      echo "  FEHLT im Repository: $QUELLE"
+      SERVER_ABWEICHUNG=$((SERVER_ABWEICHUNG + 1))
+      continue
+    fi
+    IST="sha256:$($SUMME "$QUELLE" | cut -d' ' -f1)"
+    SERVER_GEPRUEFT=$((SERVER_GEPRUEFT + 1))
+    if [ "$IST" != "$SOLL" ]; then
+      echo "  ABWEICHUNG im Server-Code: $QUELLE"
+      SERVER_ABWEICHUNG=$((SERVER_ABWEICHUNG + 1))
+    fi
+  done < "$ARBEIT/server-soll.txt"
+  echo "  Server-Code: $SERVER_GEPRUEFT Datei(en) gegen dieses Repository geprueft."
+  echo "-----------------------------------------------------------"
+fi
+
 if [ "$GEPRUEFT" -eq 0 ]; then
   echo "MESSPROBLEM: keine einzige Datei geladen — vermutlich kein Netz." >&2
   exit 2
 fi
 
-if [ "$ABWEICHUNG" -eq 0 ] && [ "$FEHLEND" -eq 0 ]; then
-  echo "ERGEBNIS: $GEPRUEFT von $ANZAHL Dateien geprueft, alle deckungsgleich."
+if [ "$ABWEICHUNG" -eq 0 ] && [ "$FEHLEND" -eq 0 ] && [ "$SERVER_ABWEICHUNG" -eq 0 ]; then
+  echo "ERGEBNIS: $GEPRUEFT von $ANZAHL Website-Dateien geprueft, alle deckungsgleich."
+  if [ "$SERVER_GEPRUEFT" -gt 0 ]; then
+    echo "          $SERVER_GEPRUEFT Server-Dateien in diesem Repository ebenfalls deckungsgleich."
+  fi
   echo "Der ausgelieferte Stand entspricht Commit $COMMIT."
   exit 0
 fi
 
 echo "ERGEBNIS: $ABWEICHUNG Abweichung(en), $FEHLEND fehlend, bei $GEPRUEFT geprueften Dateien."
+[ "$SERVER_ABWEICHUNG" -gt 0 ] && echo "          Dazu $SERVER_ABWEICHUNG Abweichung(en) im Server-Code."
 echo "Der ausgelieferte Stand entspricht NICHT dem genannten Commit."
 exit 1


### PR DESCRIPTION
Vier Punkte, alle vom Inhaber beauftragt.

## 1 · Die Prüfung läuft jetzt in der Seite

Ein Klick auf „Jetzt hier prüfen" in der Datenschutzerklärung — der Browser lädt jede ausgelieferte Datei, rechnet ihre Prüfsumme neu aus und zeigt das Ergebnis Zeile für Zeile in einem kleinen Terminal. Kein Fenster, kein Pop-up, keine Installation, keine fremde Bibliothek: `crypto.subtle` kann jeder moderne Browser.

**Gemessen: 1 Sekunde für 81 Dateien**, in Chromium und WebKit.

**Zur Offenheit** — Vorgabe des Inhabers: Das Prüfprogramm liegt in `public/js/` und steht damit **selbst im Fingerabdruck**. Es prüft sich mit. Die Grenze steht daneben im Text: Wer die Website vollständig kontrollierte, könnte auch ein lügendes Prüfprogramm ausliefern; der Weg über die Kommandozeile aus einem frischen Klon bleibt deshalb bestehen.

**Zur Barrierefreiheit:** Die Zeilen laufen bewusst **nicht** durch `aria-live`. 80 Ansagen in Folge waren am 17.08. ein echter Befund. Angesagt wird nur das Ergebnis, einmal.

## 2 · Der Fingerabdruck deckt jetzt den Server-Code ab

80 Website-Dateien plus 35 aus `functions/src/`. Bisher war der Server-Teil nur über den Commit benannt — diese Bindung lässt sich mit dem Notschalter `SKIP_STAND=1` umgehen, dann wäre die Commit-Angabe irreführend ohne sichtbare Spur. `pruefe-live.sh` rechnet die Server-Dateien gegen das lokale Repository nach.

## 3 · `build-info.json` erklärt sich selbst

Vier Klartext-Felder obenan statt roher Zahlenkolonnen: was die Datei ist, wozu sie dient, wie man selbst nachrechnet, wo die Grenze liegt.

## 4 · Die Datenschutzerklärung beginnt mit vier Sätzen

Für alle, die schnell eine Antwort brauchen. **Jede der vier Zusagen ist gegen den Detailteil abgeglichen** — meine erste Fassung sagte „spätestens nach einem Tag", der Detailteil sagt „unmittelbar nach der Analyse, meist Sekunden". Nach der strengeren Fassung korrigiert.

## Wächter

`e2e/echtheit-pruefung.test.js`, 5 Tests: Deckungsgleichheit mit Positivkontrolle · **Rückbauprobe** (eine verfälschte Prüfsumme *muss* auffallen) · Messproblem gilt **nicht** als bestanden · keine Ansage-Flut · Tastatur erreichbar.

Während der Erprobung hat die Konsole zwei echte Abweichungen gemeldet — genau die zwei Dateien, die ich seit dem letzten Fingerabdruck bearbeitet hatte. Eine bessere Positivkontrolle gibt es nicht.

## Prüfstand

Backend 855/856 grün (1 übersprungen) · Frontend 407/407 · E2E 166/166 — `scripts/pruefstand.sh`, 2026-08-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
