### PR TITLE
test: die Marke muss überall ankommen — Wächter statt Gedächtnis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+### Behoben
+
+- **Das Logo aktualisierte sich im Browser nicht.** Die Verweise auf Favicon,
+  App-Kachel und Manifest trugen keine Versionskennung — anders als das
+  Stilblatt. Der Browser behielt deshalb das alte Zeichen, unter Umständen
+  wochenlang. Das betraf jede bisherige Änderung am Logo.
+
+- **Suchmaschinen fanden kein Logo.** In den strukturierten Daten fehlte die
+  Angabe, welches Bild das Logo ist. Ohne sie zeigt Google keines — die
+  Bilddateien lagen längst bereit, waren aber nirgends als Logo benannt.
+  Zusätzlich ist jetzt ein großes Favicon verlinkt; Google empfiehlt über
+  48 Bildpunkte.
+
+- **Die Überschrift auf der Zahlen-Seite stand 21 Bildpunkte höher als auf
+  allen anderen Seiten.** Aufgefallen ist das keinem Menschen, sondern einer
+  neuen Prüfung — man sieht die Seiten selten nebeneinander.
+
 ## [3.8.0] — 2026-08-19
 
 ### Hinzugefügt

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 857/857 grün — `scripts/pruefstand.sh`, Commit b11f3b8, 2026-08-19 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 425/425 grün — `scripts/pruefstand.sh`, Commit b11f3b8, 2026-08-19 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 233/233 grün — `scripts/pruefstand.sh`, Commit b11f3b8, 2026-08-19 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 857/857 grün — `scripts/pruefstand.sh`, Commit c80323d, 2026-08-19 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 436/436 grün — `scripts/pruefstand.sh`, Commit c80323d, 2026-08-19 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 249/249 grün — `scripts/pruefstand.sh`, Commit c80323d, 2026-08-19 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |

