### PR TITLE
fix: v4.0 Welle 2 — Rechtstexte und Doku (17 Audit-Befunde)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,9 @@ Fixes #(Issue-Nummer)
 - [ ] Frontend-Tests laufen: `npm run test:frontend`
 - [ ] Backend-Lint sauber: `cd functions && npm run lint && npm run format:check`
 - [ ] Frontend-Lint sauber: `npm run lint:frontend && npm run format:frontend:check`
-- [ ] Cache-Buster in `index.html` hochgezaehlt (bei Frontend-Aenderungen)
+- [ ] Cache-Buster NICHT von Hand anfassen — `scripts/deploy.sh` zaehlt ihn beim
+      Hosting-Deploy in allen ausgelieferten Seiten selbst hoch und committet ihn
+      danach als chore-PR (DOC-2026-08-20-51)
 - [ ] Privacy-Architektur eingehalten (kein GPS an Server, keine externen Scripts)
 
 ## Screenshots

--- a/.pruefungen/fakten.txt
+++ b/.pruefungen/fakten.txt
@@ -9,7 +9,10 @@
 # denselben Fakt und melden Widersprueche, die keine sind.
 #
 # Nicht aufgenommen und warum:
-#   Testanzahl — steht bewusst nirgends fest, der CI-Lauf ist der Beleg.
+#   Testanzahl — kanonisch ist docs/VERIFICATION.md, dort stempelt sie
+#   scripts/pruefstand.sh. Andere Dateien verweisen darauf, statt sie zu nennen;
+#   AGENTS.md und docs/SETUP.md trugen bis 2026-08-21 veraltete Werte
+#   (DOC-2026-08-20-10).
 #   "N Tage"   — bezeichnet im Projekt mehrere verschiedene Fristen.
 #   Version    — steht im CHANGELOG naturgemaess vielfach; Historiendateien
 #                werden ohnehin uebersprungen.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,8 @@ Einzelbefehle:
 
 - `cd functions && npm install` — install backend dependencies
 - `npm install` (root) — install frontend test/lint dependencies (Vitest, ESLint, Prettier)
