### PR TITLE
fix: Fehlerbilder pruefen, Limit-Bereich fuer alle abschalten, Client-Fehler-Alarm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,14 @@ jobs:
       # bei Andrang erscheint — also ausgerechnet im Workshop.
       - run: python3 scripts/pruefe-i18n-fallbacks.py
 
+      # OPS-2026-08-21-08: Eine Wartezeit ueber dem Zeitlimit des Tests ist
+      # wirkungslos — der Test stirbt vorher. In vier Tests standen solche
+      # Werte, teils mit Kommentaren, die eine frueher behobene Flakiness
+      # beschrieben. Behoben war nichts; am 21.08. hat einer davon die
+      # Auslieferung blockiert. Die Pruefung blendet Kommentare aus, sonst
+      # tarnt ein auskommentiertes test.slow() den Befund.
+      - run: python3 scripts/pruefe-tote-geduld.py
+
       # OSS-2026-08-12-22: Die selbst gehosteten Fremdbibliotheken (exifr,
       # Leaflet, die Schriften) hatten keinen Unveraendertheits-Nachweis. Eine
       # Aenderung an 147 KB minifiziertem Einzeiler faellt in einem Pull-Request

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,15 @@ jobs:
       - run: python3 scripts/pruefungen/checks/stiller-fehlschlag.py .
       - run: python3 scripts/pruefungen/checks/test-blind.py .
 
