### PR TITLE
fix: gemeldeter Druck-Abbruch-Fehler wird messbar statt geraten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+### Hinzugefügt
+
+- **Ein gemeldeter Fehler wird messbar, statt geraten.** Nutzer-Fund: Profil
+  laden, Beast-Modus, „PDF speichern", dann im Druckdialog abbrechen — die
+  Seite war danach schwarz und leer, erst ein Neuladen half.
+
+  **Der Fehler ließ sich nicht nachstellen** — weder in Chromium noch in
+  WebKit, weder über das Druck-Stylesheet noch über den Aufräumweg. Die
+  üblichen Verdächtigen scheiden aus: keine hängende Überlagerung, kein
+  `backdrop-filter`, keine 3D-Ebene, die klebende Leiste ist unbeteiligt.
+
+  Statt eine Vermutung als Behebung auszuliefern, prüft die Seite nach jedem
+  Druckdialog selbst nach, ob der Ergebnisbereich noch sichtbar ist — und
+  meldet den Fall mit allen nötigen Angaben, wenn nicht. Beim nächsten
+  Auftreten liegt damit ein Befund vor statt einer Beschreibung.
+
+  Dazu ein Wächter, der festhält, was nach dem Abbrechen gelten muss.
+
 ## [3.6.0] — 2026-08-18
 
 ### Hinzugefügt

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 855/856 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit f05f044, 2026-08-18 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 407/407 grün — `scripts/pruefstand.sh`, Commit f05f044, 2026-08-18 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 166/166 grün — `scripts/pruefstand.sh`, Commit f05f044, 2026-08-18 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 855/856 grün (1 übersprungen) — `scripts/pruefstand.sh`, Commit 769048f, 2026-08-18 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 407/407 grün — `scripts/pruefstand.sh`, Commit 769048f, 2026-08-18 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 167/167 grün — `scripts/pruefstand.sh`, Commit 769048f, 2026-08-18 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/e2e/druck-abbruch.test.js
+++ b/e2e/druck-abbruch.test.js
@@ -1,0 +1,124 @@
+/**
+ * druck-abbruch.test.js — REPRODUKTION eines Nutzer-Fundes vom 2026-08-18.
+ *
+ * Gemeldet: Profil laden → Beast-Modus → „PDF speichern" → im Druckdialog
+ * ABBRECHEN → die Seite ist danach schwarz, kein Inhalt mehr sichtbar. Erst
+ * ein Neuladen bringt sie zurück.
+ *
+ * Simulationstreue: Der Druckdialog selbst lässt sich nicht fernsteuern, aber
+ * sein Effekt auf die Seite schon — Playwright kann das Druck-Stylesheet
+ * aktivieren und wieder abschalten.
+ *
+ * BEFUND DER REPRODUKTION: So lässt sich der Fehler NICHT auslösen — weder in
+ * Chromium noch in WebKit. Der Ergebnisbereich bleibt danach sichtbar, in
+ * voller Höhe, mit allen Karten. Die Ursache liegt also nicht im Umschalten
+ * des Stylesheets, sondern in etwas, das nur der echte Druckdialog tut.
+ *
+ * Der Test bleibt trotzdem: Er hält fest, was gelten MUSS, und wird rot,
+ * sobald jemand am Druck- oder Aufräumweg etwas kaputtmacht. Die eigentliche
+ * Aufklärung übernimmt die Messung in app.js — sie meldet den Fall, wenn er
+ * am echten Gerät wieder auftritt.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const PROFIL = {
+  profiles: {
+    normal: {
+      categories: {
+        alter_geschlecht: { label: "Alter & Geschlecht", value: "25-30 Jahre", confidence: 0.8 },
+        interessen: { label: "Interessen", value: "Outdoor", confidence: 0.7 },
+      },
+      ad_targeting: ["Outdoor-Werbung"],
+      manipulation_triggers: ["FOMO"],
+      profileText: "Ein junger Erwachsener mit aktivem Lebensstil.",
+    },
+    boost: {
+      categories: { alter_geschlecht: { label: "Alter & Geschlecht", value: "25-30 Jahre", confidence: 0.9 } },
+      ad_targeting: ["Premium-Werbung"],
+      manipulation_triggers: ["Statusangst"],
+      profileText: "Beast-Profil.",
+    },
+  },
+  privacyRisks: [],
+  exif: { make: "Apple", model: "iPhone 15 Pro" },
+  meta: { requestId: "a-1", mode: "multimodal", subject: "HUMAN" },
+};
+
+/** Schreibt jede Aenderung in einem aria-live-Bereich mit — das sind die Ansagen. */
+
+async function endpunkte(page, jobStatus) {
+  await page.route("**/api/stats", (r) =>
+    r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        current: { count: 1, limit: 500, limitActive: false },
+        totals: { today: 1, week: 1, month: 1, total: 1 },
+        useQueue: true,
+        sprachumschalter: true,
+      }),
+    })
+  );
+  await page.route("**/api/enqueue", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ jobId: "a", resultToken: "t" }) })
+  );
+  await page.route("**/api/job-status**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(jobStatus) })
+  );
+  await page.route("**/nominatim.openstreetmap.org/**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: "[]" })
+  );
+}
+
+test("Nach Abbrechen des Druckdialogs ist die Seite im Beast-Modus wieder da", async ({ page }) => {
+  await endpunkte(page, { status: "done", result: PROFIL });
+  await page.goto("/");
+  await page.click('[data-demo="selfie"]');
+  await page.waitForSelector(".cat-card", { timeout: 45000 });
+
+  /* In den Beast-Modus wechseln — dort trat der Fehler auf. */
+  await page.locator('[data-mode="boost"]').first().click();
+  await page.waitForTimeout(700);
+  expect(await page.locator("html").getAttribute("data-theme")).toBe("dark");
+
+  const vorher = await page.locator(".cat-card").count();
+  expect(vorher).toBeGreaterThan(0);
+
+  /* Druckvorschau öffnen und wieder verlassen = Abbrechen. */
+  await page.locator("#exportPdf").click();
+  await page.emulateMedia({ media: "print" });
+  await page.waitForTimeout(500);
+  await page.emulateMedia({ media: "screen" });
+  await page.waitForTimeout(1500);
+
+  /* DER EIGENTLICHE FUND: Ist der Inhalt danach noch sichtbar? */
+  const karte = page.locator(".cat-card").first();
+  await expect(karte).toBeVisible();
+  expect(await page.locator(".cat-card").count()).toBe(vorher);
+
+  /* Und sind die Druck-Hinweise wieder entfernt? */
+  expect(await page.locator(".print-note").count()).toBe(0);
+
+  /* Sichtprobe: Der Ergebnisbereich darf nicht auf null Höhe zusammenfallen. */
+  const zustand = await page.evaluate(() => {
+    const r = document.getElementById("resultsPanel");
+    const s = r ? getComputedStyle(r) : null;
+    const sichtbare = [...document.querySelectorAll("#resultsPanel *")].filter((n) => {
+      const c = getComputedStyle(n);
+      return c.display !== "none" && c.visibility !== "hidden";
+    }).length;
+    return {
+      hoehe: r ? Math.round(r.getBoundingClientRect().height) : -1,
+      display: s ? s.display : "?",
+      sichtbarkeit: s ? s.visibility : "?",
+      deckkraft: s ? s.opacity : "?",
+      bodyHoehe: document.body.scrollHeight,
+      sichtbareKinder: sichtbare,
+      theme: document.documentElement.getAttribute("data-theme"),
+    };
+  });
+  console.log("[druck] Zustand nach Abbrechen:", JSON.stringify(zustand));
+  expect(zustand.hoehe).toBeGreaterThan(100);
+  expect(zustand.sichtbareKinder).toBeGreaterThan(10);
+});

