### PR TITLE
fix: Ueberschrift der Zahlen-Seite springt nicht mehr, wenn die Zahlen fehlen

### DIFF
--- a/e2e/kopfbereich.test.js
+++ b/e2e/kopfbereich.test.js
@@ -115,6 +115,32 @@ test.describe("Kopfbereich", () => {
     expect(werte, `Überschriften auf verschiedenen Höhen: ${JSON.stringify(hoehen)}`).toHaveLength(1);
   });
 
+  test("BUG-2026-08-21-03: die Überschrift bleibt an Ort und Stelle, auch wenn die Zahlen nicht laden", async ({
+    page,
+  }) => {
+    /* Der Fehlerhinweis der Zahlen-Seite stand ZWISCHEN Augenbraue und
+       Überschrift und war nur mit `display: none` versteckt. Sobald er erschien
+       — also genau dann, wenn die Zahlen nicht luden —, schob er die Überschrift
+       um 21 Bildpunkte nach unten: derselbe Sprung, den v3.8.1 schon einmal
+       behoben hat, nur diesmal an einen Fehlerfall gekoppelt. In der Pipeline
+       fiel er auf, weil dort kein Backend antwortet; wer die Seite bei einer
+       Störung öffnet, sah ihn ebenso. */
+    await merkmalStellen(page);
+
+    await page.route("**/api/stats", (r) => r.fulfill({ status: 500, body: "kaputt" }));
+    await page.goto("/stats.html");
+    await page.evaluate(() => document.fonts.ready);
+    await expect(page.locator("#statsError")).toBeVisible();
+    const mitFehler = await page.evaluate(() => Math.round(document.querySelector("h1").getBoundingClientRect().top));
+
+    await page.unroute("**/api/stats");
+    await page.goto("/index.html");
+    await page.evaluate(() => document.fonts.ready);
+    const referenz = await page.evaluate(() => Math.round(document.querySelector("h1").getBoundingClientRect().top));
+
+    expect(mitFehler, `Überschrift springt bei Fehler: ${mitFehler} statt ${referenz}`).toBe(referenz);
+  });
+
   test("der Abstand hält auch OHNE das Umschalter-Skript", async ({ page }) => {
     /* DER FEHLER VOM 2026-08-19. Der Abstand hing an `.seiten-kopfzeile`, die
        auf der Startseite erst js/sprachumschalter.js erzeugt. Lief das Skript

--- a/public/stats.html
+++ b/public/stats.html
@@ -39,17 +39,24 @@
       <a class="wortmarke seiten-wortmarke" href="/" tabindex="0">malzi<span class="wortmarke-me">ME</span></a>
       <span class="page-eyebrow"><span data-i18n="stats.eyebrow">Statistik</span></span>
 
-      <!-- Error (hidden by default) -->
-      <div class="stats-error" id="statsError">
-        <p data-i18n="stats.errorText">Stats konnten nicht geladen werden. Bitte sp&auml;ter nochmal versuchen.</p>
-      </div>
-
       <!-- Hero -->
       <div class="stats-hero">
         <h1 class="stats-hero__title" data-i18n="stats.heroTitle">malziME in Zahlen</h1>
         <p class="stats-hero__sub" data-i18n="stats.heroSub">
           Anonyme Nutzungsstatistik &mdash; keine personenbezogenen Daten, keine Cookies, kein Tracking.
         </p>
+      </div>
+
+      <!-- BUG-2026-08-21-03: Der Fehlerhinweis stand ZWISCHEN Augenbraue und
+           Ueberschrift und war nur mit `display: none` versteckt. Sobald er
+           erschien — also genau dann, wenn die Zahlen nicht luden —, schob er die
+           Ueberschrift um 21 Bildpunkte nach unten: derselbe Sprung, den v3.8.1
+           schon einmal behoben hat, nur diesmal an einen Fehlerfall gekoppelt.
+           Wer die Seite bei einer Stoerung oeffnete, sah den Kopfbereich
+           springen. Jetzt steht der Hinweis UNTER der Ueberschrift, wo er nichts
+           verschiebt. -->
+      <div class="stats-error" id="statsError">
+        <p data-i18n="stats.errorText">Stats konnten nicht geladen werden. Bitte sp&auml;ter nochmal versuchen.</p>
       </div>
 
       <!-- Live Status -->


### PR DESCRIPTION
Der Deploy-Riegel hat diesen Fehler gefangen: test-e2e wurde rot mit `{"/stats.html":136}` gegen 115 auf allen anderen Seiten.

**Ursache:** Der Fehlerhinweis der Zahlen-Seite stand ZWISCHEN Augenbraue und Ueberschrift, nur mit `display: none` versteckt. Sobald er erschien — also genau dann, wenn die Zahlen nicht luden —, schob er die Ueberschrift um 21 Bildpunkte nach unten. Derselbe Sprung wie in v3.8.1, diesmal an einen Fehlerfall gekoppelt.

**Fix:** Der Hinweis steht jetzt UNTER der Ueberschrift.

**Rueckbauprobe:** alte Anordnung wiederhergestellt -> `Ueberschrift springt bei Fehler: 214 statt 115`; mit Fix 17/17 gruen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)