### PR TITLE
fix: der gcloud-Abgleich meldete fälschlich „1 übersprungen“

### DIFF
--- a/functions/src/__tests__/cloudtasks-scripts.test.js
+++ b/functions/src/__tests__/cloudtasks-scripts.test.js
@@ -96,14 +96,24 @@ describe("Cloud-Tasks-Scripts", () => {
     90000
   );
 
-  // Fehlt gcloud (so in der CI), wird der Abgleich mit test.skip als übersprungen
-  // AUSGEWIESEN, statt einen immer wahren Test zu erfinden. Ein `expect(true)`
-  // stand vorher hier: Er zählte als bestanden und behauptete damit eine
-  // Abdeckung, die es nicht gab. Übersprungen ist ehrlicher als grün.
-  //
-  // pruefungen:uebersprungen-weil der Abgleich braucht das Werkzeug gcloud, das in der CI nicht installiert ist — die Alternative waere eine Schein-Zusicherung
-  test.skip.each(gcloudDa ? [] : [["gcloud nicht installiert"]])(
-    "Parameter-Abgleich gegen die gcloud-Hilfe (%s)",
-    () => {}
-  );
+  /* Fehlt gcloud, wird der Abgleich als uebersprungen AUSGEWIESEN statt einen
+     immer wahren Test zu erfinden. Ein `expect(true)` stand hier einmal: Er
+     zaehlte als bestanden und behauptete eine Abdeckung, die es nicht gab.
+     Uebersprungen ist ehrlicher als gruen.
+
+     KORREKTUR 2026-08-19: Hier stand `test.skip.each(gcloudDa ? [] : [...])`.
+     Jest registriert aus einer LEEREN Liste trotzdem einen wartenden Eintrag —
+     erkennbar am unaufgeloesten `%s` im Namen. Folge: Jeder Lauf meldete
+     "1 skipped", auch wenn gcloud da war und der Abgleich lief. Eine Zahl, die
+     immer eine fehlende Abdeckung behauptet, wo keine fehlt, ist genau so
+     wertlos wie eine, die immer Abdeckung behauptet, wo keine ist.
+
+     Ausserdem war die Begruendung falsch: Der Ubuntu-Laeufer von GitHub
+     enthaelt die Google Cloud CLI. Der Abgleich lief die ganze Zeit auch in der
+     CI — belegt mit `jest --json` und im CI-Protokoll. Der Platzhalter greift
+     jetzt nur noch dort, wo gcloud wirklich fehlt. */
+  if (!gcloudDa) {
+    // pruefungen:uebersprungen-weil der Abgleich braucht das Werkzeug gcloud, das in dieser Umgebung fehlt — die Alternative waere eine Schein-Zusicherung
+    test.skip("Parameter-Abgleich gegen die gcloud-Hilfe (gcloud nicht installiert)", () => {});
+  }
 });


### PR DESCRIPTION
Aus der Nutzer-Frage „Warum wurde ein Test übersprungen?" — die Antwort war eine andere als erwartet.

| Befund | |
|---|---|
| gcloud fehlt in der CI | **falsch** — der Ubuntu-Läufer enthält Google Cloud CLI 579.0.0 |
| Der Abgleich läuft nicht | **falsch** — er lief die ganze Zeit, lokal und in der CI |
| Übersprungen wurde ein Test | **falsch** — es war ein **Platzhalter** |

`test.skip.each(gcloudDa ? [] : [...])` registriert auch aus einer **leeren** Liste einen wartenden Eintrag — erkennbar am unaufgelösten `%s` im Testnamen. Jeder Lauf meldete dadurch „1 skipped", obwohl nichts übersprungen wurde.

Das ist dieselbe Krankheit, gegen die der Platzhalter einst gebaut wurde, nur andersherum: **Eine Zahl, die immer eine fehlende Abdeckung behauptet, wo keine fehlt, ist genauso wertlos wie eine, die Abdeckung behauptet, wo keine ist.**

Belegt mit `jest --json` (Status je Test) und dem CI-Protokoll.

```
vorher   Tests: 1 skipped, 857 passed, 858 total
nachher  Tests: 857 passed, 857 total
```

Die Begründung für `scripts/pruefungen` bleibt erhalten und greift dann, wenn gcloud wirklich fehlt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)