-- `cd functions && npm test` — run Jest backend unit tests (611 tests)
-- `npm run test:frontend` — run Vitest frontend unit tests (193 tests)
+- `cd functions && npm test` — run Jest backend unit tests (count: see `docs/VERIFICATION.md`)
+- `npm run test:frontend` — run Vitest frontend unit tests (count: see `docs/VERIFICATION.md`)
 - `npm run test:e2e` — run Playwright E2E tests (Smoke + axe-A11y-Gate ohne Ausnahmen + Tastatur-Durchlauf; A11y misst mit reducedMotion, sonst Schein-Funde durch Einblend-Animation)
 - `cd functions && npm run lint` — ESLint backend
 - `cd functions && npm run format:check` — Prettier backend

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Firebase Hosting](https://img.shields.io/badge/Firebase-Hosting-FFCA28?logo=firebase&logoColor=black)](https://malzi.me)
 ![Node.js](https://img.shields.io/badge/Node.js-24-339933?logo=node.js&logoColor=white)
 [![CI](https://github.com/malziland/malzime/actions/workflows/ci.yml/badge.svg)](https://github.com/malziland/malzime/actions/workflows/ci.yml)
-[![Lighthouse Performance](https://img.shields.io/badge/Performance-100-brightgreen?logo=lighthouse)](https://github.com/malziland/malzime/actions/workflows/ci.yml)
+[![Lighthouse Performance](https://img.shields.io/badge/Performance-%E2%89%A590-brightgreen?logo=lighthouse)](https://github.com/malziland/malzime/actions/workflows/ci.yml)
 [![Lighthouse Accessibility](https://img.shields.io/badge/Accessibility-100-brightgreen?logo=lighthouse)](https://github.com/malziland/malzime/actions/workflows/ci.yml)
 [![Lighthouse Best Practices](https://img.shields.io/badge/Best_Practices-100-brightgreen?logo=lighthouse)](https://github.com/malziland/malzime/actions/workflows/ci.yml)
 [![Lighthouse SEO](https://img.shields.io/badge/SEO-100-brightgreen?logo=lighthouse)](https://github.com/malziland/malzime/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Workshop-Tool fuer Medienkompetenz und Datenschutz-Sensibilisierung. Zeigt Teilnehmer:innen, was KI-Algorithmen aus einem einzigen Foto ableiten koennten — inklusive Persoenlichkeitsprofil, Werbe-Targeting und Manipulationstrigger.
 
-**Alles erfunden. Nichts davon ist wahr oder bewiesen.**
+**Alles geraten. Nichts davon ist wahr oder bewiesen.**
 
 <p align="center">
   <img src="docs/screenshots/01-startseite.png" alt="malziME Startseite" width="720" />

--- a/README.md
+++ b/README.md
@@ -211,7 +211,9 @@ die **bewusst getroffenen Abwägungen mit Begründung** — steht in
 [docs/SECURITY-MODEL.md](docs/SECURITY-MODEL.md). Die wichtigsten Schichten:
 
 - **Content Security Policy** mit strikter Whitelist (`self`; Bilder zusätzlich von OpenStreetMap-Kacheln, Verbindungen zusätzlich zu Nominatim)
-- **HSTS** mit Preload
+- **HSTS** — Transportverschlüsselung erzwungen, zwei Jahre, inklusive Unterdomains; die
+  `preload`-Angabe wird mitgeliefert, ein Eintrag in der Browser-Liste ist bewusst nicht
+  erfolgt (Begründung: `docs/SECURITY-MODEL.md`)
 - **X-Frame-Options: DENY**
 - **X-Content-Type-Options: nosniff**
 - **Magic-Byte-Validierung**: Server prueft JPEG/PNG/WebP/GIF-Header

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,8 @@ malziME is a **workshop tool for media literacy education**. It is designed for 
 - **No tracking**: No cookies, no analytics, no advertising
 - **GPS never reaches our servers**: Coordinates are read in the browser and used there for the map. Reverse geocoding goes directly from the browser to OpenStreetMap Nominatim — the coordinates leave the browser, but never touch malziME infrastructure
 - **Content Security Policy**: Strict whitelist (self + OpenStreetMap tiles + Nominatim)
-- **HSTS with preload**
+- **HSTS** — enforced for two years including subdomains; the `preload` directive is sent,
+  but the site is deliberately **not** on the browser preload list (see `docs/SECURITY-MODEL.md`)
 - **Rate limiting**: Per-IP request limits
 - **Prompt injection protection**: user data isolated in XML tags (3-call path); the active single-large prompt states explicitly that text visible in the image is content, never an instruction
 - **Input validation**: File type, size, and format checks

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -12,8 +12,19 @@ nach spätestens ~30 s. Das ist das zentrale Betriebssicherheits-Element (siehe
 | Flag | Typ | Soll live | Fail-safe | Owner |
 |---|---|---|---|---|
 | `useSingleLargeCall` | Architektur-Schalter (Kill-Switch-Funktion) | `true` | `false` | Christoph Krieger |
-| `usePromptCache` | Kostenschalter | offen (siehe unten) | `false` | Christoph Krieger |
-| `useSprachumschalter` | Sichtbarkeit eines Bedienelements | `false` (Stand 2026-08-13) | `false` | Christoph Krieger |
+| `usePromptCache` | Kostenschalter | `true` | `false` | Christoph Krieger |
+| `useLiveText` | Anzeige-Schalter (Live-Text waehrend der Analyse) | `true` | `false` | Christoph Krieger |
+| `useBeastAdsCall` | Zweiter, kleiner Mistral-Aufruf fuer die Beast-Werbung | `true` | `true` | Christoph Krieger |
+| `useSprachumschalter` | Sichtbarkeit eines Bedienelements | `true` (seit v3.3.0 live) | `false` | Christoph Krieger |
+
+> **Stand 2026-08-21 (DOC-2026-08-20-09).** Die Spalte „Soll live" trug zuvor fuer
+> `useSprachumschalter` noch `false` — den Stand von der Vorbereitung am 13.08., obwohl
+> derselbe Text weiter unten den Umschalter seit v3.3.0 als live beschreibt. `useLiveText`
+> und `useBeastAdsCall` fehlten ganz, obwohl `feature-flags.js` sie liest. Ein Register,
+> das den Live-Zustand falsch angibt, ist als Wiederherstellungs-Quelle unbrauchbar: Wer
+> nach einem Zwischenfall „auf Soll" zuruecksetzt, schaltet damit Funktionen ab.
+> Der Live-Zustand ist an der Quelle gemessen (Firestore `featureFlags/current`), nicht
+> aus dem Code geschlossen.
 
 ### `useQueue` — ENTFERNT mit v2.10
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -27,8 +27,10 @@ läuft der Ablauf vollständig durch (dokumentiert in ADR-0001).
    `cd functions && npm test && npm run lint && npm run format:check` sowie
    `npm run test:frontend && npm run lint:frontend && npm run format:frontend:check`
    (E2E: `npm run test:e2e`).
-2. Änderung per Branch + PR auf `main`; die CI-Pflicht-Checks (test-backend,
-   test-frontend, test-e2e, secret-scan) sind Merge-Voraussetzung.
+2. Änderung per Branch + PR auf `main`; die **sechs** CI-Pflicht-Checks
+   (test-backend, test-frontend, test-e2e, secret-scan, playwright-version,
+   pruefungen) sind Merge-Voraussetzung. Kanonisch ist die Branch Protection,
+   siehe Abschnitt weiter unten (DOC-2026-08-20-13: hier standen vier).
 3. CHANGELOG: Sobald deployt wird, ist das ein Release — den
    `[Unveröffentlicht]`-Abschnitt im selben Schritt auf neue Versionsnummer und
    Datum stempeln.
@@ -38,7 +40,10 @@ läuft der Ablauf vollständig durch (dokumentiert in ADR-0001).
    in `deploy.sh` hinterlegte Untergrenze (Notschalter `SKIP_CLI_CHECK=1`; eine
    nicht ermittelbare Version bricht ab, statt durchzuwinken —
    `OPS-2026-08-12-25`) und zählt dann den Cache-Buster in allen
-   fünf HTML-Seiten automatisch hoch (Konvention `?v=YYYYMMDDNN`: gleicher Tag
+   ausgelieferten Seiten automatisch hoch — welche das sind, fragt das Skript
+   beim Dateisystem ab, es führt keine eigene Liste (DOC-2026-08-20-13: hier
+   stand „fünf HTML-Seiten", real sind es seit den englischen Rechtsseiten zehn
+   plus `js/demo.js`) (Konvention `?v=YYYYMMDDNN`: gleicher Tag
    → laufende Nummer +1, sonst neuer Tag mit `01`; nur bei Hosting-Deploys
    relevant, reine Functions-Deploys brauchen keinen).
 5. `release.yml` legt automatisch einen GitHub-Release an, sobald die neue
@@ -411,9 +416,16 @@ existierte bis 2026-08-10 nicht — siehe den Vorfall weiter unten.
 | A | `@` | `199.36.158.100` | Firebase Hosting (malzi.me). **Ohne diesen Eintrag ist die Seite offline.** |
 | MX | `@` | `mx00.ionos.de`, `mx01.ionos.de` (Prio 10) | E-Mail-Empfang |
 | TXT | `@` | `v=spf1 include:_spf-eu.ionos.com ~all` | SPF, sonst landen ausgehende Mails im Spam |
+| CNAME | `www` | `malzime.web.app.` | leitet www.malzi.me auf malzi.me um (301) |
 
 Weitere Einträge gibt es nicht und soll es nicht geben. Insbesondere **kein
 `api`** mehr (siehe unten).
+
+> **DOC-2026-08-20-18:** Der `www`-Eintrag fehlte dieser Tabelle, obwohl sie sich
+> ausdrücklich als „einzige schriftliche Quelle" bezeichnet — genau das
+> Wiederherstellungs-Szenario vom 2026-08-10 hätte ihn mit verloren. Gemessen am
+> 2026-08-21: `dig +short www.malzi.me CNAME @ns1091.ui-dns.de` → `malzime.web.app.`,
+> und Firebase führt `www.malzi.me` als eigene Domain (HOST_ACTIVE, CERT_ACTIVE).
 
 Prüfbefehl (fragt IONOS direkt, umgeht alle Zwischenspeicher):
 
@@ -463,15 +475,10 @@ ausschließlich der Wegweiser bei IONOS.
 Der CSP-Eintrag ist seit v2.11.0 draußen, eine echte Analyse auf malzi.me lief
 danach normal durch — damit ist belegt, dass nichts mehr daran hing.
 
-**Rest:** In Cloud Run steht die Zuordnung `api.malzi.me → analyze` noch (der
-Dienst `analyze` existiert seit v2.10 nicht mehr). Ohne DNS zeigt nichts mehr
-darauf; das ist eine Karteileiche, kein Risiko. Aufräumen:
-
-```bash
-curl -X DELETE -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-     -H "x-goog-user-project: malzime" \
-  "https://europe-west1-run.googleapis.com/apis/domains.cloudrun.com/v1/namespaces/malzime/domainmappings/api.malzi.me"
-```
+**Rest: erledigt.** Die Cloud-Run-Zuordnung `api.malzi.me → analyze` ist inzwischen
+geräumt — gemessen am 2026-08-21 über die Domain-Mappings-Schnittstelle: keine
+Einträge mehr (DOC-2026-08-20-35; hier stand sie noch als vorhanden, samt
+Aufräum-Befehl).
 
 **Reihenfolge war und bleibt wichtig: erst DNS, dann die Zuordnung.**
 Andersherum entstünde ein Zeitfenster, in dem der DNS-Eintrag auf Googles

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -164,3 +164,30 @@ Schwelle gekommen.
 
 **Bedingung für Neubewertung.** Sobald das Projekt einen zweiten Betreuer hat (Bus-Faktor
 > 1) oder ein externer Verfügbarkeitsdienst ohnehin läuft, gehört der Alarmweg dorthin.
+
+## Restrisiko: Kein Eintrag in der HSTS-Preload-Liste (seit 2026-08-21)
+
+**Entscheidung.** Die Seite sendet den HSTS-Kopf inklusive `preload`-Angabe, ist aber
+bewusst **nicht** in die fest in Browser eingebaute Preload-Liste eingetragen
+(`OPS-2026-08-20-36`; README und SECURITY.md behaupteten das zuvor).
+
+**Begründung.** Der Gewinn ist der allererste Aufruf einer von Hand getippten Adresse ohne
+`https://` in einem Browser, der die Domain noch nie gesehen hat — danach greift der
+gesendete Kopf ohnehin. Der Preis ist eine praktisch unumkehrbare Bindung: Ein Eintrag wird
+mit der Browser-Software ausgeliefert und wirkt über alte Versionen jahrelang nach, für die
+gesamte Domain samt aller künftigen Unterdomains. An `malzi.me` hängt auch die E-Mail des
+Betriebs; eine Unterdomain, deren Zertifikat einmal klemmt, wäre ohne Ausweg blockiert
+(keine Warnseite zum Durchklicken, sondern harte Verweigerung).
+
+**Betrachtete Alternative.** Eintragen. Verworfen für ein Ein-Personen-Projekt mit einer
+Domain: dauerhafte Bindung gegen einen Gewinn, den das Publikum dieses Werkzeugs
+(Workshop-Teilnehmende mit geteiltem Link, QR-Code oder Lesezeichen) praktisch nie erlebt.
+
+**Marktvergleich, gemessen 2026-08-21** über `hstspreload.org/api/v2/status`:
+`github.com` = preloaded; `orf.at`, `saferinternet.at`, `bmbwf.gv.at`, `wien.gv.at` = nicht
+gelistet. Bei großen Plattformen üblich, bei österreichischen Medien-, Bildungs- und
+Verwaltungsseiten die Ausnahme.
+
+**Bedingung für Neubewertung.** Sobald feststeht, dass keine Unterdomain ohne sichere
+Verbindung mehr geplant ist — etwa nach dem Presse-Zug und der 4.0-Auslieferung. Der
+Eintrag bleibt jederzeit möglich; der Kopf ist bereits preload-fähig.

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -32,7 +32,9 @@ cd malzime
 malziME nutzt seit v1.6.0 ausschliesslich Mistral AI fuer KI-Analysen.
 
 1. Account erstellen auf [console.mistral.ai](https://console.mistral.ai/)
-2. Stripe-Karte hinterlegen, **Scale Tier** aktivieren — Free Tier reicht nicht fuer Image-Calls
+2. Zahlungsmittel hinterlegen und einen kostenpflichtigen Tarif aktivieren — der kostenlose
+   Tarif reicht fuer Bild-Aufrufe nicht. Die Tarifnamen bei Mistral aendern sich; massgeblich
+   ist das Dashboard, nicht diese Anleitung (DOC-2026-08-20-52).
 3. API-Key generieren unter https://console.mistral.ai/api-keys/
 4. Key sofort sichern (wird nur einmal angezeigt) — wird in Schritt 5g als Firebase Secret hinterlegt
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -124,9 +124,9 @@ cd functions && npm test
 npm run test:frontend
 ```
 
-**Backend (611 Tests):** HTTP-Handler, Admin-Endpunkte, Stats-Handler, HMAC-Auth, Nonce-Flow, Tier-Erkennung, Config, Counter, Middleware (Rate Limiting), Privacy-Risiken, Upload-Parsing, Magic-Byte-Validierung, XML-Escaping, ntfy-Benachrichtigungen, i18n-Guardian, Mistral-Integration (Mocked-Fetch), JSON-Repair (4-Stufen), Throttle-Semaphore, Queue (Job-Lebenszyklus, Reaper, Feature-Flag, Cloud-Tasks-Anbindung, Abhol-Ticket).
-**Frontend (193 Tests):** DOM-Helpers, State, Scan-Animation, Limit-Banner, Maintenance-Modal, Geocoding, Render-Pipeline, API-Integration, Warteschlange samt Wiederaufnahme, Stats-Seite, i18n-Modul, i18n-Guardian.
-**E2E (5 Tests):** Playwright Smoke-, A11y- und Tastatur-Tests — Demo-Flow, fehlerfreies Laden, axe-A11y-Gate (Startseite + Profil-Ansicht), Tastatur-Durchlauf.
+**Backend** (Anzahl: siehe [VERIFICATION.md](VERIFICATION.md)): HTTP-Handler, Admin-Endpunkte, Stats-Handler, HMAC-Auth, Nonce-Flow, Tier-Erkennung, Config, Counter, Middleware (Rate Limiting), Privacy-Risiken, Upload-Parsing, Magic-Byte-Validierung, XML-Escaping, ntfy-Benachrichtigungen, i18n-Guardian, Mistral-Integration (Mocked-Fetch), JSON-Repair (4-Stufen), Throttle-Semaphore, Queue (Job-Lebenszyklus, Reaper, Feature-Flag, Cloud-Tasks-Anbindung, Abhol-Ticket).
+**Frontend** (Anzahl: siehe [VERIFICATION.md](VERIFICATION.md)): DOM-Helpers, State, Scan-Animation, Limit-Banner, Maintenance-Modal, Geocoding, Render-Pipeline, API-Integration, Warteschlange samt Wiederaufnahme, Stats-Seite, i18n-Modul, i18n-Guardian.
+**E2E** (Anzahl: siehe [VERIFICATION.md](VERIFICATION.md)): Playwright Smoke-, A11y- und Tastatur-Tests — Demo-Flow, fehlerfreies Laden, axe-A11y-Gate (Startseite + Profil-Ansicht), Tastatur-Durchlauf.
 
 ## 7. Linting + Formatting
 

--- a/docs/barrierefreiheit/IPHONE-DURCHGANG.md
+++ b/docs/barrierefreiheit/IPHONE-DURCHGANG.md
@@ -120,7 +120,7 @@ Streiche weiter nach rechts durch das fertige Profil.
 | 20  | „Dein Profil, `Bereich`"                                                   | ☐      | ☐            |
 | 21  | zu jeder Karte: erst die Bezeichnung („Alter & Geschlecht"), dann der Wert | ☐      | ☐            |
 | 22  | bei den Balken: „Konfidenz" mit einer Zahl oder einem Prozentwert          | ☐      | ☐            |
-| 23  | irgendwo wird vorgelesen, dass die Angaben **erfunden** sind               | ☐      | ☐            |
+| 23  | irgendwo wird vorgelesen, dass die Angaben **geraten** sind                | ☐      | ☐            |
 
 **Nummer 23 ist kein Formalismus.** Ein Profil, das vorgelesen wird, ohne dass die
 Einordnung mitkommt, ist genau das, wovor malziME warnt.

--- a/docs/barrierefreiheit/PRUEFPROTOKOLL.md
+++ b/docs/barrierefreiheit/PRUEFPROTOKOLL.md
@@ -8,7 +8,8 @@
 
 **Prüfgegenstand:** https://malzi.me
 **Angestrebte Stufe:** WCAG 2.2, Konformitätsstufe AA
-**Prüfdatum:** 17. August 2026
+**Prüfdatum:** 17. August 2026 (Erstprüfung, fünf Seiten) · 19. August 2026
+(Ausweitung auf zehn Seiten und Neumessung; seither gilt dieser Umfang)
 **Prüfer:** Eigenprüfung (malziland - learning | training | consulting e.U.)
 
 Der geprüfte Stand steht im Bericht — bewusst nur dort, damit die Commit-Nummer eine
@@ -33,9 +34,17 @@ Handprüfung nötig ist, steht das als offener Punkt — nicht als Häkchen.
 
 ## 2 Prüfumfang
 
-**Geprüfte Seiten:** Startseite (`/`), Zahlen (`/stats`), Datenschutz
-(`/datenschutz`), Impressum (`/impressum`), Nutzungsbedingungen
-(`/nutzungsbedingungen`).
+**Geprüfte Seiten (Stand 2026-08-21, zehn):** Startseite (`/`), Zahlen (`/stats`),
+Datenschutz (`/datenschutz`), Impressum (`/impressum`), Nutzungsbedingungen
+(`/nutzungsbedingungen`), Barrierefreiheit (`/barrierefreiheit`) sowie die vier
+englischen Fassungen (`/en/privacy`, `/en/legal-notice`, `/en/terms`,
+`/en/accessibility`).
+
+> **DOC-2026-08-20-31:** Hier standen fünf Seiten — der Umfang der Erstprüfung vom
+> 17.08. —, während weiter unten im selben Dokument bereits von „allen zehn Seiten"
+> die Rede war. Ein extern angebotener Anhang mit zwei Prüfumfängen ist nicht
+> zitierfähig. Der Umfang ist jetzt einheitlich der heutige; die Erstprüfung vom
+> 17.08. ist im Verlauf des Dokuments als solche benannt.
 
 **Geprüfte Zustände:** Startseite leer, Warteschlange mit Position und Restzeit,
 Live-Text während die KI schreibt, fertiges Profil (seriöser Modus, Beast-Modus,

--- a/docs/barrierefreiheit/VOICEOVER-CHECKLISTE.md
+++ b/docs/barrierefreiheit/VOICEOVER-CHECKLISTE.md
@@ -105,7 +105,7 @@ Gehe mit **Ctrl + ⌥ + →** durch das fertige Profil.
 
 - [ ] Wird zu jeder Karte die **Überschrift und der Inhalt** vorgelesen?
 - [ ] Werden die Konfidenz-Punkte als **Zahl oder Wort** angesagt — oder gar nicht?
-- [ ] Ist verständlich, dass alles **erfunden** ist? Wird der Hinweis vorgelesen?
+- [ ] Ist verständlich, dass alles **geraten** ist? Wird der Hinweis vorgelesen?
 
 Der letzte Punkt ist kein Formalismus: Ein Profil, das vorgelesen wird, ohne dass die
 Einordnung mitkommt, ist genau das, was malziME kritisiert.

--- a/functions/src/__tests__/doku-drift.test.js
+++ b/functions/src/__tests__/doku-drift.test.js
@@ -27,9 +27,26 @@ function lies(datei) {
 }
 
 describe("Doku-Drift-Wächter", () => {
-  test("README behauptet keine festen Testzahlen", () => {
-    const treffer = lies("README.md").match(/\b\d+\s+Tests?\b/g) || [];
+  /* DOC-2026-08-20-10: Der Waechter las nur die README. AGENTS.md und
+     docs/SETUP.md trugen deshalb ueber die gesamte v3-Reihe die Zahlen 611/193/5,
+     waehrend die kanonische Quelle (docs/VERIFICATION.md, gestempelt von
+     scripts/pruefstand.sh) laengst bei ganz anderen Werten stand. Gerade AGENTS.md
+     liest die naechste Sitzung zuerst. Gesucht wird jetzt ueber die FLAECHE der
+     Dokumente, in denen eine Testzahl ueberhaupt Sinn ergaebe. */
+  const ZAHLENFREIE_DOKU = ["README.md", "AGENTS.md", "docs/SETUP.md", "CONTRIBUTING.md"];
+
+  test.each(ZAHLENFREIE_DOKU)("%s behauptet keine festen Testzahlen", (datei) => {
+    const treffer = lies(datei).match(/\b\d+\s+Tests?\b/gi) || [];
+    /* Kanonisch ist docs/VERIFICATION.md — dort stempelt pruefstand.sh die Zahlen
+       samt Commit und Datum. Ueberall sonst wird darauf verwiesen. */
     expect(treffer).toEqual([]);
+  });
+
+  test("die kanonische Quelle nennt die Zahlen tatsaechlich (Positivkontrolle)", () => {
+    /* Ohne diese Kontrolle waere der Waechter gruen, wenn die Zahlen NIRGENDS
+       mehr stuenden — auch dort nicht, wo sie hingehoeren. */
+    const treffer = lies("docs/VERIFICATION.md").match(/\b\d+\/\d+\b/g) || [];
+    expect(treffer.length).toBeGreaterThanOrEqual(3);
   });
 
   /* DOC-2026-08-13-FE-09: Die Upload-Obergrenze steht an fünf Stellen ohne

--- a/public/app.js
+++ b/public/app.js
@@ -86,9 +86,11 @@ state.statsReady = fetch("/api/stats", { signal: statsAbort.signal })
   .catch(() => {})
   .finally(() => clearTimeout(statsTimer));
 
-/* v3.3: Sprachumschalter anmelden — bedingungslos, damit die Konsolen-Tuer
-   `malziME.sprachumschalter()` auch dann offensteht, wenn /api/stats nicht
-   antwortet. Gebaut wird erst auf Zuruf (Merkmals-Schloss oder Konsole). */
+/* v3.3: Sprachumschalter anmelden — bedingungslos, damit er auch dann entsteht,
+   wenn /api/stats nicht antwortet. Die Erprobungs-Tueren (Konsole,
+   Merkmals-Schloss) sind seit v3.3.1 ersatzlos gestrichen; sichtbar ist der
+   Umschalter ueber das Firestore-Flag `useSprachumschalter`
+   (DOC-2026-08-20-46). */
 initSprachumschalter({
   analysiere: handleNewFile,
   /* Nach einem Neuladen liegt zwar ein Ergebnis vor, die Bilddatei aber nicht

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -56,7 +56,7 @@
       </div>
       <span class="page-eyebrow">Rechtliches</span>
       <h1>Datenschutz</h1>
-      <p class="legal-subtitle">Verst&auml;ndlich erkl&auml;rt &middot; Stand: 13. August 2026</p>
+      <p class="legal-subtitle">Verst&auml;ndlich erkl&auml;rt &middot; Stand: 21. August 2026</p>
       <div class="page-rule"></div>
       <div class="disclaimer disclaimer--flush">
         <p>
@@ -116,12 +116,12 @@
         <ol class="legal-list">
           <li>
             <strong>Dein Browser macht den ersten Schritt.</strong> Noch bevor irgendetwas an einen Server geht,
-            verkleinert dein Browser das Foto auf max.&nbsp;1280&nbsp;Pixel und komprimiert es als JPEG. Der Dateiname?
-            Wird nicht &uuml;bermittelt. <abbr title="Global Positioning System">GPS</abbr>-Koordinaten und
-            Aufnahmedatum? Erreichen nie unsere Server &ndash; dein Browser liest sie aus, und mit dem neu komprimierten
-            Foto werden sie gar nicht erst mitgeschickt. Falls GPS vorhanden ist, fragt dein Browser direkt bei
-            OpenStreetMap nach der Adresse und Karte &ndash; ohne Umweg &uuml;ber uns. Unser Server bekommt davon nichts
-            mit.
+            verkleinert dein Browser das Foto auf max.&nbsp;1280&nbsp;Pixel und komprimiert es &ndash; in aller Regel
+            als JPEG, auf manchen Ger&auml;ten als PNG. Der Dateiname? Wird nicht &uuml;bermittelt.
+            <abbr title="Global Positioning System">GPS</abbr>-Koordinaten und Aufnahmedatum? Erreichen nie unsere
+            Server &ndash; dein Browser liest sie aus, und mit dem neu komprimierten Foto werden sie gar nicht erst
+            mitgeschickt. Falls GPS vorhanden ist, fragt dein Browser direkt bei OpenStreetMap nach der Adresse und
+            Karte &ndash; ohne Umweg &uuml;ber uns. Unser Server bekommt davon nichts mit.
           </li>
           <li>
             <strong>An unseren Server geht wenig.</strong> Nur das komprimierte Bild und zwei Kamera-Infos: Hersteller
@@ -183,12 +183,13 @@
               verkn&uuml;pft.
             </li>
             <li>
-              <strong>Kein Originalfoto</strong> &ndash; der Server bekommt nur eine verkleinerte JPEG-Version
-              (max.&nbsp;1280&nbsp;px). Dein hochaufl&ouml;sendes Original bleibt bei dir.
+              <strong>Kein Originalfoto</strong> &ndash; der Server bekommt nur eine verkleinerte, neu berechnete
+              Fassung (max.&nbsp;1280&nbsp;px). Dein hochaufl&ouml;sendes Original bleibt bei dir.
             </li>
             <li>
               <strong>Kein Dateiname</strong> &ndash; ob dein Foto &bdquo;selfie_am_strand.jpg&ldquo; hei&szlig;t,
-              erfahren wir nicht. Es wird immer als &bdquo;upload.jpg&ldquo; geschickt.
+              erfahren wir nicht. Mitgeschickt wird ein neu vergebener Name ohne Bezug zu deiner Datei
+              (&bdquo;upload.jpg&ldquo;, je nach Format auch &bdquo;upload.png&ldquo;).
             </li>
             <li>
               <strong>Keine GPS-Daten auf dem Server</strong> &ndash; GPS-Koordinaten werden im Browser ausgelesen und

--- a/public/en/privacy.html
+++ b/public/en/privacy.html
@@ -472,7 +472,7 @@ sh scripts/pruefe-live.sh</code></pre>
       <section class="legal-section">
         <h2>Workshops</h2>
         <p>
-          The AI profiles are <strong>invented</strong>. Algorithms assert &ndash; they prove nothing. This is not
+          The AI profiles are <strong>guesses</strong>. Algorithms assert &ndash; they prove nothing. This is not
           automated decision-making within the meaning of Art.&nbsp;22 GDPR.
         </p>
       </section>

--- a/public/en/privacy.html
+++ b/public/en/privacy.html
@@ -62,7 +62,7 @@
       <span class="page-eyebrow">Legal</span>
       <h1>Privacy</h1>
       <p class="legal-subtitle">
-        Explained plainly &middot; English version: 19 August 2026 &middot; German original: 13 August 2026
+        Explained plainly &middot; English version: 21 August 2026 &middot; German original: 21 August 2026
       </p>
       <div class="page-rule"></div>
 
@@ -125,7 +125,8 @@
         <ol class="legal-list">
           <li>
             <strong>Your browser takes the first step.</strong> Before anything reaches a server, your browser scales
-            the photo down to a maximum of 1280&nbsp;pixels and compresses it as a JPEG. The file name? Not transmitted.
+            the photo down to a maximum of 1280&nbsp;pixels and compresses it &ndash; normally as a JPEG, on some
+            devices as a PNG. The file name? Not transmitted.
             <abbr title="Global Positioning System">GPS</abbr> coordinates and the capture date? They never reach our
             servers &ndash; your browser reads them, and they are not included with the newly compressed photo. If GPS
             data is present, your browser asks OpenStreetMap directly for the address and the map &ndash; without any
@@ -189,12 +190,13 @@
               (never-collected ones after roughly 2&nbsp;hours at the latest). It is not linked to any person.
             </li>
             <li>
-              <strong>No original photo</strong> &ndash; the server only receives a scaled-down JPEG version (max.
-              1280&nbsp;px). Your high-resolution original stays with you.
+              <strong>No original photo</strong> &ndash; the server only receives a scaled-down, re-encoded version
+              (max. 1280&nbsp;px). Your high-resolution original stays with you.
             </li>
             <li>
               <strong>No file name</strong> &ndash; whether your photo is called &bdquo;selfie_at_the_beach.jpg&ldquo;
-              is something we never learn. It is always sent as &bdquo;upload.jpg&ldquo;.
+              is something we never learn. What travels along is a newly assigned name unrelated to your file
+              (&bdquo;upload.jpg&ldquo;, or &bdquo;upload.png&ldquo; depending on the format).
             </li>
             <li>
               <strong>No GPS data on the server</strong> &ndash; GPS coordinates are read in the browser and go only to

--- a/public/en/terms.html
+++ b/public/en/terms.html
@@ -56,7 +56,7 @@
       <span class="page-eyebrow">Legal</span>
       <h1>Terms of Use</h1>
       <p class="legal-subtitle">
-        malziME by malziland &middot; English version: 19 August 2026 &middot; German original: 17 July 2026
+        malziME by malziland &middot; English version: 21 August 2026 &middot; German original: 21 August 2026
       </p>
       <div class="page-rule"></div>
 
@@ -283,10 +283,13 @@
           >) apply without restriction. The place of jurisdiction is, to the extent legally permissible, Linz, Austria.
         </p>
         <p>
-          For the out-of-court settlement of consumer disputes the EU provides an online platform:
-          <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener" tabindex="0"
-            >https://ec.europa.eu/consumers/odr</a
-          >
+          The EU's online dispute resolution platform was discontinued on 20&nbsp;July 2025; a link to it would lead
+          nowhere. For the out-of-court settlement of consumer disputes, the recognised Austrian conciliation bodies
+          remain responsible, such as the
+          <a href="https://www.verbraucherschlichtung.at" target="_blank" rel="noopener" tabindex="0"
+            >Schlichtung f&uuml;r Verbrauchergesch&auml;fte</a
+          >. We are neither obliged nor willing to take part in dispute resolution proceedings before a consumer
+          arbitration board.
         </p>
         <!-- Sprachklausel. Anders als die drei Auskunftsseiten sind die
                Nutzungsbedingungen eine VEREINBARUNG. Fuer Vertraege gilt: Die

--- a/public/fonts/poppins/VERSION
+++ b/public/fonts/poppins/VERSION
@@ -1,0 +1,15 @@
+Poppins (v21, latin subset)
+Source: https://fonts.google.com/specimen/Poppins
+License: SIL Open Font License 1.1 (siehe OFL.txt in diesem Ordner)
+Designer: Indian Type Foundry, Jonny Pinhorn
+
+Abweichung vom Original: nur die WOFF2-Dateien des latin-Subsets werden
+mitgeliefert: Schnitte 300/400/500/700, je latin und latin-ext. Die Schriftdateien
+selbst sind unveraendert; nichts wurde umbenannt, neu gerendert oder editiert.
+
+Selbst gehostet, weil die Seite keine externen Skripte oder Schriften laedt —
+ein Google-Fonts-Aufruf wuerde die IP-Adresse der Besucher an einen Dritten
+uebertragen (siehe docs/SECURITY-MODEL.md und die Datenschutzerklaerung).
+
+Nachgetragen am 2026-08-21 (OSS-2026-08-20-41): THIRD-PARTY.md verspricht eine
+VERSION-Datei je Fremd-Ordner; fuer die Schriften fehlte sie als einzige.

--- a/public/img/demo/LICENSE.md
+++ b/public/img/demo/LICENSE.md
@@ -5,6 +5,11 @@ jeweils samt Thumbnail) sind **KI-generiert** (bestätigt,
 2026-07-17). Sie zeigen **keine realen Personen** — Ähnlichkeiten mit lebenden
 oder verstorbenen Personen wären rein zufällig.
 
+<!-- ABGRENZUNG zur Formulierungsregel vom 19.08.2026: Das Wort "fiktiv" ist hier
+     richtig und bleibt. Die Regel verbietet es fuer die KI-PROFILE (die erfindet
+     niemand — eine echte KI raet sie wirklich). Die EXIF-Daten dieser Demo-Bilder
+     dagegen sind tatsaechlich gesetzt: Es gibt keinen echten Aufnahmeort. -->
+
 Die EXIF-Daten der Bilder (Kamera, Aufnahmeort, Datum) sind **bewusst fiktiv**
 gesetzt — sie dienen dem Demo-Zweck von malziME, versteckte Foto-Metadaten
 sichtbar zu machen.

--- a/public/lib/PRUEFSUMMEN.json
+++ b/public/lib/PRUEFSUMMEN.json
@@ -1,6 +1,6 @@
 {
   "_hinweis": "Pruefsummen der selbst gehosteten Fremddateien (AUDIT-BEFUND OSS-2026-08-12-22). Ohne sie faellt eine Aenderung an minifiziertem Fremdcode niemandem auf — ausgerechnet exifr liest die GPS-Daten, deren Nichtweitergabe die Kernzusage ist. Geprueft von scripts/pruefe-fremddateien.mjs, im CI-Job 'pruefungen'.",
-  "_erstellt": "2026-08-12",
+  "_erstellt": "2026-08-21",
   "_herkunft": {
     "public/lib/leaflet": "npm leaflet@1.9.4, dist/ — leaflet.js ohne die sourceMappingURL-Zeile (siehe VERSION); LICENSE woertlich aus dem Leaflet-Repository (2026-08-19)",
     "public/lib/exifr": "npm exifr@7.1.x, dist/lite.esm.mjs — per Pruefsumme auf 7.1.0-7.1.3 eingegrenzt; LICENSE woertlich aus dem exifr-Repository (2026-08-19)",
@@ -27,6 +27,7 @@
     "public/lib/leaflet/images/marker-icon.png": "sha256:574c3a5cca85f4114085b6841596d62f00d7c892c7b03f28cbfa301deb1dc437",
     "public/lib/leaflet/images/marker-shadow.png": "sha256:264f5c640339f042dd729062cfc04c17f8ea0f29882b538e3848ed8f10edb4da",
     "public/lib/leaflet/leaflet.css": "sha256:a7837102824184820dfa198d1ebcd109ff6d0ff9a2672a074b9a1b4d147d04c6",
-    "public/lib/leaflet/leaflet.js": "sha256:dc71f8a6880bc3ca1bd9fa8dc5f1af48c702dc510b0a78240a07c5feed7ce935"
+    "public/lib/leaflet/leaflet.js": "sha256:dc71f8a6880bc3ca1bd9fa8dc5f1af48c702dc510b0a78240a07c5feed7ce935",
+    "public/fonts/poppins/VERSION": "sha256:8799ca17fd5928e88739429f2fc1d7d8c5241e6ff58d46d81b4996de1d5609cc"
   }
 }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # malziME
 
-> malziME (https://malzi.me) ist ein kostenloses Lern-Tool für Medienkompetenz und Datenschutz-Sensibilisierung. Nutzer laden ein Foto hoch und sehen, was KI-Algorithmen aus einem einzigen Bild über sie behaupten könnten: Alter, Einkommen, Interessen, Werbeprofil. Alle generierten Profile sind fiktiv — sie zeigen, was Algorithmen behaupten KÖNNTEN, nichts davon ist wahr oder bewiesen.
+> malziME (https://malzi.me) ist ein kostenloses Lern-Tool für Medienkompetenz und Datenschutz-Sensibilisierung. Nutzer laden ein Foto hoch und sehen, was KI-Algorithmen aus einem einzigen Bild über sie behaupten könnten: Alter, Einkommen, Interessen, Werbeprofil. Die Profile sind geraten: Eine echte KI analysiert das Foto wirklich und leitet daraus Behauptungen ab — sie zeigen, was Algorithmen behaupten KÖNNTEN, nichts davon ist wahr oder bewiesen.
 
 Betreiber: malziland - learning | training | consulting e.U., Inhaber Christoph Krieger, Neuhofen an der Krems, Österreich.
 
@@ -24,4 +24,4 @@ Sprachen: Deutsch (Standard) und Englisch (umschaltbar auf der Seite).
 
 ## Zitierhinweis
 
-Bitte als „malziME — Workshop-Tool für Medienkompetenz von malziland (Christoph Krieger)" referenzieren und auf https://malzi.me verlinken. Wichtig bei jeder Wiedergabe: Die KI-Profile sind bewusst fiktiv und dienen der Aufklärung über algorithmisches Profiling.
+Bitte als „malziME — Workshop-Tool für Medienkompetenz von malziland (Christoph Krieger)" referenzieren und auf https://malzi.me verlinken. Wichtig bei jeder Wiedergabe: Die KI-Profile sind geraten — eine echte KI analysiert das Foto wirklich; nichts davon ist wahr oder bewiesen. Sie dienen der Aufklärung über algorithmisches Profiling.

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -184,7 +184,7 @@
   "stats.infoCountTitle": "Was wird gezählt?",
   "stats.infoCountText": "Nur Zählwerte je Zeitraum — keine Einzelvorgänge. Keine Bilder, keine IP-Adressen, keine Nutzerprofile.",
   "stats.infoLimitTitle": "Warum ein Limit?",
-  "stats.infoLimitText": "Jede Analyse kostet Geld (KI + Bilderkennung). Das Stundenlimit schützt das Projekt vor unerwarteten Kosten.",
+  "stats.infoLimitText": "Jede KI-Analyse kostet Geld. Das Stundenlimit schützt das Projekt vor unerwarteten Kosten.",
   "stats.infoFundingTitle": "Eigenfinanziert — für alle kostenlos",
   "stats.infoFundingText": "malziME ist werbefrei, ohne Tracking und ohne Paywall. Mit einer Spende hilfst du, die Limits zu erhöhen und das Projekt am Laufen zu halten.",
   "stats.infoFundingButton": "Projekt unterstützen",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -184,7 +184,7 @@
   "stats.infoCountTitle": "What is being counted?",
   "stats.infoCountText": "Only counts per time period — no individual events. No images, no IP addresses, no user profiles.",
   "stats.infoLimitTitle": "Why a limit?",
-  "stats.infoLimitText": "Each analysis costs money (AI + image recognition). The hourly limit protects the project from unexpected costs.",
+  "stats.infoLimitText": "Each AI analysis costs money. The hourly limit protects the project from unexpected costs.",
   "stats.infoFundingTitle": "Self-funded — free for everyone",
   "stats.infoFundingText": "malziME is ad-free, without tracking and without paywall. With a donation you help increase the limits and keep the project running.",
   "stats.infoFundingButton": "Support the project",

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -302,6 +302,20 @@
       </section>
       <!-- 12. Kontakt -->
       <section class="legal-section">
+        <!-- BIZ-2026-08-20-43: Die Sprachklausel stand NUR in der englischen
+             Fassung. Ausgerechnet die Aussage, welche Fassung rechtlich gilt,
+             fehlte damit in genau der Fassung, die gilt — wer nur die deutsche
+             las, erfuhr nichts von der Rangfolge. -->
+        <p>
+          <strong>Sprachfassungen.</strong> Diese Nutzungsbedingungen gibt es auf Deutsch und auf Englisch. Rechtlich
+          verbindlich ist die deutsche Fassung. Weichen die Fassungen inhaltlich voneinander ab, gilt der deutsche Text.
+          Namen &ouml;sterreichischer Einrichtungen, Gerichte und Register stehen im Original &ndash; ein
+          &uuml;bersetzter Eigenname l&auml;sst sich nirgends nachschlagen. Die englische Fassung:
+          <a href="/en/terms" tabindex="0">malzi.me/en/terms</a>.
+        </p>
+      </section>
+
+      <section class="legal-section">
         <h2><span class="sec-num">12</span> Kontakt</h2>
         <p>Bei Fragen zu diesen Nutzungsbedingungen:</p>
         <ul class="legal-list">

--- a/public/nutzungsbedingungen.html
+++ b/public/nutzungsbedingungen.html
@@ -56,7 +56,7 @@
       </div>
       <span class="page-eyebrow">Rechtliches</span>
       <h1>Nutzungsbedingungen</h1>
-      <p class="legal-subtitle">malziME by malziland &middot; Stand: 17. Juli 2026</p>
+      <p class="legal-subtitle">malziME by malziland &middot; Stand: 21. August 2026</p>
       <div class="page-rule"></div>
       <!-- 1. Geltungsbereich -->
       <section class="legal-section">
@@ -291,11 +291,13 @@
           gesetzlich zul&auml;ssig, Linz, &Ouml;sterreich.
         </p>
         <p>
-          F&uuml;r die au&szlig;ergerichtliche Beilegung von Verbraucherstreitigkeiten stellt die EU eine
-          Online-Plattform bereit:
-          <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener" tabindex="0"
-            >https://ec.europa.eu/consumers/odr</a
-          >
+          Die Online-Streitbeilegungsplattform der EU wurde am 20.&nbsp;Juli 2025 eingestellt; ein Verweis darauf
+          w&uuml;rde ins Leere f&uuml;hren. F&uuml;r die au&szlig;ergerichtliche Beilegung von Verbraucherstreitigkeiten
+          sind in &Ouml;sterreich weiterhin die anerkannten Schlichtungsstellen zust&auml;ndig, etwa die
+          <a href="https://www.verbraucherschlichtung.at" target="_blank" rel="noopener" tabindex="0"
+            >Schlichtung f&uuml;r Verbrauchergesch&auml;fte</a
+          >. Wir sind weder verpflichtet noch bereit, an einem Streitbeilegungsverfahren vor einer
+          Verbraucherschlichtungsstelle teilzunehmen.
         </p>
       </section>
       <!-- 12. Kontakt -->

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,37 +2,61 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://malzi.me/</loc>
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://malzi.me/stats</loc>
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://malzi.me/datenschutz</loc>
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://malzi.me/impressum</loc>
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://malzi.me/nutzungsbedingungen</loc>
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://malzi.me/barrierefreiheit</loc>
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-08-21</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://malzi.me/en/privacy</loc>
+    <lastmod>2026-08-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://malzi.me/en/legal-notice</loc>
+    <lastmod>2026-08-21</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://malzi.me/en/terms</loc>
+    <lastmod>2026-08-21</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://malzi.me/en/accessibility</loc>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/public/stats.html
+++ b/public/stats.html
@@ -137,8 +137,8 @@
           </svg>
           <h2 class="stats-info__title" data-i18n="stats.infoLimitTitle">Warum ein Limit?</h2>
           <p class="stats-info__text" data-i18n="stats.infoLimitText">
-            Jede Analyse kostet Geld (<abbr title="K&uuml;nstliche Intelligenz">KI</abbr>&nbsp;+&nbsp;Bilderkennung).
-            Das Stundenlimit sch&uuml;tzt das Projekt vor unerwarteten Kosten.
+            Jede <abbr title="K&uuml;nstliche Intelligenz">KI</abbr>-Analyse kostet Geld. Das Stundenlimit sch&uuml;tzt
+            das Projekt vor unerwarteten Kosten.
           </p>
         </div>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -804,7 +804,7 @@ html {
    Zwei Bewegungen in EINEM Takt, damit es als eine gelesen wird und nicht als
    zwei nebeneinander: Die Pille loest sich vom Papier und wirft einen
    Schatten, waehrend die Rille des Schalters von links dunkel volllaeuft.
-   Beide kehren gemeinsam zurueck. Zwei Durchlaeufe, dann ist Ruhe.
+   Beide kehren gemeinsam zurueck. Drei Durchlaeufe (v3.9.1), dann ist Ruhe.
 
    Die Fuellfarbe ist fest verdrahtet, nicht aus einer Farbmarke: Sie zeigt den
    BEAST-MODUS an, nicht das aktuelle Thema der Seite. Der Lockruf laeuft immer

--- a/scripts/pruefe-fremddateien.mjs
+++ b/scripts/pruefe-fremddateien.mjs
@@ -101,6 +101,17 @@ if (!process.env.PRUEFSUMMEN_BASIS) {
 }
 
 if (AKTUALISIEREN) {
+  /* OSS-2026-08-21-01 (Fund bei der Behebung von OSS-2026-08-20-41): `ist` enthaelt
+     nur, was in der Liste STAND — neue Dateien landeten also nie in der Stempelung.
+     Der Schalter, den das Skript selbst als Loesung nennt, half damit ausgerechnet
+     im Fall "NEU, nicht gestempelt" nicht weiter: Man haette ihn beliebig oft
+     aufrufen koennen, der Lauf blieb rot. Jetzt werden die neu gefundenen Dateien
+     mitgestempelt — dieselbe Liste-statt-Flaeche-Luecke wie in TEST-2026-08-13-49,
+     nur eine Ebene weiter. */
+  for (const rel of neu) {
+    const pfad = resolve(REPO, rel);
+    if (existsSync(pfad)) ist[rel] = summe(pfad);
+  }
   liste.dateien = ist;
   liste._erstellt = new Date().toISOString().slice(0, 10);
   writeFileSync(LISTE, JSON.stringify(liste, null, 2) + "\n");


### PR DESCRIPTION
Zweite Welle der Sanierung des TIEF-Audits vom 2026-08-20. **Hosting-Deploy noetig**
(Rechtstexte und oeffentliche Seiten sind betroffen).

## Behobene Befunde (17)

**Rechtstexte (nutzersichtbar):**
- **PRIV-07 (P2)** — Datenschutzerklaerung DE+EN behauptete "immer JPEG / immer upload.jpg";
  seit dem iOS-Fix vom 19.08. kann es PNG sein. Schutzaussage unveraendert, Tatsachenbehauptung korrigiert.
- **BIZ-23 (P3)** — Beide Fassungen verwiesen auf die am 20.07.2025 eingestellte EU-ODR-Plattform.
- **BIZ-43 (P4)** — Die Sprachklausel stand nur in der englischen Fassung.
- **DOC-29 (P3)** — Stand-Daten waren aelter als die letzten inhaltlichen Aenderungen.

**Register und Doku:**
- **DOC-09 (P2)** — FLAGS.md fuehrte zwei aktiv gelesene Flags nicht und gab einen falschen Soll-Zustand an.
- **DOC-10 (P2)** — AGENTS/SETUP nannten Testzahlen aus der Zeit vor v3; der Waechter las nur die README.
- **DOC-08 (P2, bereits in Welle 1)** — Architektur-Diagramm zeigte den entfernten Synchronpfad.
- **DOC-13/18/35 (P3/P4)** — RUNBOOK: vier statt sechs Pflicht-Checks, "fuenf HTML-Seiten",
  geraeumte Karteileiche als vorhanden; DNS-Tabelle ohne den www-Eintrag.
- **DOC-22 (P3)** — Wortregel "geraten" fehlte in EN-Texten, README und in `llms.txt`,
  die Dritte aktiv zur verbannten Formulierung anleitete.
- **DOC-31/39/40/46/50/51/52, OSS-41 (P3/P4)** — Pruefprotokoll, Kostenbegruendung, Badge,
  Code-Kommentare, Sitemap, PR-Vorlage, Anleitung, fehlende VERSION-Datei.

**Entscheidung E3 des Betreibers umgesetzt:** Kein HSTS-Preload-Eintrag, aber offengelegt —
README und SECURITY.md sagen jetzt genau das, `docs/SECURITY-MODEL.md` traegt die Abwaegung
samt Marktvergleich und Bedingung fuer eine Neubewertung (**OPS-36**).

## Neuer Fund bei der Behebung

**OSS-2026-08-21-01 (P2), im Waechter selbst:** `pruefe-fremddateien.mjs` nennt bei einer
neuen Fremddatei `--aktualisieren` als Loesung — der Schalter stempelte aber nur bereits
bekannte Dateien. Der Lauf blieb rot, egal wie oft man ihn aufrief. Behoben und in beide
Richtungen belegt.

## Widerlegter Audit-Befund

**I18N-30 ist FALSCH und wurde zurueckgenommen:** Der englische Upload-Hinweis verlinkt
nicht auf die deutsche Seite — `i18n.js` schreibt interne Rechts-Links zur Laufzeit um.
Am Browser gemessen: `/en/privacy?lang=en`. Der Befund las einen statischen Wert und
schloss daraus auf Verhalten. Begruendung im Auditbericht.

## Beweise

Backend **868/868**, Frontend **468/468**, E2E **275/275**, `vor-dem-push.sh` **15/15**,
i18n-Guardian 14/14, Lizenz-Waechter 11/11, Barrierefreiheits-Protokoll 17/17.
Jeder Fix mit Rueckbauprobe und repo-weitem Nachlauf, Belege in den Commit-Texten.

## Nicht in diesem PR

Die Versionsnummer — alles steht unter `[Unveroeffentlicht]`. **4.0.0 wird erst gesetzt,
wenn der Betreiber freigibt.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)