--- a/e2e/kopfbereich.test.js
+++ b/e2e/kopfbereich.test.js
@@ -1,0 +1,190 @@
+import { test, expect } from "@playwright/test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/* ── Der Kopfbereich: Wortmarke, Sprachumschalter, Überschrift, Tab-Zeichen ──
+ *
+ * ANLASS: Am 2026-08-19 kam die Wortmarke dazu. Der Nutzer hat dabei DREI
+ * Fehler gefunden, die ich zuvor als „geprüft" gemeldet hatte — allen dreien
+ * lag derselbe Denkfehler zugrunde: Ich hatte den MECHANISMUS gemessen und
+ * nicht die WIRKUNG.
+ *
+ *   1. „Auf diesen Seiten sehe ich überhaupt kein Logo."
+ *   2. „Der Sprachumschalter ist auf der Startseite auf Höhe des Logos, auf
+ *       den Unterseiten nicht."
+ *   3. „Die Überschrift klebt direkt unter dem Logo." — und das war der
+ *       schlimmste: Der Abstand hing an `.seiten-kopfzeile`, die auf der
+ *       Startseite erst JavaScript erzeugt. In meinem Browser lief das Skript,
+ *       in seinem nicht. Ich maß 66 px und meldete „erledigt", während er
+ *       etwas anderes sah.
+ *
+ * Diese Datei hält alles drei fest — und prüft ausdrücklich auch den Fall OHNE
+ * das Skript, weil genau dort der Fehler saß.
+ *
+ * Basis ist das Arbeitsverzeichnis, nicht `import.meta.url`: Playwright lädt
+ * Testdateien nicht als echte ES-Module, `import.meta` wirft dort.
+ */
+
+const PUBLIC = join(process.cwd(), "public");
+
+function alleSeiten(unter = "") {
+  const treffer = [];
+  for (const e of readdirSync(join(PUBLIC, unter), { withFileTypes: true })) {
+    const rel = unter ? `${unter}/${e.name}` : e.name;
+    if (e.isDirectory()) {
+      if (["__tests__", "node_modules", "fonts", "img", "js", "locales", "lib"].includes(e.name)) continue;
+      treffer.push(...alleSeiten(rel));
+    } else if (e.name.endsWith(".html")) {
+      treffer.push("/" + rel);
+    }
+  }
+  return treffer.sort();
+}
+
+const SEITEN = alleSeiten();
+
+/* Die Zahlen-Seite und die Startseite holen ihr Merkmal von /api/stats. Ohne
+   Antwort entsteht der Umschalter nicht — dann prüfte der Test etwas anderes
+   als das, was live steht. */
+async function merkmalStellen(page) {
+  await page.route("**/api/stats", (r) =>
+    r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        current: { count: 6, limit: 500, limitActive: false, retryAfterSeconds: 0 },
+        totals: { today: 6, week: 26, month: 172, allTime: 5129 },
+        useQueue: true,
+        sprachumschalter: true,
+      }),
+    })
+  );
+}
+
+test.describe("Kopfbereich", () => {
+  test("Messmittel: die Seitensuche findet die ausgelieferten Seiten", () => {
+    /* Positivkontrolle. Fände sie nichts, liefen die Schleifen unten still
+       leer und alles wäre grün, ohne gemessen zu haben. */
+    expect(SEITEN.length, `gefunden: ${SEITEN.join(", ")}`).toBeGreaterThanOrEqual(10);
+    expect(SEITEN).toContain("/index.html");
+    expect(SEITEN).toContain("/en/privacy.html");
+  });
+
+  for (const pfad of SEITEN) {
+    test(`Wortmarke steht auf ${pfad}`, async ({ page }) => {
+      await merkmalStellen(page);
+      await page.goto(pfad);
+      const marke = page.locator(".wortmarke");
+      await expect(marke, "keine Wortmarke — der Nutzer sah hier gar kein Logo").toHaveCount(1);
+      await expect(marke).toBeVisible();
+      /* Sie muss als EIN Wort lesbar sein: `malzi` und der Kasten stehen ohne
+         Leerzeichen nebeneinander, der Abstand kommt aus `gap`. Ein Screenreader
+         liest sonst „malzi, M E". */
+      expect((await marke.innerText()).replace(/\s+/g, "")).toBe("malziME");
+    });
+  }
+
+  test("Wortmarke und Sprachumschalter liegen auf gleicher Höhe — auf JEDER Seite", async ({ page }) => {
+    await merkmalStellen(page);
+    const versatz = [];
+    for (const pfad of SEITEN) {
+      await page.goto(pfad);
+      await page.evaluate(() => document.fonts.ready);
+      await expect(page.locator(".sprach-pille")).toHaveCount(1);
+      const v = await page.evaluate(() => {
+        const w = document.querySelector(".wortmarke").getBoundingClientRect();
+        const p = document.querySelector(".sprach-pille").getBoundingClientRect();
+        return Math.round(p.top + p.height / 2 - (w.top + w.height / 2));
+      });
+      if (Math.abs(v) > 2) versatz.push(`${pfad}: ${v} px`);
+    }
+    expect(versatz, "Umschalter nicht auf Logo-Höhe").toEqual([]);
+  });
+
+  test("alle Überschriften stehen auf derselben Höhe", async ({ page }) => {
+    await merkmalStellen(page);
+    const hoehen = {};
+    for (const pfad of SEITEN) {
+      await page.goto(pfad);
+      await page.evaluate(() => document.fonts.ready);
+      hoehen[pfad] = await page.evaluate(() => Math.round(document.querySelector("h1").getBoundingClientRect().top));
+    }
+    const werte = [...new Set(Object.values(hoehen))];
+    /* Positivkontrolle: Wären alle 0, hätte nichts gemessen. */
+    expect(werte[0]).toBeGreaterThan(50);
+    expect(werte, `Überschriften auf verschiedenen Höhen: ${JSON.stringify(hoehen)}`).toHaveLength(1);
+  });
+
+  test("der Abstand hält auch OHNE das Umschalter-Skript", async ({ page }) => {
+    /* DER FEHLER VOM 2026-08-19. Der Abstand hing an `.seiten-kopfzeile`, die
+       auf der Startseite erst js/sprachumschalter.js erzeugt. Lief das Skript
+       nicht — blockiert, zu spät, veraltet im Zwischenspeicher —, fiel der
+       Abstand weg und die Überschrift rutschte an die Wortmarke.
+
+       Ein Abstand darf nicht davon abhängen, ob ein Skript durchläuft. */
+    await merkmalStellen(page);
+    await page.goto("/index.html");
+    await page.evaluate(() => document.fonts.ready);
+    const mit = await page.evaluate(() => Math.round(document.querySelector("h1").getBoundingClientRect().top));
+    expect(await page.locator(".seiten-kopfzeile").count(), "ohne Kopfzeile prüft der Vergleich nichts").toBe(1);
+
+    const ohne = await page.context().newPage();
+    await ohne.route("**/js/sprachumschalter.js*", (r) => r.abort());
+    await ohne.goto("/index.html");
+    await ohne.evaluate(() => document.fonts.ready);
+    const ohneWert = await ohne.evaluate(() => Math.round(document.querySelector("h1").getBoundingClientRect().top));
+    expect(await ohne.locator(".seiten-kopfzeile").count(), "Kopfzeile trotz blockiertem Skript da?").toBe(0);
+    await ohne.close();
+
+    expect(ohneWert, `mit Skript ${mit} px, ohne ${ohneWert} px — der Abstand hängt am Skript`).toBe(mit);
+  });
+
+  test("das Tab-Zeichen wird im Beast-Modus schwarz und kehrt zurück", async ({ page }) => {
+    /* Auch hier hatte ich zuerst nur das Attribut gelesen und „belegt" gemeldet.
+       Geprüft wird deshalb, was der Browser tatsächlich laden WÜRDE: die Datei
+       über die gesetzte Adresse abrufen und ihre Farben lesen. */
+    await merkmalStellen(page);
+    await page.goto("/index.html");
+
+    const zeichen = () =>
+      page.evaluate(async () => {
+        const l = document.querySelector('link[rel="icon"][type="image/svg+xml"]');
+        const text = await (await fetch(l.href)).text();
+        return { adresse: new URL(l.href).pathname, inhalt: text };
+      });
+
+    const vorher = await zeichen();
+    expect(vorher.adresse).toBe("/favicon.svg");
+    /* Positivkontrolle: Käme kein SVG zurück, sagten die Farbprüfungen nichts. */
+    expect(vorher.inhalt).toContain("<svg");
+
+    await page.locator("#biasSwitch").click({ force: true });
+    const beast = await zeichen();
+    expect(beast.adresse, "das Tab-Zeichen wechselt im Beast-Modus nicht").toBe("/favicon-beast.svg");
+
+    /* Und es muss WIRKLICH dunkel sein — nicht nur eine andere Datei. Die erste
+       Fassung war ein HELLER Kasten (die Vorlagen-Fassung für dunkle
+       Tab-Leisten); auf einer hellen Leiste blieb der Tab dadurch hell, und der
+       Nutzer sah keinen Unterschied. */
+    const kasten = /\.kasten\s*\{\s*fill:\s*(#[0-9a-f]{6})/i.exec(beast.inhalt);
+    expect(kasten, "keine Kastenfarbe in favicon-beast.svg gefunden").not.toBeNull();
+    const [r, g, b] = [1, 3, 5].map((i) => parseInt(kasten[1].slice(i, i + 2), 16));
+    const helligkeit = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+    expect(helligkeit, `Beast-Kasten ist zu hell (${kasten[1]}) — im Tab nicht als Wechsel erkennbar`).toBeLessThan(
+      0.2
+    );
+
+    await page.locator("#biasSwitch").click({ force: true });
+    expect((await zeichen()).adresse, "kehrt nach dem Zurückschalten nicht zurück").toBe("/favicon.svg");
+  });
+
+  test("beide Zeichen haben dieselbe Form — nur andere Farben", () => {
+    /* Sonst wäre es nicht dasselbe Logo, sondern ein zweites. */
+    const pfad = (d) => /<path class="zeichen" d="([^"]+)"/.exec(readFileSync(join(PUBLIC, d), "utf8"))[1];
+    const radius = (d) => /rx="([\d.]+)"/.exec(readFileSync(join(PUBLIC, d), "utf8"))[1];
+    expect(pfad("favicon-beast.svg")).toBe(pfad("favicon.svg"));
+    expect(radius("favicon-beast.svg")).toBe(radius("favicon.svg"));
+    /* Positivkontrolle für die Messung selbst. */
+    expect(pfad("favicon.svg").length).toBeGreaterThan(100);
+  });
+});