--- a/public/app.js
+++ b/public/app.js
@@ -17,7 +17,7 @@ import { enthuellungAbkuerzen, modusWechsel } from "./js/live-anzeige.js";
 import * as realitaetsCheck from "./js/realitaets-check.js";
 import { merkeModus, gemerkterModus } from "./js/modus-speicher.js";
 import { initAbsturzWache, merkePhase } from "./js/absturz-wache.js";
-import { initFehlerNachsendung } from "./js/error-logger.js";
+import { initFehlerNachsendung, logClientError } from "./js/error-logger.js";
 import { initSprachumschalter, merkmalUebernehmen } from "./js/sprachumschalter.js";
 
 /* ── Absturz-Wache: als ALLERERSTES, vor jedem await ──
@@ -314,4 +314,36 @@ elements.exportPdf.addEventListener("click", () => {
   setTimeout(removePrintNotes, 1000);
 });
 
-window.addEventListener("afterprint", removePrintNotes);
+window.addEventListener("afterprint", () => {
+  removePrintNotes();
+
+  /* NUTZER-FUND 2026-08-18: Nach „PDF speichern" → Abbrechen war die Seite im
+     Beast-Modus schwarz und leer; erst ein Neuladen brachte sie zurueck.
+     Headless ist das nicht reproduzierbar — weder ueber das Druck-Stylesheet
+     noch in Chromium oder WebKit. Statt eine Vermutung als Behebung
+     auszuliefern, wird der Fall hier MESSBAR gemacht: Bleibt der
+     Ergebnisbereich nach dem Druckdialog unsichtbar, geht das mit den
+     noetigen Angaben in die Fehlererfassung. Beim naechsten Auftreten liegt
+     dann ein Befund vor statt einer Beschreibung.
+     Zwei Bildschirmrahmen Abstand, damit der Browser fertig gezeichnet hat. */
+  requestAnimationFrame(() =>
+    requestAnimationFrame(() => {
+      const panel = document.getElementById("resultsPanel");
+      if (!panel) return;
+      const kasten = panel.getBoundingClientRect();
+      const stil = window.getComputedStyle(panel);
+      const unsichtbar = kasten.height < 50 || stil.display === "none" || stil.visibility === "hidden";
+      if (!unsichtbar) return;
+      logClientError("druck-abbruch-seite-leer", {
+        hoehe: Math.round(kasten.height),
+        display: stil.display,
+        sichtbarkeit: stil.visibility,
+        deckkraft: stil.opacity,
+        modus: document.documentElement.getAttribute("data-mode"),
+        thema: document.documentElement.getAttribute("data-theme"),
+        bodyHoehe: document.body.scrollHeight,
+        druckhinweise: document.querySelectorAll(".print-note").length,
+      });
+    })
+  );
+});


