### PR TITLE
release: Version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,7 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
-## [Unveröffentlicht]
-
-> **Was hiervon live ist, Stand 2026-08-21:** Die Rechtstexte und die
-> Doku-Korrekturen sind ausgeliefert (Hosting-Deploy, Cache-Kennung
-> `2026082101`). Die Code-Fixes darunter — Karte, Sprachwahl, Boost,
-> Wochenzähler, Fehlerpfade — sind gebaut und geprüft, aber **noch nicht
-> ausgeliefert**; sie gehen mit dem nächsten Deploy live.
->
-> Alles steht bewusst weiter unter „Unveröffentlicht": Die Sanierung des TIEF-Audits vom 20.08. wird als
-> **Version 4.0.0** ausgeliefert, und die Nummer wird erst vergeben, wenn alle
-> Befunde behoben und ausdrücklich freigegeben sind. Bis dahin darf hier keine
-> Versionsnummer stehen — `release.yml` legte sonst sofort einen GitHub-Release
-> an. Nicht „korrigieren".
+## [4.0.0] — 2026-08-21
 
 Ein Lang-Audit hat das Projekt in der Nacht auf den 21. August durchleuchtet:
 14 Prüfer entlang getrennter Fragen, jeder Verdacht danach von einem eigenen
@@ -43,6 +31,17 @@ Aussagen, die nicht mehr zum Code passten.
   Verkleinern wurde der Zeichenspeicher nicht freigegeben — dieselbe Ursache,
   die im August schon einmal das zweite Bild scheitern ließ, nur in einem
   selteneren Zweig.
+
+- **Die Überschrift der Zahlen-Seite sprang, wenn die Zahlen nicht luden.** Der
+  Fehlerhinweis stand über der Überschrift und schob sie nach unten, sobald er
+  erschien — ausgerechnet bei einer Störung wackelte also der Seitenkopf. Er
+  steht jetzt darunter, wo er nichts verschiebt.
+
+- **Die Tastatur fand nach der Sprachwahl-Rückfrage nicht immer zurück.** Wer
+  die Rückfrage mit der Tastatur schloss, sollte auf dem auslösenden Knopf
+  landen. Auf langsamen Geräten kam die Markierung dort manchmal nicht an und
+  die Bedienung begann wieder von vorn. Sie wird jetzt so lange nachgeführt,
+  bis sie sitzt.
 
 ### Behoben — was in den Rechtstexten stand
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -13,9 +13,9 @@ Einträge mit Status **offen** sind bewusst als offen ausgewiesen.
 
 | Anforderung | Nachweisweg | Letztes Ergebnis |
 |---|---|---|
-| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 857/857 grün — `scripts/pruefstand.sh`, Commit d0e245f, 2026-08-19 |
-| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 461/461 grün — `scripts/pruefstand.sh`, Commit d0e245f, 2026-08-19 |
-| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 261/261 grün — `scripts/pruefstand.sh`, Commit d0e245f, 2026-08-19 |
+| Backend-Unit-Tests | CI-Job `test-backend` (jeder Push/PR); lokal `npm test --prefix functions` | ✅ 879/879 grün — `scripts/pruefstand.sh`, Commit bedb08e, 2026-08-21 |
+| Frontend-Unit-Tests | CI-Job `test-frontend`; lokal `npm run test:frontend` | ✅ 472/472 grün — `scripts/pruefstand.sh`, Commit bedb08e, 2026-08-21 |
+| E2E kritischster Nutzerfluss (Demo-Foto → Queue → Disclaimer → Profil) | CI-Job `test-e2e` (Playwright, Container-Image = Paketversion); lokal `npm run test:e2e` | ✅ 279/279 grün — `scripts/pruefstand.sh`, Commit bedb08e, 2026-08-21 |
 | Lint + Format (Backend & Frontend) | Teil der CI-Jobs `test-backend`/`test-frontend` (ESLint, Prettier `--check`) | ✅ sauber — 2026-08-10 |
 | Secret-Scan (inkl. voller Historie) | CI-Job `secret-scan` (gitleaks v3.0.0, SHA-gepinnt, `fetch-depth: 0`) | ✅ kein Fund — CI-Run 29562535095, 2026-07-17 |
 | Dependency-Audit | CI-Job `test-backend`: `node ../scripts/audit-gate.mjs functions .` (aus `functions/` heraus) — **beide** Abhängigkeitsbäume (Gate, bricht Build; High/Critical blockieren, Ausnahmen nur begründet **und mit Ablaufdatum** in `.github/audit-allowlist.json`) | ✅ **0 Meldungen, Ausnahmeliste leer** — `npm audit` in beiden Projekten 0, auch inklusive Entwicklungswerkzeuge (vorher 27). Stand 2026-07-29 |


### PR DESCRIPTION
Die Sanierung des TIEF-Audits vom 20.08. bekommt ihre Nummer. **52 Befunde, alle behoben**, plus vier Funde aus der Behebung selbst.

Freigabe am 21.08. erteilt, nachdem der Drucktest am iPhone mehrfach fehlerfrei lief.

## Was dieser PR aendert

- `CHANGELOG.md`: `[Unveroeffentlicht]` → `[4.0.0] — 2026-08-21`. Der Kasten mit dem Zwischenstand ist entfallen — er beschrieb, was noch nicht ausgeliefert war, und ist ueberholt.
- Zwei Nachzuegler ergaenzt, die nach dem grossen Abschnitt dazukamen: der springende Seitenkopf der Zahlen-Seite (#198) und die Tastatur-Rueckgabe nach der Sprachwahl-Rueckfrage (#197).
- `docs/VERIFICATION.md` frisch gestempelt.

## Pruefstand vor dem Release

```
Alle Suiten gruen: Backend 879 · Frontend 472 · E2E 279
scripts/pruefstand.sh, Commit bedb08e, 2026-08-21
```

`release.yml` legt Tag und GitHub-Release an, sobald das auf main steht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)