### PR TITLE
fix: im Beast-Modus bleibt genau ein Tab-Zeichen übrig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+### Behoben
+
+- **Im Beast-Modus wurde das Zeichen im Browser-Tab doch nicht schwarz.** Die
+  Seite bietet dem Browser drei Zeichen an — für ältere Browser, für moderne
+  und für Suchmaschinen. Der Browser sucht sich eines aus, und wir tauschten
+  nur eines davon: meist genau das, das er gar nicht anzeigte. Jetzt bleibt im
+  Beast-Modus ein einziges übrig, danach ist der ursprüngliche Satz zurück.
+
 ## [3.8.1] — 2026-08-19
 
 ### Behoben

--- a/e2e/kopfbereich.test.js
+++ b/e2e/kopfbereich.test.js
@@ -170,6 +170,18 @@ test.describe("Kopfbereich", () => {
     const beast = await zeichen();
     expect(beast.adresse, "das Tab-Zeichen wechselt im Beast-Modus nicht").toBe("/favicon-beast.svg");
 
+    /* UND es darf kein zweites geben. BEFUND 2026-08-19: Die Seite nennt DREI
+       Zeichen (ico, svg, 192-px-png). Der Browser sucht sich EINES aus und
+       bevorzugt oft das .ico. Solange nur der SVG-Verweis getauscht wurde,
+       tauschten wir etwas, das gar nicht angezeigt wird — beim Nutzer blieb der
+       Tab unveraendert, in Safari wie in Brave. Im echten Chrome nachgemessen:
+       Erst als genau ein Verweis uebrig blieb, holte der Browser
+       favicon-beast.svg tatsaechlich (HTTP 200 im Netzwerk-Mitschnitt). */
+    const alleImBeast = await page
+      .locator("link[rel='icon']")
+      .evaluateAll((els) => els.map((e) => e.getAttribute("href")));
+    expect(alleImBeast, "im Beast-Modus darf nur EIN Zeichen angeboten werden").toHaveLength(1);
+
     /* Und es muss WIRKLICH dunkel sein — nicht nur eine andere Datei. Die erste
        Fassung war ein HELLER Kasten (die Vorlagen-Fassung für dunkle
        Tab-Leisten); auf einer hellen Leiste blieb der Tab dadurch hell, und der
@@ -184,6 +196,10 @@ test.describe("Kopfbereich", () => {
 
     await page.locator("#biasSwitch").click({ force: true });
     expect((await zeichen()).adresse, "kehrt nach dem Zurückschalten nicht zurück").toBe("/favicon.svg");
+    const alleZurueck = await page
+      .locator("link[rel='icon']")
+      .evaluateAll((els) => els.map((e) => e.getAttribute("href")));
+    expect(alleZurueck.length, "der urspruengliche Satz wird nicht wiederhergestellt").toBeGreaterThan(1);
   });
 
   test("beide Zeichen haben dieselbe Form — nur andere Farben", () => {

--- a/public/app.js
+++ b/public/app.js
@@ -206,6 +206,57 @@ document.addEventListener("drop", (e) => e.preventDefault());
    überlebt Neuladen und Tab-Wechsel, endet aber mit dem Tab. Im Workshop
    startet damit jede neue Person und jedes weitergereichte Gerät wieder
    seriös und erlebt den Kontrast selbst (siehe js/modus-speicher.js). */
+/* Das Tab-Zeichen dem Modus folgen lassen.
+ *
+ * WARUM ALLE VERWEISE UND NICHT NUR DER SVG-VERWEIS (Befund 2026-08-19):
+ * Die Seite nennt DREI Zeichen — favicon.ico (Rueckfall fuer alte Browser),
+ * favicon.svg (skalierbar) und favicon-192x192.png (fuer Suchmaschinen). Der
+ * Browser sucht sich EINES davon aus, und viele bevorzugen das .ico oder das
+ * grosse PNG. Wer nur den SVG-Verweis tauscht, tauscht dann etwas, das gar
+ * nicht angezeigt wird — beim Nutzer blieb der Tab unveraendert, in Safari wie
+ * in Brave.
+ *
+ * Im Beast-Modus bleibt deshalb GENAU EIN Verweis uebrig, damit es nichts
+ * auszuwaehlen gibt. Beim Zurueckschalten wird der urspruengliche Satz
+ * wiederhergestellt — er wird beim ersten Aufruf gemerkt, nicht nachgebaut.
+ *
+ * WAS SICH NICHT PRUEFEN LAESST: Ob der Browser das Zeichen daraufhin neu
+ * zeichnet. Die Tab-Leiste ist Browser-Oberflaeche; Playwright fotografiert sie
+ * nicht, und headless-Browser fordern Favicons gar nicht erst an. Automatisch
+ * belegbar ist allein, WELCHE Verweise im Dokument stehen. */
+let zeichenUrsprung = null;
+
+function tabZeichenSetzen(boost) {
+  const kopf = document.head;
+  if (!kopf) return;
+
+  if (zeichenUrsprung === null) {
+    zeichenUrsprung = Array.from(kopf.querySelectorAll('link[rel="icon"]')).map((el) => el.outerHTML);
+  }
+  /* Ohne gemerkten Satz gibt es nichts zu tauschen — dann lieber nichts tun,
+     als einen erfundenen Satz zu schreiben. */
+  if (!zeichenUrsprung.length) return;
+
+  const vorhanden = Array.from(kopf.querySelectorAll('link[rel="icon"]'));
+  const kennung = vorhanden.length ? new URL(vorhanden[0].href, location.href).search : "";
+  const istBeast = vorhanden.length === 1 && vorhanden[0].getAttribute("href")?.includes("favicon-beast");
+  if (boost === istBeast) return;
+
+  vorhanden.forEach((el) => el.remove());
+
+  if (boost) {
+    const neu = document.createElement("link");
+    neu.rel = "icon";
+    neu.type = "image/svg+xml";
+    neu.href = "/favicon-beast.svg" + kennung;
+    kopf.appendChild(neu);
+  } else {
+    for (const html of zeichenUrsprung) {
+      kopf.insertAdjacentHTML("beforeend", html);
+    }
+  }
+}
+
 function applyModeTheme() {
   const boost = elements.biasSwitch.checked;
   document.documentElement.setAttribute("data-mode", boost ? "boost" : "normal");
@@ -230,25 +281,7 @@ function applyModeTheme() {
 
      Es entsteht dabei KEIN neuer Tab und kein Neuladen — getauscht wird nur
      das `href` des vorhandenen Elements. */
-  const alt = document.querySelector('link[rel="icon"][type="image/svg+xml"]');
-  /* Die Kennung des ausgelieferten Standes mitnehmen. Ohne sie behaelt der
-     Browser das alte Zeichen — Favicons speichert er besonders hartnaeckig
-     zwischen, weit ueber das hinaus, was die Kopfzeilen verlangen. Genau das
-     ist am 2026-08-19 passiert: "Ich sehe immer noch das alte Favicon."
-     Die Kennung steht bereits im vorhandenen Verweis; sie wird nicht geraten,
-     sondern uebernommen. */
-  const kennung = alt ? new URL(alt.href, location.href).search : "";
-  const ziel = (boost ? "/favicon-beast.svg" : "/favicon.svg") + kennung;
-  if (alt && new URL(alt.href, location.href).pathname !== ziel.split("?")[0]) {
-    /* ERSETZEN, nicht nur `href` setzen. Browser halten Favicons zaeh fest;
-       ein geaendertes Attribut allein loest das Neuzeichnen nicht zuverlaessig
-       aus. Ein frisches Element mit derselben Rolle tut es. */
-    const neu = document.createElement("link");
-    neu.rel = "icon";
-    neu.type = "image/svg+xml";
-    neu.href = ziel;
-    alt.replaceWith(neu);
-  }
+  tabZeichenSetzen(boost);
 }
 /* Gemerkte Wahl wiederherstellen, BEVOR das Theme angewendet wird — sonst
    blitzt kurz der falsche Look auf. `null` heisst „nie gewählt": dann bleibt


### PR DESCRIPTION
Nach zwei Anläufen die eigentliche Ursache — gefunden, weil ich es endlich **im echten Chrome** getestet habe statt in einer Simulation.

## Warum es nicht wirkte

Die Seite bietet dem Browser **drei** Zeichen an:

```
<link rel="icon" href="favicon.ico">            für ältere Browser
<link rel="icon" href="favicon.svg">            ← nur dieses tauschten wir
<link rel="icon" href="favicon-192x192.png">    für Suchmaschinen
```

Der Browser sucht sich **eines** aus und bevorzugt oft das `.ico`. Wir tauschten also meist genau das, was gar nicht angezeigt wurde. **Der Code war richtig — er wirkte ins Leere.**

Im Beast-Modus bleibt jetzt genau **ein** Verweis übrig; danach ist der ursprüngliche Satz zurück.

## Der Beleg

Echtes Chrome, Netzwerk-Mitschnitt:

```
GET /favicon.svg?v=2026081904        200
GET /favicon.ico?v=2026081904        200
GET /favicon-beast.svg?v=2026081904  200   ← beim Umschalten geholt
```

## Was ich nicht belegen kann, und das gehört gesagt

**Mit Playwright ist der Favicon-Wechsel grundsätzlich nicht prüfbar.** Headless-Browser zeichnen keine Tab-Leiste und fordern Favicons gar nicht erst an — beide Maschinen holten *überhaupt kein* Favicon, auch nicht beim Laden. Mein bisheriger Test konnte nur beweisen, welche Adresse im Dokument steht, nie was der Browser daraus macht. Das steht jetzt als Einschränkung im Test.

Der Test prüft dafür die Bedingung, an der es tatsächlich lag: **im Beast-Modus darf nur ein Zeichen angeboten werden.**

## Prüfstand

Frontend **436/436** · Kopfbereich-E2E **16/16**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