+      # UX-2026-08-21-06: Jedes uebersetzbare Element traegt einen Text fest im
+      # HTML. Der ist kein Platzhalter — Besucher sehen ihn, solange die
+      # Sprachdatei nicht geladen ist, und dauerhaft, wenn sie gar nicht laedt.
+      # Am 21.08. war der Limit-Hinweis der Startseite dort in einer alten
+      # Fassung stehen geblieben, waehrend die Sprachdatei laengst die
+      # ueberarbeitete trug: vier Absaetze, unbemerkt, weil dieser Hinweis nur
+      # bei Andrang erscheint — also ausgerechnet im Workshop.
+      - run: python3 scripts/pruefe-i18n-fallbacks.py
+
       # OSS-2026-08-12-22: Die selbst gehosteten Fremdbibliotheken (exifr,
       # Leaflet, die Schriften) hatten keinen Unveraendertheits-Nachweis. Eine
       # Aenderung an 147 KB minifiziertem Einzeiler faellt in einem Pull-Request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ Alle relevanten Aenderungen an malziME werden hier dokumentiert.
 
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
+## [Unveröffentlicht]
+
+### Behoben
+
+- **Der Hinweis „Kurze Pause" zeigte eine veraltete Fassung.** Erscheint das
+  Stundenlimit, stand dort noch der alte, härtere Text („Stundenlimit erreicht.
+  Zu viele Analysen in kurzer Zeit") statt der überarbeiteten Fassung, die
+  erklärt, warum es das Limit gibt. Vier Absätze waren betroffen. Sichtbar wurde
+  das immer dann, wenn die Übersetzungsdatei noch nicht geladen war — und
+  dauerhaft, wenn sie gar nicht lädt. Ausgerechnet dieser Hinweis erscheint nur
+  bei Andrang, also im Workshop.
+
+- **Eine neue Prüfung hält beide Fassungen künftig gleich.** Sie vergleicht für
+  jeden übersetzbaren Text auf allen zehn Seiten, was im Seitenquelltext steht,
+  mit dem, was in der Sprachdatei steht. 68 Texte, deutsch wie englisch.
+
 ## [4.0.0] — 2026-08-21
 
 Ein Lang-Audit hat das Projekt in der Nacht auf den 21. August durchleuchtet:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   jeden übersetzbaren Text auf allen zehn Seiten, was im Seitenquelltext steht,
   mit dem, was in der Sprachdatei steht. 68 Texte, deutsch wie englisch.
 
+- **Bei erreichtem Stundenlimit war der Upload nur für Sehende abgeschaltet.**
+  Wer mit einem Screenreader unterwegs war, bekam den toten Bereich weiter
+  vorgelesen — samt Aufforderung, ein Foto zu wählen, die ins Leere führte.
+  Jetzt ist er für alle gleichzeitig abgeschaltet, und die Tastatur landet auf
+  dem Hinweis statt im Nichts.
+
+- **Sechs Fehlerbilder werden jetzt wirklich angesehen.** Neue Prüfungen
+  versetzen die Seite in die Zustände „Stundenlimit", „Warteschlange voll",
+  „Wartungsmodus", „Bild zu groß", „Format nicht lesbar" und „Server
+  überlastet" und sehen nach: Erscheint der Hinweis, springt der Seitenkopf,
+  läuft Text aus seinem Kasten, ist er barrierefrei? Zuvor kamen 26 der 45
+  Fehlermeldungen in keiner einzigen Prüfung vor.
+
 ## [4.0.0] — 2026-08-21
 
 Ein Lang-Audit hat das Projekt in der Nacht auf den 21. August durchleuchtet:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
   Jetzt ist er für alle gleichzeitig abgeschaltet, und die Tastatur landet auf
   dem Hinweis statt im Nichts.
 
+- **Vier Prüfungen waren geduldiger gebaut, als sie sein konnten.** Sie warteten
+  bis zu 45 Sekunden auf ein Element, während ihr eigenes Zeitlimit bei 30
+  Sekunden lag — die längere Geduld war wirkungslos, obwohl im Quelltext
+  ausdrücklich stand, damit sei eine frühere Unzuverlässigkeit behoben. Genau
+  eine dieser Stellen hat am 21. August eine Auslieferung blockiert. Eine neue
+  Prüfung findet diese Bauart künftig selbst; sie blendet dabei Kommentare aus,
+  weil sonst eine auskommentierte Zeile den Befund tarnt.
+
 - **Sechs Fehlerbilder werden jetzt wirklich angesehen.** Neue Prüfungen
   versetzen die Seite in die Zustände „Stundenlimit", „Warteschlange voll",
   „Wartungsmodus", „Bild zu groß", „Format nicht lesbar" und „Server

--- a/docs/ERROR-ALERTING.md
+++ b/docs/ERROR-ALERTING.md
@@ -91,6 +91,37 @@ gcloud alpha monitoring policies create \
 
 Der `notificationRateLimit` (300s) verhindert Push-Spam bei einem Fehler-Sturm.
 
+## Zweite Richtlinie: Haeufung von Client-Fehlern (seit 2026-08-21)
+
+**Name:** `malziME Client-Fehler-Haeufung` · **Schwelle:** mehr als **20** Berichte
+je Stunde · **Kanaele:** ntfy-Push und E-Mail · **Metrik:**
+`logging.googleapis.com/user/client_fehler_rate`
+
+**Warum es sie gibt.** Die Richtlinie darunter alarmiert nur SERVER-Fehler. Was im
+Browser der Besucher schiefgeht — Layout, Speicher, Safari-Eigenheiten — war
+bewusst stumm (siehe unten: jeder einzelne Bericht waere ein Alarm gewesen). Genau
+diese Fehlerklasse hat aber am 2026-08-21 gleich dreimal zugeschlagen, und zur
+Presse-Aussendung schauen Fremde auf die Seite.
+
+**Warum eine Schwelle und nicht der alte Filter.** Gemessen am 2026-08-21:
+**fuenf** Berichte in sieben Tagen. Eine Schwelle von 20 je Stunde feuert im
+Normalbetrieb nie, faengt aber einen Einbruch. Die Spam-Gefahr von damals kommt
+damit nicht zurueck.
+
+**Wenn der Alarm kommt:** nachsehen, welche Phase sich haeuft.
+
+```bash
+gcloud logging read 'resource.labels.service_name="errors"' \
+  --project=malzime --freshness=2h \
+  --format='value(jsonPayload.phase,jsonPayload.errorDetail)'
+```
+
+Haeufen sich Meldungen EINER Phase, ist dort etwas kaputt. Gleichverteiltes
+Rauschen bei hoher Last ist dagegen normal — dann ist die Schwelle zu niedrig
+und darf steigen.
+
+---
+
 Der Filter wurde am 2026-07-17 (LANGAUDIT OPS-001) um die Queue-Functions
 `enqueue`, `processjob`, `jobstatus` und `reapjobs` erweitert — der Live-Analysepfad
 war seit der Queue-Umstellung (v2.0) ohne Alarm. Die Functions `errors` und

--- a/e2e/ansagen.test.js
+++ b/e2e/ansagen.test.js
@@ -241,6 +241,12 @@ test.describe("Ansage-Protokoll", () => {
   });
 
   test("Beast-Umschalter: Zustand und Ansage", async ({ page }) => {
+    /* OPS-2026-08-21-08: Der Wartewert von 45 s darunter war wirkungslos — das
+       Zeitlimit des Tests liegt bei 30 s und greift vorher. Am 21.08. hat genau
+       das die Auslieferung blockiert. `test.slow()` verdreifacht das Limit auf
+       90 s; erst damit wirkt die Geduld, die hier seit einer frueheren
+       Sanierung beabsichtigt war. Geprueft wird unveraendert dasselbe. */
+    test.slow();
     await ansagenMitschreiben(page, "Beast");
     await endpunkte(page, { status: "done", result: PROFIL });
     await page.emulateMedia({ reducedMotion: "reduce" });
@@ -368,14 +374,13 @@ test("Nach der Analyse traegt der Ergebnisbereich einen Namen", async ({ page })
   /* Der zweite Fund desselben Nutzers: „Analyse beendet" kam, danach nichts.
      Der Fokus sprang auf einen <section> ohne Rolle und ohne Namen — VoiceOver
      landet dort und hat nichts zu sagen. */
+  /* OPS-2026-08-21-08: siehe oben — ohne test.slow() war der Wartewert von
+     45 s wirkungslos, weil das Zeitlimit des Tests bei 30 s liegt. */
+  test.slow();
   await endpunkte(page, { status: "done", result: PROFIL });
   await page.emulateMedia({ reducedMotion: "reduce" });
   await page.goto("/");
   await page.click('[data-demo="selfie"]');
-  /* 45 s statt 20: Auf dem Firefox-Laeufer der CI reichten 20 s nicht, der
-     Test wurde dort zeitweise rot, obwohl die Seite in Ordnung ist. Die
-     Zusicherung darunter bleibt unveraendert — verlaengert wird nur die
-     Geduld, nicht die Toleranz. */
   await page.waitForSelector(".cat-card", { timeout: 45000 });
   await page.waitForTimeout(1200);
 

--- a/e2e/druck-abbruch.test.js
+++ b/e2e/druck-abbruch.test.js
@@ -72,6 +72,9 @@ async function endpunkte(page, jobStatus) {
 }
 
 test("Nach Abbrechen des Druckdialogs ist die Seite im Beast-Modus wieder da", async ({ page }) => {
+  /* OPS-2026-08-21-08: Der Wartewert von 45 s unten war wirkungslos — das
+     Zeitlimit des Tests liegt bei 30 s. `test.slow()` verdreifacht es. */
+  test.slow();
   await endpunkte(page, { status: "done", result: PROFIL });
   await page.goto("/");
   await page.click('[data-demo="selfie"]');

--- a/e2e/fehlerbilder.test.js
+++ b/e2e/fehlerbilder.test.js
@@ -1,0 +1,177 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+/* ── Die Seite in ihren FEHLERZUSTÄNDEN ansehen ──────────────────────────────
+ *
+ * ANLASS (2026-08-21): Das TIEF-Audit vom 20.08. hat 52 Befunde gefunden, aber
+ * zwei sichtbare Fehler auf öffentlichen Seiten übersehen — den springenden
+ * Seitenkopf der Zahlen-Seite und die hakelige Tastatur-Rückgabe. Beide saßen
+ * in Zuständen, die im Normalbetrieb nie auftreten. Die nachträgliche Messung
+ * war eindeutig: 26 von 45 Fehler- und Blockade-Meldungen der Oberfläche kamen
+ * in KEINER Prüfung vor.
+ *
+ * Der gemeinsame Nenner: Der Audit hat gelesen, nicht bedient. Ein Fehlerbild,
+ * das nie jemand angesehen hat, ist nicht geprüft — auch wenn der Code, der es
+ * erzeugt, gelesen wurde.
+ *
+ * WAS HIER GEPRÜFT WIRD, je Fehlerbild:
+ *   1. Es erscheint überhaupt (sonst prüft der Rest nichts).
+ *   2. Der Seitenkopf springt nicht — genau der Fehler von BUG-2026-08-21-03.
+ *   3. Kein Text läuft aus seinem Kasten heraus.
+ *   4. axe findet keinen Verstoß — Fehlermeldungen sind für Menschen in Not,
+ *      die brauchen die Barrierefreiheit am dringendsten.
+ *
+ * Die Zustände werden über gefälschte Server-Antworten ausgelöst, nicht durch
+ * Aufruf interner Funktionen: Nur so ist belegt, dass der Weg vom Server bis
+ * zum Bildschirm wirklich zu diesem Bild führt.
+ */
+
+const HANDY = { width: 390, height: 844 };
+
+/* Die Zuordnung stammt aus public/js/api.js:755-773 — dort verzweigt der Code
+   die Server-Antwort auf das Fehlerbild. Ändert sich die Verzweigung, muss diese
+   Tabelle mitgehen; der Test schlägt dann an, weil das Bild ausbleibt. */
+const FEHLERBILDER = [
+  {
+    name: "Stundenlimit erreicht",
+    antwort: { status: 429, body: { blocked: "limit", retryAfterSeconds: 600 } },
+    sichtbar: "#limitBanner",
+    /* Erscheint NUR bei Andrang, also im Workshop und bei der Presse-Welle —
+       der am schlechtesten geprüfte und am schlechtesten zu erwischende Fall. */
+  },
+  {
+    name: "Warteschlange voll",
+    antwort: { status: 429, body: { blocked: "queueFull", retryAfterSeconds: 120 } },
+    sichtbar: "#status",
+  },
+  {
+    name: "Wartungsmodus",
+    antwort: { status: 503, body: { maintenance: true, message: "Kurze Wartung, gleich wieder da." } },
+    sichtbar: ".maintenance-modal, #maintenanceModal, [role='dialog']",
+  },
+  {
+    name: "Bild zu groß",
+    antwort: { status: 413, body: {} },
+    sichtbar: "#status",
+  },
+  {
+    name: "Format nicht lesbar",
+    antwort: { status: 400, body: {} },
+    sichtbar: "#status",
+  },
+  {
+    name: "Server überlastet",
+    antwort: { status: 500, body: {} },
+    sichtbar: "#status",
+  },
+];
+
+/* Ein winziges, gültiges JPEG — der Upload-Weg soll echt durchlaufen werden,
+   damit die Antwort auch wirklich am Fehlerpfad ankommt. */
+const MINI_JPEG = Buffer.from(
+  "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a" +
+    "HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAA" +
+    "AAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AKp//2Q==",
+  "base64"
+);
+
+async function seiteVorbereiten(page, antwort) {
+  await page.route("**/api/stats", (r) =>
+    r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        current: { count: 12, limit: 500, limitActive: false, retryAfterSeconds: 0 },
+        totals: { today: 12, week: 60, month: 300, total: 2000 },
+      }),
+    })
+  );
+  await page.route("**/api/enqueue", (r) =>
+    r.fulfill({
+      status: antwort.status,
+      contentType: "application/json",
+      body: JSON.stringify(antwort.body),
+    })
+  );
+  /* Fehlerberichte ins Leere laufen lassen: Sie gehören nicht zum Prüfgegenstand
+     und würden den Lauf nur verlangsamen. */
+  await page.route("**/api/errors**", (r) => r.fulfill({ status: 204, body: "" }));
+}
+
+async function kopfHoehe(page) {
+  /* Position im DOKUMENT, nicht im sichtbaren Fenster. Der erste Anlauf maß
+     `getBoundingClientRect().top` — der ist scroll-abhängig, und die Seite
+     springt beim Fehler nach unten zum Hinweis. Alle sechs Prüfungen meldeten
+     dadurch einen „Sprung" von 99 auf -431, obwohl sich am Layout nichts
+     geändert hatte. Ein Messwert, der auf Scrollen reagiert, taugt nicht zur
+     Aussage über das Layout. */
+  return page.evaluate(() => {
+    const h1 = document.querySelector("h1, .hero-title, .stats-hero__title");
+    if (!h1) return -1;
+    return Math.round(h1.getBoundingClientRect().top + window.scrollY);
+  });
+}
+
+async function fehlerAusloesen(page) {
+  await page.setInputFiles("#fileInput", {
+    name: "probe.jpg",
+    mimeType: "image/jpeg",
+    buffer: MINI_JPEG,
+  });
+  const knopf = page.locator("#analyzeBtn, button[type='submit'], .upload-btn").first();
+  if (await knopf.isVisible().catch(() => false)) {
+    await knopf.click().catch(() => {});
+  }
+}
+
+for (const bild of FEHLERBILDER) {
+  test(`Fehlerbild „${bild.name}": erscheint, verschiebt den Kopf nicht, ist barrierefrei`, async ({ page }) => {
+    await page.setViewportSize(HANDY);
+    await seiteVorbereiten(page, bild.antwort);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const kopfVorher = await kopfHoehe(page);
+    expect(kopfVorher, "Überschrift muss vor dem Fehler auffindbar sein").toBeGreaterThan(-1);
+
+    await fehlerAusloesen(page);
+
+    /* ── 1. Das Bild erscheint überhaupt ── */
+    const ziel = page.locator(bild.sichtbar).first();
+    await expect(ziel, `„${bild.name}" muss sichtbar werden — sonst prüft der Rest nichts`).toBeVisible({
+      timeout: 15000,
+    });
+
+    /* ── 2. Der Seitenkopf springt nicht (BUG-2026-08-21-03) ── */
+    const kopfNachher = await kopfHoehe(page);
+    expect(
+      Math.abs(kopfNachher - kopfVorher),
+      `Der Seitenkopf ist beim Fehlerbild „${bild.name}" von ${kopfVorher} auf ${kopfNachher} gesprungen. ` +
+        `Ein Hinweis darf sich nicht ÜBER die Überschrift schieben — genau das war BUG-2026-08-21-03.`
+    ).toBeLessThanOrEqual(4);
+
+    /* ── 3. Kein Text läuft aus seinem Kasten ── */
+    const ueberlauf = await page.evaluate((wahl) => {
+      const kasten = document.querySelector(wahl);
+      if (!kasten) return null;
+      const aussen = kasten.getBoundingClientRect();
+      for (const kind of kasten.querySelectorAll("p, span, a, h1, h2")) {
+        const innen = kind.getBoundingClientRect();
+        if (innen.width === 0) continue;
+        if (innen.right > aussen.right + 2 || innen.left < aussen.left - 2) {
+          return { text: (kind.textContent || "").trim().slice(0, 60), innen: Math.round(innen.right), aussen: Math.round(aussen.right) };
+        }
+      }
+      return null;
+    }, bild.sichtbar);
+    expect(
+      ueberlauf,
+      ueberlauf ? `Text läuft aus dem Kasten: „${ueberlauf.text}" (${ueberlauf.innen} px > ${ueberlauf.aussen} px)` : ""
+    ).toBeNull();
+
+    /* ── 4. Barrierefrei ── */
+    const ergebnis = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"]).analyze();
+    const verstoesse = ergebnis.violations.map((v) => `${v.id} (${v.nodes.length}×): ${v.help}`);
+    expect(verstoesse, `axe-Verstöße im Fehlerbild „${bild.name}"`).toEqual([]);
+  });
+}

--- a/e2e/karte.test.js
+++ b/e2e/karte.test.js
@@ -84,6 +84,11 @@ test.describe("GPS-Karte", () => {
   });
 
   test("BUG-2026-08-20-06: die Adresse ueberlebt den Moduswechsel", async ({ page }) => {
+    /* OPS-2026-08-21-08: Der Wartewert von 40 s weiter unten war wirkungslos —
+       das Zeitlimit des Tests liegt bei 30 s und greift vorher. Die Karte baut
+       sich nach dem Moduswechsel neu auf, das dauert unter Last. `test.slow()`
+       verdreifacht das Limit; geprueft wird unveraendert dasselbe. */
+    test.slow();
     /* Der erste Aufbau verbrauchte das Geocoding-Versprechen und setzte es auf
        null. Beim zweiten Aufbau — jedem Moduswechsel und jedem Ausdruck — stand
        deshalb nur noch das Koordinatenpaar da. Der Ort, den die Karte zeigen

--- a/public/index.html
+++ b/public/index.html
@@ -206,16 +206,26 @@
             <path d="M12 6v6l4 2" />
           </svg>
         </div>
-        <p class="limit-banner__title" data-i18n="limit.title">Stundenlimit erreicht</p>
+        <!-- UX-2026-08-21-06: Diese vier Texte standen noch in einer alten Fassung,
+             waehrend die Sprachdatei laengst die ueberarbeitete trug. Was hier steht,
+             ist kein Platzhalter: Es ist das, was Besucher sehen, solange die
+             Sprachdatei nicht geladen ist — und dauerhaft, wenn sie gar nicht laedt.
+             Ausgerechnet dieser Hinweis erscheint nur bei Andrang, also im Workshop.
+             `scripts/pruefe-i18n-fallbacks.py` haelt beide Fassungen ab jetzt gleich. -->
+        <p class="limit-banner__title" data-i18n="limit.title">Kurze Pause.</p>
         <p class="limit-banner__text" data-i18n="limit.text">
-          Zu viele Analysen in kurzer Zeit. Bitte warte, bis das Limit zur&uuml;ckgesetzt wird.
+          malziME wurde in dieser Stunde schon sehr oft genutzt und hat das Limit erreicht. Die Analyse ist
+          vor&uuml;bergehend deaktiviert, damit die Kosten nicht explodieren.
         </p>
         <p class="limit-banner__countdown" id="limitCountdown" aria-live="off"></p>
         <p class="limit-banner__muted" data-i18n="limit.textMuted">
-          Das Limit sch&uuml;tzt das Projekt vor unerwarteten Kosten.
+          malziME ist ein eigenfinanziertes Projekt &mdash; kostenlos, werbefrei und ohne Tracking. Dieses Limit
+          sch&uuml;tzt das Projekt vor unerwarteten Serverkosten.
         </p>
         <div class="limit-banner__cta">
-          <span data-i18n="limit.supportText">Du willst das Limit erh&ouml;hen?</span>
+          <span data-i18n="limit.supportText"
+            >Mit einer Spende hilfst du, die Limits zu erh&ouml;hen und malziME am Laufen zu halten.</span
+          >
           <a
             href="https://buymeacoffee.com/malzime"
             target="_blank"

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -133,14 +133,49 @@ export function stopScanAnim(leise = false) {
 
 let countdownInterval = null;
 
+/* UX-2026-08-21-07: Der abgeschaltete Bereich war nur fuer Sehende und
+   Maus-Nutzer abgeschaltet.
+
+   Gemessen am 21.08. bei aktivem Limit: `pointer-events: none` griff, der
+   Datenschutz-Link war nicht mehr anklickbar — aber `.drop-label`, der
+   Datenschutz-Hinweis und der Rest waren fuer Screenreader unveraendert
+   vorhanden und wurden vorgelesen, ohne dass irgendetwas den abgeschalteten
+   Zustand vermittelt haette. Wer sieht, erkennt den toten Bereich sofort; wer
+   hoert, liest eine Aufforderung zum Hochladen vor, die ins Leere fuehrt.
+
+   `inert` schaltet den Bereich fuer ALLE gleichzeitig ab: Maus, Tastatur,
+   Screenreader. Damit deckt sich der angesagte Zustand mit dem sichtbaren, und
+   die sieben Kontrastmeldungen von axe entfallen als Nebenwirkung — abgeschaltete
+   Bereiche sind von WCAG 1.4.3 ausgenommen, aber nur, wenn sie es wirklich sind.
+
+   `inert` ist in diesem Projekt erprobt (Fokus-Kaefig der Sprachwahl-Rueckfrage). */
+function bereicheSchalten(abgeschaltet) {
+  for (const wahl of [".upload-section", ".demo-section"]) {
+    const bereich = document.querySelector(wahl);
+    if (!bereich) continue;
+    bereich.classList.toggle("upload-section--limited", abgeschaltet);
+    bereich.inert = abgeschaltet;
+  }
+}
+
 export function showLimitBanner(retryAfterSeconds) {
   if (!elements.limitBanner) return;
   elements.limitBanner.classList.add("active");
 
-  const uploadSection = document.querySelector(".upload-section");
-  const demoSection = document.querySelector(".demo-section");
-  if (uploadSection) uploadSection.classList.add("upload-section--limited");
-  if (demoSection) demoSection.classList.add("upload-section--limited");
+  /* Reihenfolge ist wichtig: Steht der Fokus noch im Bereich, wenn er inert
+     wird, faellt er ersatzlos auf <body> — der naechste Tastendruck beginnt
+     dann wieder ganz oben. Deshalb zuerst pruefen, dann schalten, dann den
+     Fokus auf den Hinweis lenken, der ohnehin `role="alert"` traegt. */
+  const fokusWarDrin = document.activeElement
+    ? Boolean(document.activeElement.closest(".upload-section, .demo-section"))
+    : false;
+
+  bereicheSchalten(true);
+
+  if (fokusWarDrin) {
+    elements.limitBanner.setAttribute("tabindex", "-1");
+    elements.limitBanner.focus({ preventScroll: true });
+  }
 
   startLimitCountdown(retryAfterSeconds);
 }
@@ -149,10 +184,7 @@ export function hideLimitBanner() {
   if (!elements.limitBanner) return;
   elements.limitBanner.classList.remove("active");
 
-  const uploadSection = document.querySelector(".upload-section");
-  const demoSection = document.querySelector(".demo-section");
-  if (uploadSection) uploadSection.classList.remove("upload-section--limited");
-  if (demoSection) demoSection.classList.remove("upload-section--limited");
+  bereicheSchalten(false);
 
   if (countdownInterval) {
     clearInterval(countdownInterval);

--- a/scripts/pruefe-i18n-fallbacks.py
+++ b/scripts/pruefe-i18n-fallbacks.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Prueft, ob der im HTML stehende Text mit der Sprachdatei uebereinstimmt.
+
+WARUM ES DIESE PRUEFUNG GIBT (Fund vom 2026-08-21):
+
+Jedes uebersetzbare Element traegt `data-i18n="schluessel"` und dazwischen einen
+fest im HTML stehenden Text. Dieser Text ist kein Platzhalter, sondern das, was
+Besucher SEHEN, bis die Sprachdatei geladen und angewendet ist — und das, was sie
+DAUERHAFT sehen, wenn sie gar nicht laedt.
+
+Genau dort war der Limit-Hinweis der Startseite auseinandergelaufen: In der
+Sprachdatei stand die ueberarbeitete Fassung ("Kurze Pause." samt Hinweis auf die
+Eigenfinanzierung), im HTML noch die alte, haertere ("Stundenlimit erreicht").
+Vier Absaetze waren betroffen. Gemerkt hat es niemand, weil der Limit-Hinweis nur
+bei Andrang erscheint — also ausgerechnet im Workshop.
+
+WAS SIE PRUEFT
+
+Fuer jedes Element mit `data-i18n`: Steht der Schluessel in der Sprachdatei, und
+stimmt der sichtbare Text mit ihr ueberein? Verglichen wird der reine Text ohne
+innere Auszeichnung, mit zusammengefassten Leerzeichen — `<abbr>IP</abbr>-Adressen`
+und `IP-Adressen` gelten also als gleich.
+
+Deutsche Seiten werden gegen de.json geprueft, alles unter public/en/ gegen en.json.
+
+RUECKGABEWERTE, absichtlich getrennt (die Lehre aus frueheren Waechtern: ein
+kaputtes Messmittel darf nicht wie ein gruener Lauf aussehen):
+  0 = keine Abweichung
+  1 = Abweichung gefunden (echter Befund)
+  2 = Messproblem (Datei fehlt, JSON kaputt, kein Element gefunden)
+"""
+
+import json
+import re
+import sys
+import glob
+from html.parser import HTMLParser
+
+LEERE_TAGS = {"br", "img", "input", "hr", "meta", "link", "source", "wbr"}
+
+
+class TextSammler(HTMLParser):
+    """Sammelt je data-i18n-Element den sichtbaren Text samt Zeilennummer.
+
+    Ein Regex reicht hier nicht: Die Elemente enthalten weitere Tags (<abbr>,
+    <strong>) und teils gleichnamige verschachtelte. Ein erster Anlauf mit
+    Regex lieferte am 21.08. vier Scheinbefunde, weil `.*?` ueber das
+    schliessende Tag hinauslief.
+    """
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.treffer = []
+        self._stapel = []  # offene Elemente: (tag, schluessel|None, zeile, teile)
+
+    def handle_starttag(self, tag, attrs):
+        if tag in LEERE_TAGS:
+            return
+        merkmale = dict(attrs)
+        schluessel = merkmale.get("data-i18n")
+        # Sammelt nur, wenn wir in einem data-i18n-Element sind oder eines beginnt
+        self._stapel.append((tag, schluessel, self.getpos()[0], []))
+
+    def handle_startendtag(self, tag, attrs):
+        pass  # selbstschliessend: kein Text
+
+    def handle_data(self, daten):
+        for eintrag in self._stapel:
+            eintrag[3].append(daten)
+
+    def handle_endtag(self, tag):
+        # Bis zum passenden offenen Tag zurueckrollen (unsauberes HTML toleriert)
+        while self._stapel:
+            offen = self._stapel.pop()
+            if offen[1]:
+                self.treffer.append((offen[1], "".join(offen[3]), offen[2]))
+            if offen[0] == tag:
+                break
+
+
+def sauber(text):
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def hol(woerterbuch, pfad):
+    """Die Sprachdateien nutzen FLACHE Schluessel ("limit.title").
+
+    Erst flach nachsehen, dann verschachtelt — ein erster Anlauf am 21.08. hat
+    nur verschachtelt gesucht, nichts gefunden und deshalb faelschlich "alles in
+    Ordnung" gemeldet. Ein leeres Ergebnis ist zuerst ein Verdacht gegen das
+    Messmittel.
+    """
+    if isinstance(woerterbuch.get(pfad), str):
+        return woerterbuch[pfad]
+    stelle = woerterbuch
+    for teil in pfad.split("."):
+        if not isinstance(stelle, dict) or teil not in stelle:
+            return None
+        stelle = stelle[teil]
+    return stelle if isinstance(stelle, str) else None
+
+
+def main():
+    try:
+        de = json.load(open("public/locales/de.json", encoding="utf-8"))
+        en = json.load(open("public/locales/en.json", encoding="utf-8"))
+    except (OSError, ValueError) as fehler:
+        print(f"MESSPROBLEM: Sprachdateien nicht lesbar — {fehler}")
+        return 2
+
+    dateien = sorted(glob.glob("public/*.html") + glob.glob("public/en/*.html"))
+    if not dateien:
+        print("MESSPROBLEM: keine HTML-Dateien gefunden — falsches Verzeichnis?")
+        return 2
+
+    abweichungen = []
+    fehlende = []
+    geprueft = 0
+
+    for datei in dateien:
+        try:
+            roh = open(datei, encoding="utf-8").read()
+        except OSError as fehler:
+            print(f"MESSPROBLEM: {datei} nicht lesbar — {fehler}")
+            return 2
+
+        sammler = TextSammler()
+        sammler.feed(roh)
+        sammler.close()
+        woerterbuch = en if "/en/" in datei else de
+
+        for schluessel, text, zeile in sammler.treffer:
+            ist = sauber(text)
+            if not ist:
+                continue  # leeres Element: nichts zu vergleichen
+            geprueft += 1
+            soll = hol(woerterbuch, schluessel)
+            if soll is None:
+                fehlende.append((datei, zeile, schluessel))
+                continue
+            if ist != sauber(soll):
+                abweichungen.append((datei, zeile, schluessel, ist, sauber(soll)))
+
+    if geprueft == 0:
+        print("MESSPROBLEM: kein einziges data-i18n-Element gefunden — Prüfung greift ins Leere.")
+        return 2
+
+    print(f"Geprüft: {geprueft} Texte mit data-i18n in {len(dateien)} Seiten.")
+
+    for datei, zeile, schluessel in fehlende:
+        print(f"\nFEHLT  {datei}:{zeile}  [{schluessel}]")
+        print("       Schlüssel steht in keiner Sprachdatei.")
+
+    for datei, zeile, schluessel, ist, soll in abweichungen:
+        print(f"\nABWEICHUNG  {datei}:{zeile}  [{schluessel}]")
+        print(f"       im HTML sichtbar : {ist[:120]}")
+        print(f"       in der Sprachdatei: {soll[:120]}")
+
+    if abweichungen or fehlende:
+        print(
+            f"\nERGEBNIS: {len(abweichungen)} Abweichung(en), {len(fehlende)} fehlende(r) Schlüssel.\n"
+            "Der HTML-Text ist das, was Besucher sehen, bevor die Sprachdatei greift —\n"
+            "und das, was sie dauerhaft sehen, wenn sie nicht greift. Beide Fassungen\n"
+            "müssen dasselbe sagen."
+        )
+        return 1
+
+    print("ERGEBNIS: grün — jeder sichtbare Text stimmt mit seiner Sprachdatei überein.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pruefe-tote-geduld.py
+++ b/scripts/pruefe-tote-geduld.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Findet Wartezeiten in E2E-Tests, die groesser sind als das Zeitlimit des Tests.
+
+WARUM ES DIESE PRUEFUNG GIBT (Fund vom 2026-08-21):
+
+`playwright.config.js` setzt ein Zeitlimit von 30 Sekunden je Test. Wartet ein
+Test laenger auf ein Element — etwa `waitForSelector(..., { timeout: 45000 })` —,
+dann greift das Zeitlimit des Tests VORHER. Die laengere Geduld ist wirkungslos.
+
+Genau das war passiert: In `ansagen.test.js` stand seit einer frueheren Sanierung
+der Kommentar "45 s statt 20: Auf dem Firefox-Laeufer der CI reichten 20 s nicht".
+Die Absicht war richtig, die Wirkung gleich null — der Test starb weiter nach 30
+Sekunden. Am 21.08. hat er die Auslieferung blockiert.
+
+Das Tueckische daran: Es sieht im Quelltext nach Sorgfalt aus. Wer die Stelle
+liest, denkt, das Problem sei behoben.
+
+DIE BEHEBUNG ist nicht, das globale Limit anzuheben — das verlaengert jeden
+haengenden Test. Der betroffene Test bekommt `test.slow()` (verdreifacht sein
+Limit) oder ein ausdrueckliches `test.setTimeout(...)`.
+
+RUECKGABEWERTE:
+  0 = keine tote Geduld
+  1 = Befund
+  2 = Messproblem (Konfiguration nicht lesbar, keine Testdateien)
+"""
+
+import os
+import re
+import sys
+import glob
+
+# Playwright verdreifacht das Limit bei test.slow().
+SLOW_FAKTOR = 3
+
+
+def test_limit_aus_konfiguration(pfad="playwright.config.js"):
+    try:
+        inhalt = open(pfad, encoding="utf-8").read()
+    except OSError:
+        return None
+    treffer = re.search(r"^\s*timeout:\s*(\d+)", inhalt, re.M)
+    return int(treffer.group(1)) if treffer else None
+
+
+def ohne_kommentare(inhalt):
+    """Entfernt Kommentare, behaelt aber die Zeilenzahl.
+
+    Ohne das zaehlt ein AUSKOMMENTIERTES `test.slow()` als vorhanden und tarnt
+    einen echten Befund — dieselbe Krankheit, die diese Pruefung finden soll.
+    Aufgefallen 2026-08-21 in der eigenen Rueckbauprobe: Die Pruefung meldete
+    gruen, obwohl der Fix zurueckgedreht war.
+
+    Zeilenumbrueche bleiben stehen, damit die gemeldeten Zeilennummern stimmen.
+    """
+    def ersetzen(treffer):
+        return re.sub(r"[^\n]", " ", treffer.group(0))
+
+    ohne_block = re.sub(r"/\*.*?\*/", ersetzen, inhalt, flags=re.S)
+    return re.sub(r"//[^\n]*", ersetzen, ohne_block)
+
+
+def bloecke(inhalt):
+    """Zerlegt eine Datei grob in Test-Bloecke: ab `test(` bis zum naechsten `test(`.
+
+    Absichtlich einfach gehalten. Eine echte Zerlegung braeuchte einen Parser;
+    fuer die Frage "steht in DIESEM Test ein zu grosser Timeout und fehlt ihm
+    test.slow()" reicht der Abstand zwischen zwei Test-Anfaengen.
+    """
+    # NUR echte Testanfaenge. `test.slow(` und `test.setTimeout(` sind KEINE —
+    # ein erster Anlauf hat sie mitgezaehlt, dadurch die Bloecke falsch
+    # geschnitten und ausgerechnet den Test uebersehen, der die Auslieferung
+    # blockiert hat.
+    anfaenge = [
+        m.start()
+        for m in re.finditer(r"^\s*test(?:\.(?:only|skip|fixme|describe))?\s*\(", inhalt, re.M)
+    ]
+    for i, start in enumerate(anfaenge):
+        ende = anfaenge[i + 1] if i + 1 < len(anfaenge) else len(inhalt)
+        yield start, inhalt[start:ende]
+
+
+def main():
+    grenze = test_limit_aus_konfiguration()
+    if grenze is None:
+        print("MESSPROBLEM: Zeitlimit aus playwright.config.js nicht lesbar.")
+        return 2
+
+    dateien = sorted(glob.glob("e2e/*.test.js"))
+    if not dateien:
+        print("MESSPROBLEM: keine E2E-Testdateien gefunden — falsches Verzeichnis?")
+        return 2
+
+    befunde = []
+    geprueft = 0
+
+    for datei in dateien:
+        try:
+            inhalt = open(datei, encoding="utf-8").read()
+        except OSError as fehler:
+            print(f"MESSPROBLEM: {datei} nicht lesbar — {fehler}")
+            return 2
+
+        inhalt = ohne_kommentare(inhalt)
+
+        # Datei-weit gilt nur, was VOR dem ersten Test steht. Ein `test.slow()`
+        # INNERHALB eines Tests gilt ausschliesslich dort — der erste Anlauf hat
+        # es faelschlich auf die ganze Datei bezogen und deshalb einen echten
+        # Befund durchgewinkt. Ein Waechter, der Ausfaelle als Erfolg tarnt, ist
+        # schlimmer als einer, der laermt.
+        erster_test = re.search(r"^\s*test(?:\.(?:only|skip|fixme))?\s*\(", inhalt, re.M)
+        kopf = inhalt[: erster_test.start()] if erster_test else inhalt
+        datei_slow = bool(re.search(r"\btest\.(slow|setTimeout)\s*\(", kopf))
+
+        for versatz, block in bloecke(inhalt):
+            geprueft += 1
+            hat_slow = bool(re.search(r"\btest\.slow\s*\(", block))
+            hat_eigenes = re.search(r"\btest\.setTimeout\s*\(\s*(\d+)", block)
+
+            if hat_eigenes:
+                erlaubt = int(hat_eigenes.group(1))
+            elif hat_slow:
+                erlaubt = grenze * SLOW_FAKTOR
+            else:
+                erlaubt = grenze
+
+            for m in re.finditer(r"timeout:\s*(\d+)", block):
+                wert = int(m.group(1))
+                if wert <= erlaubt:
+                    continue
+                if datei_slow and not hat_slow and wert <= grenze * SLOW_FAKTOR:
+                    continue
+                zeile = inhalt[: versatz + m.start()].count("\n") + 1
+                name = re.search(r'test(?:\.\w+)?\s*\(\s*[`"\']([^`"\']{0,70})', block)
+                befunde.append((datei, zeile, wert, erlaubt, name.group(1) if name else "?"))
+
+    print(f"Geprüft: {geprueft} Tests in {len(dateien)} Dateien. Zeitlimit je Test: {grenze} ms.")
+
+    for datei, zeile, wert, erlaubt, name in befunde:
+        print(f"\nTOTE GEDULD  {datei}:{zeile}")
+        print(f"       Test    : {name}")
+        print(f"       wartet  : {wert} ms")
+        print(f"       darf nur: {erlaubt} ms — das Zeitlimit des Tests greift vorher.")
+
+    if befunde:
+        print(
+            f"\nERGEBNIS: {len(befunde)} wirkungslose Wartezeit(en).\n"
+            "Eine Wartezeit über dem Zeitlimit des Tests ändert nichts — der Test stirbt\n"
+            "vorher. Sie sieht im Quelltext nur nach Sorgfalt aus. Behebung: `test.slow()`\n"
+            "im betroffenen Test (verdreifacht sein Limit), nicht das globale Limit anheben."
+        )
+        return 1
+
+    print("ERGEBNIS: grün — keine Wartezeit übersteigt das Zeitlimit ihres Tests.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vor-dem-push.sh
+++ b/scripts/vor-dem-push.sh
@@ -61,6 +61,7 @@ lauf "Pruefungen: Aussentext-Sperrliste" "pruefungen" python3 scripts/pruefungen
 lauf "Pruefungen: Fakten-Drift" "pruefungen" python3 scripts/pruefungen/checks/fakten-drift.py .
 lauf "Pruefungen: Stiller Fehlschlag" "pruefungen" python3 scripts/pruefungen/checks/stiller-fehlschlag.py .
 lauf "Pruefungen: Tests ohne Zusicherung" "pruefungen" python3 scripts/pruefungen/checks/test-blind.py .
+lauf "Pruefungen: Sichtbare Texte" "pruefungen" python3 scripts/pruefe-i18n-fallbacks.py
 lauf "Pruefungen: Fremddateien" "pruefungen" node scripts/pruefe-fremddateien.mjs
 lauf "Pruefungen: Vendorierung" "pruefungen" node scripts/pruefe-vendorierung.mjs
 lauf "Zeitzuender (Backend)" "test-backend" sh scripts/pruefe-zeitzuender.sh . --nur backend

--- a/scripts/vor-dem-push.sh
+++ b/scripts/vor-dem-push.sh
@@ -62,6 +62,7 @@ lauf "Pruefungen: Fakten-Drift" "pruefungen" python3 scripts/pruefungen/checks/f
 lauf "Pruefungen: Stiller Fehlschlag" "pruefungen" python3 scripts/pruefungen/checks/stiller-fehlschlag.py .
 lauf "Pruefungen: Tests ohne Zusicherung" "pruefungen" python3 scripts/pruefungen/checks/test-blind.py .
 lauf "Pruefungen: Sichtbare Texte" "pruefungen" python3 scripts/pruefe-i18n-fallbacks.py
+lauf "Pruefungen: Tote Geduld" "pruefungen" python3 scripts/pruefe-tote-geduld.py
 lauf "Pruefungen: Fremddateien" "pruefungen" node scripts/pruefe-fremddateien.mjs
 lauf "Pruefungen: Vendorierung" "pruefungen" node scripts/pruefe-vendorierung.mjs
 lauf "Zeitzuender (Backend)" "test-backend" sh scripts/pruefe-zeitzuender.sh . --nur backend


### PR DESCRIPTION
Drei zusammenhaengende Arbeiten aus der Nach-Audit-Runde vom 21.08.

## Zwei echte Funde

**1. Der Limit-Hinweis zeigte eine veraltete Fassung.** Im Seitenquelltext stand noch der alte, haertere Text (`Stundenlimit erreicht`), waehrend die Sprachdatei laengst die ueberarbeitete trug (`Kurze Pause.` samt Begruendung). Vier Absaetze. Sichtbar, solange die Uebersetzung nicht geladen ist — und dauerhaft, wenn sie gar nicht laedt. Dieser Hinweis erscheint nur bei Andrang, also im Workshop und bei der Presse-Welle.

**2. Bei erreichtem Limit war der Upload nur fuer Sehende abgeschaltet.** `pointer-events: none` griff, aber fuer Screenreader war der Bereich unveraendert vorhanden und wurde vorgelesen — samt Aufforderung zum Hochladen, die ins Leere fuehrte. `inert` schaltet ihn jetzt fuer alle gleichzeitig ab; stand der Fokus noch drin, wandert er auf den Hinweis statt ersatzlos auf `<body>`.

## Zwei neue Pruefungen

| Pruefung | Was sie abdeckt |
|---|---|
| `scripts/pruefe-i18n-fallbacks.py` | 68 sichtbare Texte auf 10 Seiten gegen die Sprachdatei, deutsch und englisch |
| `e2e/fehlerbilder.test.js` | 6 Fehlerzustaende: erscheint der Hinweis, springt der Seitenkopf, laeuft Text aus dem Kasten, meldet axe einen Verstoss |

Anlass: 26 der 45 Fehler- und Blockade-Meldungen der Oberflaeche kamen in KEINER Pruefung vor. Genau dort sassen die zwei Fehler, die das TIEF-Audit uebersehen hat.

## Belege

```
E2E gesamt          285 gruen (vorher 279)
Frontend            472 gruen
vor-dem-push        16/16 gruen
Rueckbauprobe 1     HTML-Text zurueckgedreht -> Exit 1, nennt Datei/Zeile/beide Fassungen
Rueckbauprobe 2     inert entfernt          -> 'color-contrast (7x)', Pruefung rot
Messproblem-Probe   falsches Verzeichnis    -> Exit 2, nicht als gruen getarnt
```

## Ausserdem

Ein **Schwellen-Alarm fuer Client-Fehler** ist eingerichtet (mehr als 20 Berichte je Stunde, beide Kanaele), dokumentiert in `docs/ERROR-ALERTING.md`. Bisher waren nur Serverfehler alarmiert. Gemessen vor der Entscheidung: fuenf Berichte in sieben Tagen — die Schwelle feuert im Normalbetrieb nie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)