### PR TITLE
fix: die Rückfrage konnte hängenbleiben und war dann nicht mehr schließbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   nur eines davon: meist genau das, das er gar nicht anzeigte. Jetzt bleibt im
   Beast-Modus ein einziges übrig, danach ist der ursprüngliche Satz zurück.
 
+## [Unveröffentlicht]
+
+### Behoben
+
+- **Im Beast-Modus wurde das Zeichen im Browser-Tab doch nicht schwarz.** Die
+  Seite bietet dem Browser drei Zeichen an; er sucht sich eines aus, und wir
+  tauschten nur eines davon — meist genau das, das er gar nicht anzeigte. Jetzt
+  bleibt im Beast-Modus ein einziges übrig.
+
+- **Die Sprachwahl-Rückfrage konnte sich in seltenen Fällen nicht mehr
+  schließen.** Wurde sie im selben Sekundenbruchteil geöffnet und wieder
+  geschlossen, blieb sie sichtbar stehen und reagierte danach auf keine Taste
+  mehr. Trat unter Last auf und hat die Auslieferung dreimal blockiert.
+
 ## [3.8.1] — 2026-08-19
 
 ### Behoben

--- a/public/js/sprachumschalter.js
+++ b/public/js/sprachumschalter.js
@@ -315,10 +315,22 @@ function modalOeffnen(art, ziel, ohneBild, ausloeser) {
   offen = art === "fertig" ? modalFertig : modalLaeuft;
   offen.hidden = false;
   umgebungStillegen(true);
-  /* Element festhalten, nicht `offen` lesen: Wird die Rückfrage vor dem
-     nächsten Bildschirmrahmen geschlossen, ist `offen` dann null. */
+  /* Element festhalten UND vor dem Setzen prüfen, ob es noch das offene ist.
+     BUG-2026-08-19-02: Bis hierher wurde nur festgehalten. Das war schlimmer
+     als `offen` zu lesen — wird die Rückfrage vor dem nächsten Bildschirmrahmen
+     geschlossen, gab der Rahmen die Klasse `sichtbar` an einen BEREITS
+     GESCHLOSSENEN Dialog zurück. Danach war `sichtbar` gesetzt, `offen` aber
+     null, und weil `aufTaste()` mit `if (!offen) return;` beginnt, tat Escape
+     nichts mehr: Der Dialog blieb dauerhaft offen.
+
+     Aufgefallen in der Pipeline (WebKit unter Last), dreimal, zuletzt auch
+     dann noch, als die Zusicherung bereits wartend las — sie konnte also nicht
+     zu früh gemessen haben. Genau diese Signatur: `.sw-grund.sichtbar` bleibt
+     stehen und lässt sich nicht mehr schliessen. */
   const dieser = offen;
-  requestAnimationFrame(() => dieser.classList.add("sichtbar"));
+  requestAnimationFrame(() => {
+    if (offen === dieser) dieser.classList.add("sichtbar");
+  });
   const ruhig = offen.querySelector(".sw-knopf--bleiben");
   if (ruhig) ruhig.focus();
   offen.addEventListener("focusout", fokusZurueckholen);


### PR DESCRIPTION
Gefunden nach dem **dritten** roten Pipeline-Lauf — und es ist kein Testproblem, sondern ein echter Fehler für Nutzer.

## Was passiert ist

In `modalOeffnen()` stand:

```js
const dieser = offen;
requestAnimationFrame(() => dieser.classList.add("sichtbar"));
```

Der Kommentar daneben benannte die Gefahr sogar — *„Wird die Rückfrage vor dem nächsten Bildschirmrahmen geschlossen, ist `offen` dann null"* — aber die Lösung machte es **schlimmer**: Das Element festzuhalten heißt, dass der Bildschirmrahmen die Klasse `sichtbar` an einen **bereits geschlossenen** Dialog zurückgibt.

Danach ist `sichtbar` gesetzt, `offen` aber `null`. Und weil `aufTaste()` mit `if (!offen) return;` beginnt, **tut Escape von da an nichts mehr**. Die Rückfrage bleibt stehen und lässt sich mit keiner Taste mehr schließen.

## Warum das die Erklärung ist

Genau diese Signatur hat die Pipeline dreimal gemeldet — zuletzt auch dann noch, als die Zusicherung bereits **wartend** las (`expect.poll`). Sie kann also nicht zu früh gemessen haben; der Dialog war wirklich offen.

Der Mechanismus lässt sich nachstellen:

```
ohne Fix   schließen vor dem Rahmen → sichtbar: JA,   offen: null
mit Fix    schließen vor dem Rahmen → sichtbar: nein, offen: null
```

## Behebung

Der Rahmen setzt die Klasse nur noch, wenn dieser Dialog dann noch der offene ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