### PR DESCRIPTION
## Der Fund

Nutzer-Meldung: Profil laden → Beast-Modus → „PDF speichern" → im Druckdialog **abbrechen** → die Seite ist schwarz und leer. Erst ein Neuladen hilft.

## Die Reproduktion ist gescheitert — und das steht so im Code

Weder in Chromium noch in WebKit, weder über das Druck-Stylesheet noch über den Aufräumweg. Gemessen bleibt der Ergebnisbereich in allen Versuchen sichtbar: 3585 px hoch, 238 sichtbare Kindelemente, `display: block`, `visibility: visible`.

**Die üblichen Verdächtigen scheiden aus:** keine hängende Überlagerung (`.modal-overlay` ist die einzige ganzflächige und wird nirgends geschaltet), kein `backdrop-filter`, kein `will-change`, keine 3D-Ebene, und die klebende Leiste setzt nur eine Klasse.

## Warum keine Behebung

Eine Vermutung als Fix auszuliefern verstößt gegen die eigene Regel: keine Behauptung ohne Ausführung. Ich könnte etwas einbauen, das plausibel klingt — belegen könnte ich nichts davon.

## Was stattdessen passiert

`app.js` prüft nach jedem `afterprint` (zwei Bildschirmrahmen später, damit der Browser fertig gezeichnet hat), ob der Ergebnisbereich noch sichtbar ist. Ist er es nicht, geht der Fall **mit allen nötigen Angaben** in die Fehlererfassung: Höhe, `display`, `visibility`, Deckkraft, Modus, Thema, Body-Höhe, Anzahl der Druckhinweise.

**Beim nächsten Auftreten liegt damit ein Befund vor statt einer Beschreibung.**

Dazu ein Wächter, der festhält, was nach dem Abbrechen gelten muss — heute grün, rot sobald jemand am Druck- oder Aufräumweg etwas kaputtmacht.

## Prüfstand

Backend 855/856 grün (1 übersprungen) · Frontend 407/407 · E2E 167/167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
