### PR TITLE
fix: öffentliche Barrierefreiheitserklärung nachgezogen + Datums-Wächter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,14 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   unter dem geforderten Kontrast (4,40 · 4,01 · 4,41 statt 4,5 : 1). Jetzt
   4,56 · 4,57 · 4,59 : 1.
 
-  Aufgefallen sind sie erst jetzt, weil die automatische Prüfung diesen Bereich
-  **nie gemessen** hatte: Die Sprechblase der Karte überdeckte etwas, woraufhin
+  Die öffentliche Barrierefreiheitserklärung nennt den Fund und trägt das neue
+  Prüfdatum — in beiden Sprachen. Dass sie beim ersten Anlauf vergessen wurde,
+  kann sich nicht wiederholen: Eine neue Prüfung vergleicht das Prüfdatum in der
+  deutschen Erklärung, der englischen und dem Prüfbericht und schlägt Alarm,
+  sobald eines davon abweicht.
+
+  Aufgefallen sind die drei Farben erst jetzt, weil die automatische Prüfung
+  diesen Bereich **nie gemessen** hatte: Die Sprechblase der Karte überdeckte etwas, woraufhin
   das Prüfwerkzeug den ganzen Profilinhalt übersprang — und „keine Verstöße"
   meldete, ohne hingesehen zu haben. Die Prüfung nennt jetzt zuerst, was sie
   angesehen hat, und schlägt Alarm, wenn ein sichtbarer Bereich fehlt. Das

--- a/docs/barrierefreiheit/PRUEFBERICHT-WCAG-EM.md
+++ b/docs/barrierefreiheit/PRUEFBERICHT-WCAG-EM.md
@@ -16,7 +16,7 @@ Bewertung der Konformität mit den Web Content Accessibility Guidelines.
 | ------------------- | ------------------------------------------------------------------------------ |
 | **Prüfer**          | malziland - learning \| training \| consulting e.U., Inhaber Christoph Krieger |
 | **Auftraggeber**    | Eigenprüfung                                                                   |
-| **Prüfdatum**       | 17.–18. August 2026                                                            |
+| **Prüfdatum**       | 17.–19. August 2026                                                            |
 | **Geprüfter Stand** | Commit `05e2a71` (v3.4.0), ausgelieferte Kennung `2026081802`                  |
 | **Art der Prüfung** | Selbstbewertung, werkzeuggestützt und teilweise manuell                        |
 

--- a/e2e/barrierefreiheit-protokoll.test.js
+++ b/e2e/barrierefreiheit-protokoll.test.js
@@ -1213,5 +1213,48 @@ test.describe("Prüfprotokoll WCAG 2.2 AA", () => {
        nichts und wäre still grün. */
     expect(gelesen, "keine Unterlage gefunden — der Drift-Wächter ist blind").toBeGreaterThan(0);
     expect(falsch, `Doku nennt eine andere Zahl von Zuständen als gemessen: ${JSON.stringify(falsch)}`).toEqual([]);
+
+    /* ── Und dasselbe für das Prüfdatum ────────────────────────────────────
+       ANLASS 2026-08-19, vom Nutzer gefunden: Nach drei behobenen
+       Kontrastfehlern hatte ich die beiden Unterlagen in docs/ nachgezogen,
+       die ÖFFENTLICHE Erklärung aber nicht — ausgerechnet die, auf die sich
+       ein Dritter beruft. Sie stand danach mit einem Datum da, an dem der
+       Befund noch gar nicht bekannt war. Der Nutzer musste daran denken; das
+       ist die falsche Person dafür.
+
+       Warum hier und nicht im Fakten-Drift-Wächter: Der liest ausschließlich
+       Markdown und Text. Ein Muster für HTML wäre dort still nie angesprungen
+       und hätte Sicherheit vorgetäuscht — nachgemessen, nicht vermutet. */
+    const DATUM_STELLEN = [
+      ["public/barrierefreiheit.html", /zuletzt gepr&uuml;ft am (\d{1,2})\.&nbsp;\w+&nbsp;(\d{4})/],
+      ["public/barrierefreiheit.html", /nicht behauptet &middot; Stand: (\d{1,2})\. \w+ (\d{4})/],
+      ["public/en/accessibility.html", /last reviewed on (\d{1,2})&nbsp;\w+&nbsp;(\d{4})/],
+      [
+        "docs/barrierefreiheit/PRUEFBERICHT-WCAG-EM.md",
+        /\*\*Prüfdatum\*\*\s*\|\s*\d{1,2}\.–(\d{1,2})\.\s*\w+\s*(\d{4})/,
+      ],
+    ];
+    const daten = [];
+    for (const [rel, muster] of DATUM_STELLEN) {
+      const pfad = join(process.cwd(), rel);
+      if (!existsSync(pfad)) continue;
+      const treffer = readFileSync(pfad, "utf8").match(muster);
+      daten.push({ datei: rel, datum: treffer ? `${treffer[1]}.${treffer[2]}` : null });
+    }
+
+    /* POSITIVKONTROLLE: Jede Stelle MUSS treffen. Ein Muster, das ins Leere
+       läuft, meldet „kein Widerspruch" und ist damit von einem gesunden
+       Ergebnis nicht zu unterscheiden. */
+    expect(
+      daten.filter((d) => d.datum === null).map((d) => d.datei),
+      "Prüfdatum an dieser Stelle nicht gefunden — der Wächter ist dort blind"
+    ).toEqual([]);
+    expect(daten.length, "keine Unterlage mit Prüfdatum gefunden").toBeGreaterThan(2);
+
+    const verschieden = [...new Set(daten.map((d) => d.datum))];
+    expect(
+      verschieden.length,
+      `Das Datum der letzten Barrierefreiheits-Prüfung steht unterschiedlich da: ${JSON.stringify(daten)}`
+    ).toBe(1);
   });
 });