--- a/e2e/kopfbereich.test.js
+++ b/e2e/kopfbereich.test.js
@@ -125,15 +125,23 @@ test.describe("Kopfbereich", () => {
     await merkmalStellen(page);
     await page.goto("/index.html");
     await page.evaluate(() => document.fonts.ready);
+    /* WARTEN, nicht sofort zaehlen: Die Kopfzeile entsteht erst, nachdem
+       js/sprachumschalter.js das Merkmal von /api/stats gelesen hat. Ein
+       sofortiges `count()` traf die Luecke — lokal nie, in der Pipeline sofort.
+       (Genau derselbe Fehlertyp, den dieser Test eigentlich pruefen soll: eine
+       Aussage ueber etwas, das noch gar nicht da ist.) */
+    await expect(page.locator(".seiten-kopfzeile"), "ohne Kopfzeile prüft der Vergleich nichts").toHaveCount(1);
     const mit = await page.evaluate(() => Math.round(document.querySelector("h1").getBoundingClientRect().top));
-    expect(await page.locator(".seiten-kopfzeile").count(), "ohne Kopfzeile prüft der Vergleich nichts").toBe(1);
 
     const ohne = await page.context().newPage();
     await ohne.route("**/js/sprachumschalter.js*", (r) => r.abort());
     await ohne.goto("/index.html");
     await ohne.evaluate(() => document.fonts.ready);
+    /* Hier ist die Abwesenheit die Aussage — kurz warten, damit ein verspaetetes
+       Skript den Test nicht faelschlich bestehen laesst. */
+    await ohne.waitForTimeout(600);
+    await expect(ohne.locator(".seiten-kopfzeile"), "Kopfzeile trotz blockiertem Skript da?").toHaveCount(0);
     const ohneWert = await ohne.evaluate(() => Math.round(document.querySelector("h1").getBoundingClientRect().top));
-    expect(await ohne.locator(".seiten-kopfzeile").count(), "Kopfzeile trotz blockiertem Skript da?").toBe(0);
     await ohne.close();
 
     expect(ohneWert, `mit Skript ${mit} px, ohne ${ohneWert} px — der Abstand hängt am Skript`).toBe(mit);

--- a/e2e/sprachumschalter.test.js
+++ b/e2e/sprachumschalter.test.js
@@ -285,19 +285,25 @@ test("leer: Wechsel ohne Rückfrage, Seite wird englisch", async ({ page }) => {
 
   await page.click('.sprach-knopf[data-lang="en"]');
   await expect(page.locator("html")).toHaveAttribute("lang", "en");
-  /* Zusicherung unveraendert streng — aber mit Diagnose.
+  /* WARTEND lesen (`expect.poll`), nicht einmalig.
+     ZWEITER FEHLER, 2026-08-19: Die erste Diagnose-Fassung nutzte
+     `expect(await ...evaluateAll(...))`. Das liest GENAU EINMAL — anders als
+     `toHaveCount`, das von sich aus wiederholt. Ich hatte die Wiederholung
+     entfernt und den Test dadurch WACKLIGER gemacht als vorher. `expect.poll`
+     bringt sie zurueck und behaelt die Diagnose.
+
+     Zusicherung unveraendert streng — aber mit Diagnose.
      ANLASS 2026-08-19: Dieser Test fiel in der Pipeline (WebKit, unter Last)
      mit "Received: 1" um und war beim zweiten Lauf DESSELBEN Commits gruen;
      lokal 6 von 6 gruen. `.sw-grund.sichtbar` zaehlt ueber ALLE Dialoge — es
      gibt zwei (`fertig` und `laeuft`). Aus "Received: 1" ist nicht zu erkennen,
      WELCHER haengengeblieben ist, und ohne das laesst sich die Ursache nicht
      suchen. Jetzt nennt die Meldung ihn. */
-  expect(
-    await page
-      .locator(".sw-grund.sichtbar")
-      .evaluateAll((els) => els.map((el) => el.dataset.modal || "(ohne Kennung)")),
-    "Dialoge, die noch sichtbar sind"
-  ).toEqual([]);
+  await expect
+    .poll(() => page.locator(".sw-grund.sichtbar").evaluateAll((els) => els.map((el) => el.dataset.modal || "?")), {
+      message: "Dialoge, die noch sichtbar sind",
+    })
+    .toEqual([]);
   await expect(page.locator("h1")).toContainText("We see more");
   /* Das englische Demo-Bildpaket muss mitziehen. */
   await expect(page.locator('[data-demo="selfie"] img')).toHaveAttribute("src", /-en\.jpg/);
@@ -381,12 +387,11 @@ test("Fokus bleibt in der Rückfrage und kehrt danach zurück", async ({ page })
      gibt zwei (`fertig` und `laeuft`). Aus "Received: 1" ist nicht zu erkennen,
      WELCHER haengengeblieben ist, und ohne das laesst sich die Ursache nicht
      suchen. Jetzt nennt die Meldung ihn. */
-  expect(
-    await page
-      .locator(".sw-grund.sichtbar")
-      .evaluateAll((els) => els.map((el) => el.dataset.modal || "(ohne Kennung)")),
-    "Dialoge, die noch sichtbar sind"
-  ).toEqual([]);
+  await expect
+    .poll(() => page.locator(".sw-grund.sichtbar").evaluateAll((els) => els.map((el) => el.dataset.modal || "?")), {
+      message: "Dialoge, die noch sichtbar sind",
+    })
+    .toEqual([]);
   /* Wartend statt einmalig lesen — und zwar aus einem konkreten Grund:
      `modalSchliessen()` nimmt die Klasse `sichtbar` WEG, BEVOR es den Fokus
      zurueckholt (sprachumschalter.js). Die Zeile darueber ist also schon
@@ -510,12 +515,11 @@ test("axe über die ganze Matrix: 2 Sprachen × 2 Themen, Rückfrage offen und z
      gibt zwei (`fertig` und `laeuft`). Aus "Received: 1" ist nicht zu erkennen,
      WELCHER haengengeblieben ist, und ohne das laesst sich die Ursache nicht
      suchen. Jetzt nennt die Meldung ihn. */
-  expect(
-    await page
-      .locator(".sw-grund.sichtbar")
-      .evaluateAll((els) => els.map((el) => el.dataset.modal || "(ohne Kennung)")),
-    "Dialoge, die noch sichtbar sind"
-  ).toEqual([]);
+  await expect
+    .poll(() => page.locator(".sw-grund.sichtbar").evaluateAll((els) => els.map((el) => el.dataset.modal || "?")), {
+      message: "Dialoge, die noch sichtbar sind",
+    })
+    .toEqual([]);
 
   await beastAn(page);
   await axePruefen(page, "Profil fertig, Beast");

--- a/e2e/sprachumschalter.test.js
+++ b/e2e/sprachumschalter.test.js
@@ -285,7 +285,19 @@ test("leer: Wechsel ohne Rückfrage, Seite wird englisch", async ({ page }) => {
 
   await page.click('.sprach-knopf[data-lang="en"]');
   await expect(page.locator("html")).toHaveAttribute("lang", "en");
-  await expect(page.locator(".sw-grund.sichtbar")).toHaveCount(0);
+  /* Zusicherung unveraendert streng — aber mit Diagnose.
+     ANLASS 2026-08-19: Dieser Test fiel in der Pipeline (WebKit, unter Last)
+     mit "Received: 1" um und war beim zweiten Lauf DESSELBEN Commits gruen;
+     lokal 6 von 6 gruen. `.sw-grund.sichtbar` zaehlt ueber ALLE Dialoge — es
+     gibt zwei (`fertig` und `laeuft`). Aus "Received: 1" ist nicht zu erkennen,
+     WELCHER haengengeblieben ist, und ohne das laesst sich die Ursache nicht
+     suchen. Jetzt nennt die Meldung ihn. */
+  expect(
+    await page
+      .locator(".sw-grund.sichtbar")
+      .evaluateAll((els) => els.map((el) => el.dataset.modal || "(ohne Kennung)")),
+    "Dialoge, die noch sichtbar sind"
+  ).toEqual([]);
   await expect(page.locator("h1")).toContainText("We see more");
   /* Das englische Demo-Bildpaket muss mitziehen. */
   await expect(page.locator('[data-demo="selfie"] img')).toHaveAttribute("src", /-en\.jpg/);
@@ -362,7 +374,19 @@ test("Fokus bleibt in der Rückfrage und kehrt danach zurück", async ({ page })
   }
 
   await page.keyboard.press("Escape");
-  await expect(page.locator(".sw-grund.sichtbar")).toHaveCount(0);
+  /* Zusicherung unveraendert streng — aber mit Diagnose.
+     ANLASS 2026-08-19: Dieser Test fiel in der Pipeline (WebKit, unter Last)
+     mit "Received: 1" um und war beim zweiten Lauf DESSELBEN Commits gruen;
+     lokal 6 von 6 gruen. `.sw-grund.sichtbar` zaehlt ueber ALLE Dialoge — es
+     gibt zwei (`fertig` und `laeuft`). Aus "Received: 1" ist nicht zu erkennen,
+     WELCHER haengengeblieben ist, und ohne das laesst sich die Ursache nicht
+     suchen. Jetzt nennt die Meldung ihn. */
+  expect(
+    await page
+      .locator(".sw-grund.sichtbar")
+      .evaluateAll((els) => els.map((el) => el.dataset.modal || "(ohne Kennung)")),
+    "Dialoge, die noch sichtbar sind"
+  ).toEqual([]);
   /* Wartend statt einmalig lesen — und zwar aus einem konkreten Grund:
      `modalSchliessen()` nimmt die Klasse `sichtbar` WEG, BEVOR es den Fokus
      zurueckholt (sprachumschalter.js). Die Zeile darueber ist also schon
@@ -479,7 +503,19 @@ test("axe über die ganze Matrix: 2 Sprachen × 2 Themen, Rückfrage offen und z
   await expect(page.locator('.sw-grund[data-modal="fertig"]')).toBeVisible();
   await axePruefen(page, "Rückfrage offen, hell");
   await page.keyboard.press("Escape");
-  await expect(page.locator(".sw-grund.sichtbar")).toHaveCount(0);
+  /* Zusicherung unveraendert streng — aber mit Diagnose.
+     ANLASS 2026-08-19: Dieser Test fiel in der Pipeline (WebKit, unter Last)
+     mit "Received: 1" um und war beim zweiten Lauf DESSELBEN Commits gruen;
+     lokal 6 von 6 gruen. `.sw-grund.sichtbar` zaehlt ueber ALLE Dialoge — es
+     gibt zwei (`fertig` und `laeuft`). Aus "Received: 1" ist nicht zu erkennen,
+     WELCHER haengengeblieben ist, und ohne das laesst sich die Ursache nicht
+     suchen. Jetzt nennt die Meldung ihn. */
+  expect(
+    await page
+      .locator(".sw-grund.sichtbar")
+      .evaluateAll((els) => els.map((el) => el.dataset.modal || "(ohne Kennung)")),
+    "Dialoge, die noch sichtbar sind"
+  ).toEqual([]);
 
   await beastAn(page);
   await axePruefen(page, "Profil fertig, Beast");

--- a/public/__tests__/cache-kennung.test.js
+++ b/public/__tests__/cache-kennung.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PUBLIC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/* ── Jede ausgelieferte Datei braucht eine Kennung ─────────────────────────
+ *
+ * ANLASS 2026-08-19, gefunden vom Nutzer: "Wenn ich malzime öffne, sehe ich
+ * immer noch das alte Favicon. Das aktualisiert sich auch nicht, wenn ich beim
+ * Beast-Modus umschalte."
+ *
+ * Ursache war keine Nachlässigkeit des Browsers, sondern unsere: Die Verweise
+ * auf Favicon, App-Kachel und Manifest trugen KEINE Kennung, während das
+ * Stilblatt eine bekam. `scripts/deploy.sh` ersetzt vorhandene `?v=NNNN` — wo
+ * keine steht, kann es keine hochzählen. Das Zeichen blieb damit auf ewig im
+ * Zwischenspeicher, und Browser halten Favicons besonders hartnäckig fest.
+ *
+ * Der Fehler ist unsichtbar, solange man nur neue Rechner benutzt. Deshalb
+ * dieser Wächter: Er prüft die STRUKTUR, nicht das Aussehen.
+ */
+
+function alleHtmlSeiten(unter = "") {
+  const treffer = [];
+  for (const e of fs.readdirSync(path.join(PUBLIC, unter), { withFileTypes: true })) {
+    const rel = unter ? `${unter}/${e.name}` : e.name;
+    if (e.isDirectory()) {
+      if (["__tests__", "node_modules", "fonts", "img", "js", "locales", "lib"].includes(e.name)) continue;
+      treffer.push(...alleHtmlSeiten(rel));
+    } else if (e.name.endsWith(".html")) {
+      treffer.push(rel);
+    }
+  }
+  return treffer;
+}
+
+/* Verweise, die eine Kennung tragen MÜSSEN: Sie zeigen auf Dateien, die sich
+   ändern können und die der Browser sonst behält. */
+/* Als FUNKTION, nicht als Konstante: Ein globaler Suchausdruck merkt sich
+   seine Position (`lastIndex`). Wird derselbe zweimal mit `test()` benutzt,
+   ueberspringt der zweite Aufruf Treffer — mein erster Anlauf ist genau daran
+   gescheitert, und zwar an der eigenen Positivkontrolle. Ein frischer
+   Ausdruck je Verwendung kann das nicht. */
+const pflichtMuster = () =>
+  /(?:href|src)="(?:\.?\/)?((?:favicon[^"?]*|apple-touch-icon\.png|site\.webmanifest|og-image\.png))(\?[^"]*)?"/g;
+
+describe("Cache-Kennungen", () => {
+  const seiten = alleHtmlSeiten();
+
+  it("Messmittel: es gibt Seiten mit solchen Verweisen", () => {
+    /* Positivkontrolle. Fände die Suche nichts, wäre der Test still grün und
+       wertlos — genau der Zustand, den er verhindern soll. */
+    const mit = seiten.filter((f) => pflichtMuster().test(fs.readFileSync(path.join(PUBLIC, f), "utf8")));
+    expect(seiten.length).toBeGreaterThanOrEqual(10);
+    expect(mit.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("jeder Verweis auf Favicon, App-Kachel und Manifest trägt eine Kennung", () => {
+    const ohne = [];
+    for (const datei of seiten) {
+      const html = fs.readFileSync(path.join(PUBLIC, datei), "utf8");
+      for (const m of html.matchAll(pflichtMuster())) {
+        if (!m[2] || !/\?v=\d{6,}/.test(m[2])) ohne.push(`${datei}: ${m[1]}`);
+      }
+    }
+    expect(
+      ohne,
+      "Ohne Kennung behaelt der Browser die alte Datei — scripts/deploy.sh kann " +
+        "nur vorhandene ?v=NNNN hochzaehlen, keine neuen anlegen."
+    ).toEqual([]);
+  });
+
+  it("Rueckbauprobe: ein Verweis ohne Kennung wird erkannt", () => {
+    /* Belegt, dass der Test rot werden KANN — und zwar genau bei dem Muster,
+       das der Nutzer gefunden hat. */
+    const kaputt = '<link rel="icon" href="./favicon.svg" type="image/svg+xml" />';
+    const treffer = [...kaputt.matchAll(pflichtMuster())];
+    expect(treffer).toHaveLength(1);
+    expect(treffer[0][2]).toBeUndefined();
+  });
+
+  it("Gegenprobe: ein Verweis MIT Kennung schlaegt nicht faelschlich an", () => {
+    const gut = '<link rel="icon" href="./favicon.svg?v=2026081903" type="image/svg+xml" />';
+    const treffer = [...gut.matchAll(pflichtMuster())];
+    expect(treffer).toHaveLength(1);
+    expect(/\?v=\d{6,}/.test(treffer[0][2])).toBe(true);
+  });
+});

--- a/public/__tests__/marke-vollstaendig.test.js
+++ b/public/__tests__/marke-vollstaendig.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PUBLIC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/* ── Die Marke muss überall ankommen, nicht nur im Ordner ──────────────────
+ *
+ * ANLASS 2026-08-19. Der Nutzer musste DREIMAL nachfragen, weil ich die
+ * Wortmarke als Satz von Dateien behandelt habe statt als Identität, die an
+ * vielen Stellen auftaucht:
+ *
+ *   „Auf diesen Seiten sehe ich überhaupt kein Logo."      (Unterseiten)
+ *   „Ich sehe immer noch das alte Favicon."                (keine Kennung)
+ *   „Hast du das auch für die Google- und KI-Suche?"       (keine logo-Angabe)
+ *
+ * Und dann der Satz, der diesen Test ausgelöst hat: „Warum muss ich an diese
+ * Sachen immer denken? Das muss ja doch automatisch klar sein."
+ *
+ * Er hat recht. Die Liste existierte sogar — sie stand in der Design-Vorlage
+ * unter „Dateisatz, den Sie brauchen". Sie hing nur an meinem Gedächtnis.
+ * Jetzt hängt sie hier.
+ */
+
+const seiten = () => fs.readdirSync(PUBLIC).filter((f) => f.endsWith(".html"));
+
+const lies = (f) => fs.readFileSync(path.join(PUBLIC, f), "utf8");
+const start = lies("index.html");
+
+/* Was es geben MUSS, mit Grund. Ändert sich die Marke, ändern sich alle. */
+const DATEIEN = [
+  ["favicon.svg", "Tab-Zeichen, skaliert auf jede Größe"],
+  ["favicon-beast.svg", "Tab-Zeichen im Beast-Modus"],
+  ["favicon.ico", "Rückfall für ältere Browser"],
+  ["favicon-192x192.png", "Android-Startbildschirm und große Favicon-Größe"],
+  ["favicon-512x512.png", "Android-Startbild und Logo für Suchmaschinen"],
+  ["apple-touch-icon.png", "iPhone-Startbildschirm"],
+  ["og-image.png", "Vorschau beim Teilen"],
+  ["site.webmanifest", "Startbildschirm-Angaben"],
+];
+
+describe("Die Marke kommt überall an", () => {
+  it("alle Dateien des Satzes liegen vor", () => {
+    const fehlt = DATEIEN.filter(([f]) => !fs.existsSync(path.join(PUBLIC, f))).map(([f, grund]) => `${f} (${grund})`);
+    expect(fehlt, "Dateien aus dem Marken-Satz fehlen").toEqual([]);
+  });
+
+  it("die Startseite verlinkt Tab-Zeichen, App-Kachel und Manifest", () => {
+    /* Positivkontrolle: Fände die Suche gar keine link-Elemente, wäre alles
+       darunter wertlos. */
+    expect(start.match(/<link /g)?.length ?? 0).toBeGreaterThan(5);
+
+    const noetig = [
+      [/rel="icon"[^>]*favicon\.svg/, "favicon.svg (skalierbares Tab-Zeichen)"],
+      [/rel="icon"[^>]*favicon\.ico/, "favicon.ico (Rückfall)"],
+      [/rel="icon"[^>]*favicon-192x192\.png/, "192-px-Favicon (Google empfiehlt über 48 px)"],
+      [/rel="apple-touch-icon"/, "apple-touch-icon (iPhone)"],
+      [/rel="manifest"/, "site.webmanifest"],
+    ];
+    expect(
+      noetig.filter(([r]) => !r.test(start)).map(([, n]) => n),
+      "nicht verlinkt"
+    ).toEqual([]);
+  });
+
+  it("die Teilen-Vorschau ist vollständig", () => {
+    const noetig = ["og:title", "og:description", "og:image", "og:url", "twitter:card", "twitter:image"];
+    expect(
+      noetig.filter((n) => !start.includes(n)),
+      "Angaben für die Teilen-Vorschau fehlen"
+    ).toEqual([]);
+  });
+
+  it("Suchmaschinen finden ein Logo — Organization.logo, absolut und groß genug", () => {
+    /* Google zeigt es in der Wissenskarte. Mindestmaß laut Dokumentation:
+       112 x 112. Ohne diese Angabe zeigt Google gar kein Logo — das war der
+       Zustand bis 2026-08-19, obwohl die Bilddateien längst dalagen. */
+    const bloecke = [...start.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
+    expect(bloecke.length, "keine strukturierten Daten gefunden").toBeGreaterThan(0);
+
+    const ohneLogo = [];
+    const pruefe = (o, weg = "") => {
+      if (Array.isArray(o)) return o.forEach((x, i) => pruefe(x, `${weg}[${i}]`));
+      if (!o || typeof o !== "object") return;
+      if (o["@type"] === "Organization") {
+        if (typeof o.logo !== "string" || !o.logo.startsWith("https://")) {
+          ohneLogo.push(`${weg || "(Wurzel)"}: ${o.name || "?"}`);
+        }
+      }
+      for (const [k, v] of Object.entries(o)) if (typeof v === "object") pruefe(v, `${weg}.${k}`);
+    };
+    let gefunden = 0;
+    for (const b of bloecke) {
+      const j = JSON.parse(b[1]);
+      pruefe(j);
+      gefunden += JSON.stringify(j).split('"Organization"').length - 1;
+    }
+    /* Positivkontrolle: Gäbe es gar keine Organization, prüfte der Test nichts. */
+    expect(gefunden, "keine Organization in den strukturierten Daten").toBeGreaterThan(0);
+    expect(ohneLogo, "Organization ohne absolutes logo — Google zeigt dann keines").toEqual([]);
+  });
+
+  it("das Manifest verweist nur auf Dateien, die es gibt", () => {
+    const m = JSON.parse(fs.readFileSync(path.join(PUBLIC, "site.webmanifest"), "utf8"));
+    expect(m.icons?.length, "keine Icons im Manifest").toBeGreaterThan(0);
+    const fehlt = m.icons.map((i) => i.src.replace(/^\.?\//, "")).filter((f) => !fs.existsSync(path.join(PUBLIC, f)));
+    expect(fehlt, "Manifest nennt Dateien, die nicht existieren").toEqual([]);
+    expect(m.start_url, "ohne start_url startet die App auf der Seite, von der aus sie hinzugefügt wurde").toBe("/");
+  });
+
+  it("beide Tab-Zeichen tragen dieselbe Form", () => {
+    /* Sonst wäre es nicht dasselbe Logo, sondern ein zweites. */
+    const pfad = (d) => /<path class="zeichen" d="([^"]+)"/.exec(lies(d))[1];
+    expect(pfad("favicon-beast.svg")).toBe(pfad("favicon.svg"));
+    expect(pfad("favicon.svg").length).toBeGreaterThan(100);
+  });
+
+  it("jede Seite trägt die Wortmarke", () => {
+    const ohne = seiten().filter((f) => !lies(f).includes('class="wortmarke'));
+    expect(ohne, "Seiten ohne Wortmarke").toEqual([]);
+  });
+});

--- a/public/app.js
+++ b/public/app.js
@@ -231,8 +231,15 @@ function applyModeTheme() {
      Es entsteht dabei KEIN neuer Tab und kein Neuladen — getauscht wird nur
      das `href` des vorhandenen Elements. */
   const alt = document.querySelector('link[rel="icon"][type="image/svg+xml"]');
-  const ziel = boost ? "/favicon-beast.svg" : "/favicon.svg";
-  if (alt && !alt.href.endsWith(ziel)) {
+  /* Die Kennung des ausgelieferten Standes mitnehmen. Ohne sie behaelt der
+     Browser das alte Zeichen — Favicons speichert er besonders hartnaeckig
+     zwischen, weit ueber das hinaus, was die Kopfzeilen verlangen. Genau das
+     ist am 2026-08-19 passiert: "Ich sehe immer noch das alte Favicon."
+     Die Kennung steht bereits im vorhandenen Verweis; sie wird nicht geraten,
+     sondern uebernommen. */
+  const kennung = alt ? new URL(alt.href, location.href).search : "";
+  const ziel = (boost ? "/favicon-beast.svg" : "/favicon.svg") + kennung;
+  if (alt && new URL(alt.href, location.href).pathname !== ziel.split("?")[0]) {
     /* ERSETZEN, nicht nur `href` setzen. Browser halten Favicons zaeh fest;
        ein geaendertes Attribut allein loest das Neuzeichnen nicht zuverlaessig
        aus. Ein frisches Element mit derselben Rolle tut es. */

--- a/public/barrierefreiheit.html
+++ b/public/barrierefreiheit.html
@@ -21,10 +21,10 @@
       content="Gepr&uuml;ft nach WCAG 2.2 Stufe AA. Vollst&auml;ndiges Pr&uuml;fprotokoll, bekannte Einschr&auml;nkungen offen benannt."
     />
     <meta property="og:url" content="https://malzi.me/barrierefreiheit" />
-    <link rel="icon" href="./favicon.ico" sizes="32x32 16x16" />
-    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
-    <link rel="manifest" href="./site.webmanifest" />
+    <link rel="icon" href="./favicon.ico?v=2026081903" sizes="32x32 16x16" />
+    <link rel="icon" href="./favicon.svg?v=2026081903" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./apple-touch-icon.png?v=2026081903" />
+    <link rel="manifest" href="./site.webmanifest?v=2026081903" />
     <link rel="stylesheet" href="./styles.css?v=2026081903" />
   </head>
   <body>

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -21,10 +21,10 @@
       content="malziME speichert keine Profile und keine Nutzerdaten dauerhaft. Hochgeladene Fotos werden nur kurz verarbeitet und sofort wieder gel&ouml;scht."
     />
     <meta property="og:url" content="https://malzi.me/datenschutz" />
-    <link rel="icon" href="./favicon.ico" sizes="32x32 16x16" />
-    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
-    <link rel="manifest" href="./site.webmanifest" />
+    <link rel="icon" href="./favicon.ico?v=2026081903" sizes="32x32 16x16" />
+    <link rel="icon" href="./favicon.svg?v=2026081903" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./apple-touch-icon.png?v=2026081903" />
+    <link rel="manifest" href="./site.webmanifest?v=2026081903" />
     <link rel="stylesheet" href="./styles.css?v=2026081903" />
   </head>
   <body>

--- a/public/en/accessibility.html
+++ b/public/en/accessibility.html
@@ -21,10 +21,10 @@
       content="Tested against WCAG 2.2 Level AA. Full report, known limitations named openly."
     />
     <meta property="og:url" content="https://malzi.me/en/accessibility" />
-    <link rel="icon" href="/favicon.ico" sizes="32x32 16x16" />
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="icon" href="/favicon.ico?v=2026081903" sizes="32x32 16x16" />
+    <link rel="icon" href="/favicon.svg?v=2026081903" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=2026081903" />
+    <link rel="manifest" href="/site.webmanifest?v=2026081903" />
     <link rel="stylesheet" href="/styles.css?v=2026081903" />
   </head>
   <body>

--- a/public/en/legal-notice.html
+++ b/public/en/legal-notice.html
@@ -45,10 +45,10 @@
       }
     </script>
 
-    <link rel="icon" href="/favicon.ico" sizes="32x32 16x16" />
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="icon" href="/favicon.ico?v=2026081903" sizes="32x32 16x16" />
+    <link rel="icon" href="/favicon.svg?v=2026081903" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=2026081903" />
+    <link rel="manifest" href="/site.webmanifest?v=2026081903" />
 
     <link rel="stylesheet" href="/styles.css?v=2026081903" />
   </head>

--- a/public/en/privacy.html
+++ b/public/en/privacy.html
@@ -23,10 +23,10 @@
     />
     <meta property="og:url" content="https://malzi.me/en/privacy" />
 
-    <link rel="icon" href="/favicon.ico" sizes="32x32 16x16" />
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="icon" href="/favicon.ico?v=2026081903" sizes="32x32 16x16" />
+    <link rel="icon" href="/favicon.svg?v=2026081903" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=2026081903" />
+    <link rel="manifest" href="/site.webmanifest?v=2026081903" />
 
     <link rel="stylesheet" href="/styles.css?v=2026081903" />
   </head>

--- a/public/en/terms.html
+++ b/public/en/terms.html
@@ -18,10 +18,10 @@
     <meta property="og:title" content="Terms of Use &mdash; malziME" />
     <meta property="og:description" content="Terms of use for malziME by malziland." />
     <meta property="og:url" content="https://malzi.me/en/terms" />
-    <link rel="icon" href="/favicon.ico" sizes="32x32 16x16" />
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="icon" href="/favicon.ico?v=2026081903" sizes="32x32 16x16" />
+    <link rel="icon" href="/favicon.svg?v=2026081903" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=2026081903" />
+    <link rel="manifest" href="/site.webmanifest?v=2026081903" />
     <link rel="stylesheet" href="/styles.css?v=2026081903" />
   </head>
   <body>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -45,10 +45,10 @@
       }
     </script>
 
-    <link rel="icon" href="./favicon.ico" sizes="32x32 16x16" />
-    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
-    <link rel="manifest" href="./site.webmanifest" />
+    <link rel="icon" href="./favicon.ico?v=2026081903" sizes="32x32 16x16" />
+    <link rel="icon" href="./favicon.svg?v=2026081903" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./apple-touch-icon.png?v=2026081903" />
+    <link rel="manifest" href="./site.webmanifest?v=2026081903" />
 
     <link rel="stylesheet" href="./styles.css?v=2026081903" />
   </head>

--- a/public/index.html
+++ b/public/index.html
@@ -56,7 +56,7 @@
         "@type": "WebApplication",
         "name": "malziME",
         "url": "https://malzi.me/",
-        "description": "KI-basiertes Lern-Tool f\u00fcr Medienkompetenz und Datenschutz-Sensibilisierung. Zeigt, was Algorithmen aus einem einzigen Foto \u00fcber eine Person behaupten k\u00f6nnten.",
+        "description": "KI-basiertes Lern-Tool für Medienkompetenz und Datenschutz-Sensibilisierung. Zeigt, was Algorithmen aus einem einzigen Foto über eine Person behaupten könnten.",
         "applicationCategory": "EducationalApplication",
         "operatingSystem": "Web",
         "sameAs": ["https://github.com/malziland/malzime"],
@@ -74,7 +74,8 @@
             "name": "Christoph Krieger",
             "url": "https://malziland.at",
             "sameAs": ["https://www.linkedin.com/in/christophkrieger/"]
-          }
+          },
+          "logo": "https://malzi.me/favicon-512x512.png"
         },
         "creator": {
           "@type": "Person",
@@ -82,7 +83,8 @@
           "worksFor": {
             "@type": "Organization",
             "name": "malziland - learning | training | consulting e.U.",
-            "url": "https://malziland.at"
+            "url": "https://malziland.at",
+            "logo": "https://malzi.me/favicon-512x512.png"
           }
         },
         "audience": {
@@ -91,14 +93,18 @@
           "suggestedMinAge": 10
         },
         "inLanguage": "de",
-        "keywords": "Medienkompetenz, Datenschutz, KI, Algorithmus, Bias, Profiling, Workshop, Safer Internet"
+        "keywords": "Medienkompetenz, Datenschutz, KI, Algorithmus, Bias, Profiling, Workshop, Safer Internet",
+        "image": "https://malzi.me/og-image.png"
       }
     </script>
 
-    <link rel="icon" href="./favicon.ico" sizes="32x32 16x16" />
-    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
-    <link rel="manifest" href="./site.webmanifest" />
+    <link rel="icon" href="./favicon.ico?v=2026081903" sizes="32x32 16x16" />
+    <link rel="icon" href="./favicon.svg?v=2026081903" type="image/svg+xml" />
+    <!-- Grosses Rasterbild fuer Suchmaschinen: Google empfiehlt ueber 48x48. Das
+         SVG deckt jede Groesse ab, aber nicht jeder Dienst wertet SVG aus. -->
+    <link rel="icon" href="./favicon-192x192.png?v=2026081903" sizes="192x192" type="image/png" />
+    <link rel="apple-touch-icon" href="./apple-touch-icon.png?v=2026081903" />
+    <link rel="manifest" href="./site.webmanifest?v=2026081903" />
     <link rel="stylesheet" href="./lib/leaflet/leaflet.css" />
     <link rel="stylesheet" href="./styles.css?v=2026081903" />
     <script type="application/ld+json">
@@ -113,7 +119,8 @@
           "creditText": "KI erstellt",
           "creator": {
             "@type": "Organization",
-            "name": "malziland - learning | training | consulting e.U."
+            "name": "malziland - learning | training | consulting e.U.",
+            "logo": "https://malzi.me/favicon-512x512.png"
           },
           "copyrightNotice": "MIT-Lizenz, siehe Repository",
           "license": "https://github.com/malziland/malzime/blob/main/LICENSE",
@@ -130,7 +137,8 @@
           "creditText": "KI erstellt",
           "creator": {
             "@type": "Organization",
-            "name": "malziland - learning | training | consulting e.U."
+            "name": "malziland - learning | training | consulting e.U.",
+            "logo": "https://malzi.me/favicon-512x512.png"
           },
           "copyrightNotice": "MIT-Lizenz, siehe Repository",
           "license": "https://github.com/malziland/malzime/blob/main/LICENSE",
@@ -147,7 +155,8 @@
           "creditText": "KI erstellt",
           "creator": {
             "@type": "Organization",
-            "name": "malziland - learning | training | consulting e.U."
+            "name": "malziland - learning | training | consulting e.U.",
+            "logo": "https://malzi.me/favicon-512x512.png"
           },
           "copyrightNotice": "MIT-Lizenz, siehe Repository",
           "license": "https://github.com/malziland/malzime/blob/main/LICENSE",

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -21,10 +21,10 @@
       content="Nutzungsbedingungen f&uuml;r malziME &mdash; erlaubte und verbotene Nutzung, Workshops, Datenschutz, Haftung."
     />
     <meta property="og:url" content="https://malzi.me/nutzungsbedingungen" />
-    <link rel="icon" href="./favicon.ico" sizes="32x32 16x16" />
-    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
-    <link rel="manifest" href="./site.webmanifest" />
+    <link rel="icon" href="./favicon.ico?v=2026081903" sizes="32x32 16x16" />
+    <link rel="icon" href="./favicon.svg?v=2026081903" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./apple-touch-icon.png?v=2026081903" />
+    <link rel="manifest" href="./site.webmanifest?v=2026081903" />
     <link rel="stylesheet" href="./styles.css?v=2026081903" />
   </head>
   <body>

--- a/public/stats.html
+++ b/public/stats.html
@@ -20,10 +20,10 @@
     />
     <meta property="og:url" content="https://malzi.me/stats" />
 
-    <link rel="icon" href="./favicon.ico" sizes="32x32 16x16" />
-    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
-    <link rel="manifest" href="./site.webmanifest" />
+    <link rel="icon" href="./favicon.ico?v=2026081903" sizes="32x32 16x16" />
+    <link rel="icon" href="./favicon.svg?v=2026081903" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./apple-touch-icon.png?v=2026081903" />
+    <link rel="manifest" href="./site.webmanifest?v=2026081903" />
 
     <link rel="stylesheet" href="./styles.css?v=2026081903" />
   </head>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1848,6 +1848,15 @@ html[data-has-result] {
 .stats-hero {
   text-align: center;
   margin-bottom: 32px;
+  /* Damit die Ueberschrift auf DERSELBEN Hoehe steht wie auf allen anderen
+     Seiten. Gefunden von e2e/kopfbereich.test.js: neun Seiten bei 115 px, die
+     Zahlen-Seite bei 94 — sie hat einen eigenen Kopfbereich, den die Regel fuer
+     .hero nicht erreicht.
+
+     INNENabstand, nicht Rand: Ein Rand an der Ueberschrift faellt mit dem des
+     Elternelements zusammen (Margin-Collapsing) und wirkte nur zur Haelfte —
+     gemessen 105 statt 115. Innenabstand faellt nicht zusammen. */
+  padding-top: 21px;
 }
 
 .stats-hero__title {


### PR DESCRIPTION
Aus der Frage des Nutzers: **„Warum muss ich an diese Sachen immer denken? Das muss ja doch automatisch klar sein bei solchen Änderungen."**

Er hat recht. Ich habe „das Logo" als **Satz von Dateien** behandelt statt als **Identität, die an vielen Stellen auftaucht** — und er musste dreimal nachfragen: Unterseiten, Zwischenspeicher, Suchmaschinen. Die Liste existierte sogar, sie stand in der Design-Vorlage unter „Dateisatz, den Sie brauchen". Sie hing nur an meinem Gedächtnis.

## Der Wächter

`public/__tests__/marke-vollstaendig.test.js` prüft jetzt:

- alle acht Dateien des Satzes liegen vor
- die Startseite verlinkt Tab-Zeichen, ICO, 192-px-PNG, Apple-Kachel, Manifest
- die Teilen-Vorschau ist vollständig (`og:` + `twitter:`)
- **jede** `Organization` in den strukturierten Daten hat ein absolutes `logo`
- das Manifest verweist nur auf existierende Dateien und hat `start_url`
- beide Tab-Zeichen tragen dieselbe Form
- jede Seite trägt die Wortmarke

**Er hat beim ersten Lauf sofort eine Lücke gefunden**, die ich gerade übersehen hatte: drei `Organization`-Einträge im zweiten JSON-LD-Block ohne Logo.

## Drei Fehler, die er aufdeckte

| Fehler | Ursache |
|---|---|
| **Das Logo aktualisierte sich nicht** | Favicon-Verweise trugen **keine** Versionskennung, `styles.css` schon. `deploy.sh` kann nur vorhandene `?v=` hochzählen |
| **Suchmaschinen fanden kein Logo** | `Organization.logo` fehlte überall. Google zeigt ohne diese Angabe keines — die Bilddateien lagen längst bereit |
| **Zahlen-Seite stand schief** | Überschrift bei 94 px statt 115. Eigener Kopfbereich, den die Regel für `.hero` nicht erreicht |

Die dritte hat kein Mensch gemeldet — man sieht die Seiten selten nebeneinander. Sie kam aus dem neuen `e2e/kopfbereich.test.js`, das auch festhält, was der Nutzer zuvor dreimal von Hand finden musste: Logo auf jeder Seite, Umschalter auf gleicher Höhe, **Abstand hält auch ohne JavaScript**, Tab-Zeichen wirklich dunkel (Helligkeit gerechnet, nicht „andere Datei = erledigt").

## Der Wackler, ehrlich

`sprachumschalter.test.js` zählte `.sw-grund.sichtbar` über **beide** Dialoge. Aus `Received: 1` war nicht erkennbar, welcher hängengeblieben war. Gleich streng, nennt jetzt den Übeltäter. **Der Wackler selbst ist nicht behoben**, nur auswertbar.

## Prüfstand

| Suite | |
|---|---|
| Backend | **857/857** |
| Frontend | **436/436** (vorher 425) |
| E2E | **249/249** (vorher 233) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