--- a/public/barrierefreiheit.html
+++ b/public/barrierefreiheit.html
@@ -56,7 +56,7 @@
       </div>
       <span class="page-eyebrow">Rechtliches</span>
       <h1>Barrierefreiheit</h1>
-      <p class="legal-subtitle">Gepr&uuml;ft, nicht behauptet &middot; Stand: 18. August 2026</p>
+      <p class="legal-subtitle">Gepr&uuml;ft, nicht behauptet &middot; Stand: 19. August 2026</p>
       <div class="page-rule"></div>
 
       <!-- 1. Anspruch -->
@@ -154,6 +154,11 @@
           <li>
             <strong>Jede Messung hat eine Gegenprobe.</strong> Findet das Pr&uuml;fwerkzeug nichts zu pr&uuml;fen,
             bricht der Lauf ab. Sonst s&auml;he ein kaputter Lauf aus wie ein perfektes Ergebnis.
+            <strong>Am 19.&nbsp;August ist genau das eingetreten:</strong> Eine Sprechblase auf der Karte verdeckte den
+            Profilinhalt so, dass das Werkzeug ihn gar nicht ansah &ndash; und &bdquo;keine Verst&ouml;&szlig;e&ldquo;
+            meldete, ohne hingesehen zu haben. Dahinter lagen drei zu blasse Textfarben im Beast-Modus, die noch am
+            selben Tag behoben wurden. Seither nennt die Pr&uuml;fung zuerst, <em>was</em> sie angesehen hat, und
+            schl&auml;gt Alarm, wenn ein sichtbarer Bereich fehlt.
           </li>
         </ul>
         <p>
@@ -277,7 +282,7 @@
           <p>Weitere Kontaktdaten im <a href="/impressum" tabindex="0">Impressum</a>.</p>
         </div>
         <p>
-          Erstellt am 17.&nbsp;August&nbsp;2026, zuletzt gepr&uuml;ft am 18.&nbsp;August&nbsp;2026, auf Grundlage einer
+          Erstellt am 17.&nbsp;August&nbsp;2026, zuletzt gepr&uuml;ft am 19.&nbsp;August&nbsp;2026, auf Grundlage einer
           Selbstbewertung mit den unter 03 genannten Werkzeugen. Wir pr&uuml;fen erneut bei jeder &Auml;nderung an
           Aussehen, Bedienung oder Seitenaufbau, mindestens aber halbj&auml;hrlich. Die maschinellen Messungen laufen
           bei jeder Auslieferung automatisch mit.

--- a/public/en/accessibility.html
+++ b/public/en/accessibility.html
@@ -59,7 +59,7 @@
       <span class="page-eyebrow">Legal</span>
       <h1>Accessibility</h1>
       <p class="legal-subtitle">
-        Tested, not claimed &middot; English version: 19 August 2026 &middot; German original: 18 August 2026
+        Tested, not claimed &middot; English version: 19 August 2026 &middot; German original: 19 August 2026
       </p>
       <div class="page-rule"></div>
 
@@ -149,6 +149,11 @@
           <li>
             <strong>Every measurement has a control.</strong> If the testing tool finds nothing to test, the run aborts.
             Otherwise a broken run would look like a perfect result.
+            <strong>On 19&nbsp;August that is exactly what happened:</strong> a popup on the map covered the profile
+            content in such a way that the tool never looked at it &ndash; and reported &ldquo;no violations&rdquo;
+            without having looked. Behind it were three text colours in Beast Mode that were too pale; all three were
+            fixed the same day. Since then the check first states <em>what</em> it looked at, and raises an alarm when a
+            visible area is missing.
           </li>
         </ul>
         <p>
@@ -262,7 +267,7 @@
           <p>Further contact details in the <a href="/en/legal-notice" tabindex="0">legal notice</a>.</p>
         </div>
         <p>
-          Prepared on 17&nbsp;August&nbsp;2026, last reviewed on 18&nbsp;August&nbsp;2026, on the basis of a
+          Prepared on 17&nbsp;August&nbsp;2026, last reviewed on 19&nbsp;August&nbsp;2026, on the basis of a
           self-assessment using the tools listed under 03. We test again whenever the appearance, the interaction or the
           page structure changes, and at least every six months. The automated measurements run with every release.
         </p>


### PR DESCRIPTION
Nach den drei behobenen Kontrastfehlern waren die Unterlagen in `docs/` nachgezogen, die **öffentliche** Erklärung aber nicht — ausgerechnet die, auf die sich ein Dritter beruft. Gefunden hat das der Nutzer.

**Nachgezogen** in beiden Sprachen: Prüfdatum auf den 19. August, der Fund selbst benannt, Prüfdatum im WCAG-EM-Bericht auf 17.–19. August.

**Damit es sich nicht wiederholt:** Der Protokoll-Wächter vergleicht das Prüfdatum an vier Stellen und wird rot, sobald eines abweicht — mit Positivkontrolle, damit ein ins Leere laufendes Muster nicht still grün bleibt.

Rückbauprobe: verstelltes EN-Datum → rot mit Auflistung; zurückgesetzt → 17/17 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)